### PR TITLE
📖 🏗 🔧Enable access of interactive demo hosted in remote server

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: ./Dockerfile
       args:
         API_URL: http://localhost:5000
+        DEMO_URL: http://localhost:5173
+        EVALUATION_URL: http://localhost:5100
     depends_on:
       - api
       - demo-dino-game-vue

--- a/modules/front-end/Dockerfile
+++ b/modules/front-end/Dockerfile
@@ -6,9 +6,15 @@ COPY package*.json /app/
 RUN npm install
 COPY ./ /app/
 
-ARG API_URL
+ARG API_URL \ 
+    DEMO_URL \ 
+    EVALUATION_URL
 RUN sed -i "s|__API_URL__|${API_URL}|g" src/environments/environment.ts  \
     && sed -i "s|__API_URL__|${API_URL}|g" src/environments/environment.prod.ts \
+    && sed -i "s|__DEMO_URL__|${DEMO_URL}|g" src/environments/environment.ts  \
+    && sed -i "s|__DEMO_URL__|${DEMO_URL}|g" src/environments/environment.prod.ts \
+    && sed -i "s|__EVALUATION_URL__|${EVALUATION_URL}|g" src/environments/environment.ts  \
+    && sed -i "s|__EVALUATION_URL__|${EVALUATION_URL}|g" src/environments/environment.prod.ts \
     && npm run build:prod
 
 # Stage 1, based on Nginx, to have only the compiled app, ready for production with Nginx

--- a/modules/front-end/src/app/core/components/guide/guide.component.html
+++ b/modules/front-end/src/app/core/components/guide/guide.component.html
@@ -13,21 +13,21 @@
         <h4 nz-typography i18n="@@guide.get-started">Get started</h4>
         <a class="btn-link" target="_blank" href="https://featbit.gitbook.io/docs/">
           <span nz-icon nzType="play-square" nzTheme="outline"></span>
-          <span i18n="@@guide.featbit-in-3-min">FeatBit in 3 minutes</span>
+          1. <span i18n="@@guide.featbit-in-3-min">FeatBit in 3 minutes</span>
         </a>
         <a class="btn-link" target="_blank"
           href="https://featbit.gitbook.io/docs/get-started/create-two-feature-flags">
           <span nz-icon nzType="flag" nzTheme="outline"></span>
-          <span i18n="@@guide.create-ff">Create feature flags for the demo</span>
+          2. <span i18n="@@guide.create-ff">Create feature flags for the demo</span>
         </a>
         <a class="btn-link" target="_blank"
           href="{{demoUrl}}">
           <span nz-icon nzType="block" nzTheme="outline"></span>
-          <span i18n="@@guide.try-interactive-demo">Try interactive with the demo</span>
+          3. <span i18n="@@guide.try-interactive-demo">Try interactive with the demo</span>
         </a>
         <a class="btn-link" target="_blank" href="https://featbit.gitbook.io/docs/get-started/connect-an-sdk">
           <span nz-icon nzType="code" nzTheme="outline"></span>
-          <span i18n="@@guide.connect-to-sdk">Connect to SDK</span>
+          4. <span i18n="@@guide.connect-to-sdk">Connect to SDK</span>
         </a>
       </div>
       <div class="block">

--- a/modules/front-end/src/app/core/components/guide/guide.component.ts
+++ b/modules/front-end/src/app/core/components/guide/guide.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { OrganizationService } from '@services/organization.service';
+import { environment } from 'src/environments/environment';
 import { IProjectEnv } from '@shared/types';
 
 @Component({
@@ -19,7 +20,9 @@ export class GuideComponent {
     private organizationService: OrganizationService
   ) {
     const currentOrganizationProjectEnv = this.organizationService.getCurrentOrganizationProjectEnv();
-    this.demoUrl = `http://localhost:5173?envKey=${currentOrganizationProjectEnv?.projectEnv?.envSecret}`;
+    const envSecret = currentOrganizationProjectEnv?.projectEnv?.envSecret
+    const evaluationUrl = environment.evaluationUrl
+    this.demoUrl = `${environment.demoUrl}?envKey=${envSecret}&evaluationUrl=${evaluationUrl}`;
   }
 
   onClose() {

--- a/modules/front-end/src/app/core/components/guide/guide.component.ts
+++ b/modules/front-end/src/app/core/components/guide/guide.component.ts
@@ -20,9 +20,8 @@ export class GuideComponent {
     private organizationService: OrganizationService
   ) {
     const currentOrganizationProjectEnv = this.organizationService.getCurrentOrganizationProjectEnv();
-    const envSecret = currentOrganizationProjectEnv?.projectEnv?.envSecret
-    const evaluationUrl = environment.evaluationUrl
-    this.demoUrl = `${environment.demoUrl}?envKey=${envSecret}&evaluationUrl=${evaluationUrl}`;
+    const envSecret = currentOrganizationProjectEnv?.projectEnv?.envSecret;
+    this.demoUrl = `${environment.demoUrl}?envKey=${envSecret}&evaluationUrl=${environment.evaluationUrl}`;
   }
 
   onClose() {

--- a/modules/front-end/src/environments/environment.prod.ts
+++ b/modules/front-end/src/environments/environment.prod.ts
@@ -1,4 +1,6 @@
 export const environment = {
   production: true,
-  url: '__API_URL__'
+  url: '__API_URL__',
+  demoUrl: '__DEMO_URL__',
+  evaluationUrl: '__EVALUATION_URL__'
 };

--- a/modules/front-end/src/environments/environment.ts
+++ b/modules/front-end/src/environments/environment.ts
@@ -1,4 +1,6 @@
 export const environment = {
   production: false,
-  url: ''
+  url: '',
+  demoUrl: '',
+  evaluationUrl: ''
 };


### PR DESCRIPTION
"3. Try interactive with demo" button in "Quick start guide" is a dynamic link which is composed by :
- Demo's remote server URL (which should be configurable).
- Environment secret of current environment in Portal.
- Evaluation server url which demo can communicate with for its FeatBit SDK.

![image](https://user-images.githubusercontent.com/68597908/199650373-39a2bce1-6f8b-4baa-80a3-dcb4d482bf5e.png)

So:

1. I modified the code which recomposes the link of "3. Try interactive with demo" button.
2. I added configurable params in environment.ts and environment.prod.ts. Because demo's url and evaluation server are different and depend on how users construct their network.
3. I updated docker-compose-dev.yml file that we can pass two enviroment's params from docker-compose.

PS:
I also added the number before each "Get Started" item. This is feedback from testing users.
![image](https://user-images.githubusercontent.com/68597908/199650530-591192ea-7c06-4dd5-afed-e4ca7272cc33.png)
