### PR TITLE
✨ feat: (api) add feature flag description

### DIFF
--- a/modules/back-end/src/Application/FeatureFlags/CreateFeatureFlag.cs
+++ b/modules/back-end/src/Application/FeatureFlags/CreateFeatureFlag.cs
@@ -12,6 +12,8 @@ public class CreateFeatureFlag : IRequest<FeatureFlag>
     public string Name { get; set; }
 
     public string Key { get; set; }
+
+    public string Description { get; set; }
 }
 
 public class CreateFeatureFlagValidator : AbstractValidator<CreateFeatureFlag>
@@ -48,7 +50,7 @@ public class CreateFeatureFlagHandler : IRequestHandler<CreateFeatureFlag, Featu
 
     public async Task<FeatureFlag> Handle(CreateFeatureFlag request, CancellationToken cancellationToken)
     {
-        var flag = new FeatureFlag(request.EnvId, request.Name, request.Key, _currentUser.Id);
+        var flag = new FeatureFlag(request.EnvId, request.Name, request.Description, request.Key, _currentUser.Id);
         await _service.AddOneAsync(flag);
 
         // write audit log

--- a/modules/back-end/src/Application/FeatureFlags/FeatureFlagVm.cs
+++ b/modules/back-end/src/Application/FeatureFlags/FeatureFlagVm.cs
@@ -7,6 +7,8 @@ public class FeatureFlagVm
     public string Id { get; set; }
 
     public string Name { get; set; }
+    
+    public string Description { get; set; }
 
     public string Key { get; set; }
 

--- a/modules/back-end/src/Application/FeatureFlags/UpdateSetting.cs
+++ b/modules/back-end/src/Application/FeatureFlags/UpdateSetting.cs
@@ -9,6 +9,8 @@ public class UpdateSetting : IRequest<bool>
     public Guid Id { get; set; }
 
     public string Name { get; set; }
+    
+    public string Description { get; set; }
 
     public bool IsEnabled { get; set; }
 
@@ -46,7 +48,7 @@ public class UpdateSettingHandler : IRequestHandler<UpdateSetting, bool>
     public async Task<bool> Handle(UpdateSetting request, CancellationToken cancellationToken)
     {
         var flag = await _service.GetAsync(request.Id);
-        var dataChange = flag.UpdateSetting(request.Name, request.IsEnabled, request.DisabledVariationId, _currentUser.Id);
+        var dataChange = flag.UpdateSetting(request.Name, request.Description, request.IsEnabled, request.DisabledVariationId, _currentUser.Id);
         await _service.UpdateAsync(flag);
 
         // write audit log

--- a/modules/back-end/src/Domain/FeatureFlags/FeatureFlag.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/FeatureFlag.cs
@@ -14,6 +14,8 @@ public class FeatureFlag : FullAuditedEntity
 
     public string Name { get; set; }
 
+    public string Description { get; set; }
+
     public string Key { get; set; }
 
     public string VariationType { get; set; }
@@ -36,11 +38,12 @@ public class FeatureFlag : FullAuditedEntity
 
     public bool IsArchived { get; set; }
 
-    public FeatureFlag(Guid envId, string name, string key, Guid currentUserId) : base(currentUserId)
+    public FeatureFlag(Guid envId, string name, string description, string key, Guid currentUserId) : base(currentUserId)
     {
         EnvId = envId;
 
         Name = name;
+        Description = description;
         Key = key;
 
         var falsyVariationId = Guid.NewGuid().ToString();
@@ -132,11 +135,12 @@ public class FeatureFlag : FullAuditedEntity
         return dataChange.To(this);
     }
 
-    public DataChange UpdateSetting(string name, bool isEnabled, string disabledVariationId, Guid currentUserId)
+    public DataChange UpdateSetting(string name, string description, bool isEnabled, string disabledVariationId, Guid currentUserId)
     {
         var dataChange = new DataChange(this);
 
         Name = name;
+        Description = description;
         IsEnabled = isEnabled;
         DisabledVariationId = disabledVariationId;
 


### PR DESCRIPTION
It may happen, that we forget the purpose of a feature flag. A description could be helpful.

I've added the 'description' property to provide the Front-End the possibility to declare a description on creating/updating a feature flag and also to display it.

Solved issue: #243 

Related issues: 
Front-End: #257 #237 #236 