### PR TITLE
🐛 force to logout after reinitialized mongodb data

### DIFF
--- a/modules/front-end/src/app/core/services/account-preject-env-resolver.service.ts
+++ b/modules/front-end/src/app/core/services/account-preject-env-resolver.service.ts
@@ -5,10 +5,12 @@ import { take, mergeMap } from 'rxjs/operators';
 import { ProjectService } from '@services/project.service';
 import { OrganizationService } from '@services/organization.service';
 import { IOrganization, IProjectEnv } from '@shared/types';
+import { IdentityService } from "@services/identity.service";
 
 @Injectable()
 export class AccountProjectEnvResolver implements Resolve<any> {
   constructor(
+    private identityService: IdentityService,
     private projectService: ProjectService,
     private accountService: OrganizationService,
   ) { }
@@ -17,12 +19,17 @@ export class AccountProjectEnvResolver implements Resolve<any> {
     return this.accountService.getCurrentOrganization().pipe(
         take(1),
         mergeMap((account: IOrganization) => {
-            return this.projectService.getCurrentProjectEnv(account.id).pipe(
-              take(1),
-              mergeMap((projectEnv: IProjectEnv) => {
-                return of({});
-              })
-            )
+          if (!account) {
+            this.identityService.doLogoutUser(false);
+            return;
+          }
+
+          return this.projectService.getCurrentProjectEnv(account.id).pipe(
+            take(1),
+            mergeMap((projectEnv: IProjectEnv) => {
+              return of({});
+            })
+          )
           }
         )
       );

--- a/modules/front-end/src/app/core/services/account-preject-env-resolver.service.ts
+++ b/modules/front-end/src/app/core/services/account-preject-env-resolver.service.ts
@@ -4,7 +4,7 @@ import { Observable, of } from 'rxjs';
 import { take, mergeMap } from 'rxjs/operators';
 import { ProjectService } from '@services/project.service';
 import { OrganizationService } from '@services/organization.service';
-import { IOrganization, IProjectEnv } from '@shared/types';
+import { IOrganization } from '@shared/types';
 import { IdentityService } from "@services/identity.service";
 
 @Injectable()
@@ -17,8 +17,8 @@ export class AccountProjectEnvResolver implements Resolve<any> {
 
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
     return this.accountService.getCurrentOrganization().pipe(
-        take(1),
-        mergeMap((account: IOrganization) => {
+      take(1),
+      mergeMap((account: IOrganization) => {
           if (!account) {
             this.identityService.doLogoutUser(false);
             return;
@@ -26,12 +26,12 @@ export class AccountProjectEnvResolver implements Resolve<any> {
 
           return this.projectService.getCurrentProjectEnv(account.id).pipe(
             take(1),
-            mergeMap((projectEnv: IProjectEnv) => {
+            mergeMap(() => {
               return of({});
             })
           )
-          }
-        )
-      );
+        }
+      )
+    );
   }
 }

--- a/modules/front-end/src/app/core/services/identity.service.ts
+++ b/modules/front-end/src/app/core/services/identity.service.ts
@@ -64,13 +64,16 @@ export class IdentityService {
     });
   }
 
-  async doLogoutUser() {
+  async doLogoutUser(keepOrgProject: boolean = true) {
     const storageToKeep = {
-      // restore account and project, so when user login, he would always see the same project & env
-      [CURRENT_ORGANIZATION()]: localStorage.getItem(CURRENT_ORGANIZATION()),
-      [CURRENT_PROJECT()]: localStorage.getItem(CURRENT_PROJECT()),
       [CURRENT_LANGUAGE()]: localStorage.getItem(CURRENT_LANGUAGE()),
     };
+
+    if (keepOrgProject) {
+      // restore account and project, so when user login, he would always see the same project & env
+      storageToKeep[CURRENT_ORGANIZATION()] = localStorage.getItem(CURRENT_ORGANIZATION());
+      storageToKeep[CURRENT_PROJECT()] = localStorage.getItem(CURRENT_PROJECT());
+    }
 
     localStorage.clear();
     Object.keys(storageToKeep).forEach(k => localStorage.setItem(k, storageToKeep[k]))


### PR DESCRIPTION
After regenerated data in mongodb, if we refresh the UI, we would see a blank page, that's because the org the current user loged in doesn't exist any more (id changed) . 

The current PR forces to logout the user in this situation.

<!--
# Instructions

1. Pick a meaningful and result oriented title for your pull request. (Use sentence case, don't include any words indicating the way you achived this result, we just want the result. Keep it short < 70 characters)
  - Prefix the title with an emoji to categorize what is being done. (Copy-paste the emoji from the list below.)
  - Assign the appropriate label(s) to the pull request. (Use one of the labels from the list below.)
  
2. Enter a succinct description that says why the PR is necessary, and what it does.
  - Implement aspect X
  - Leave out feature Y because of A
  - Improve performance by B
  - Improve accessibility by C

3. Provide clear testing instructions that include any pertinent information, i.e. seat, roles, etc.
4. Include screenshots of your changes if they impact the UI (Before & After).
5. Update the preview link with your pull request number.
6. Include any JIRA tickets, design documents, GitHub issues, or other related items to the bottom of the PR.

# Available labels
UI
API
Evaluation Server
OLAP

# Emojis for categorizing pull requests

✨ New feature or functionality
🐛 Bugfix
🔥 P0 fix
✅ Tests
🚀 Performance improvements
🖍 CSS / Styling
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
↩️ Reverting a previous change
🧹 Refactoring / Housekeeping
🔧 Package Upgrades / Maintenance
🗑️ Deleting code

-->
