### PR TITLE
feat: add CHECK_DB_LIVNESS params

### DIFF
--- a/modules/data-analytics/Dockerfile
+++ b/modules/data-analytics/Dockerfile
@@ -13,6 +13,7 @@ ARG MONGO_HOST=mongodb
 ARG MONGO_URI=mongodb://admin:password@mongodb:27017
 ARG MONGO_INITDB_DATABASE=featbit
 ARG IS_PRO=false
+ARG CHECK_DB_LIVNESS=true
 ENV KAFKA_HOSTS=${KAFKA_HOSTS} \
     CLICKHOUSE_USER=${CLICKHOUSE_USER} \
     CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD} \
@@ -26,7 +27,8 @@ ENV KAFKA_HOSTS=${KAFKA_HOSTS} \
     MONGO_HOST=${MONGO_HOST} \
     MONGO_URI=${MONGO_URI} \
     MONGO_DB=${MONGO_INITDB_DATABASE} \
-    IS_PRO=${IS_PRO}
+    IS_PRO=${IS_PRO} \
+    CHECK_DB_LIVNESS=${CHECK_DB_LIVNESS}
 RUN apt update &&apt install -y nginx && apt install -y supervisor && apt install -y git
 RUN mkdir -p /var/log/nginx && \
     touch /var/log/nginx/access.log && \

--- a/modules/data-analytics/docker-entrypoint.sh
+++ b/modules/data-analytics/docker-entrypoint.sh
@@ -3,12 +3,13 @@
 # Abort on any error (including if wait-for-it fails).
 set -e
 
-if [ "$IS_PRO" = false ]; then
-    ./wait-for-it.sh "${MONGO_HOST}:27017 --timeout=300 --strict" 
-else
-    ./wait-for-it.sh "${CLICKHOUSE_HOST}:8123 --timeout=300 --strict" 
+if [ "$CHECK_DB_LIVNESS" = true ]; then
+    if [ "$IS_PRO" = false ]; then
+        ./wait-for-it.sh "${MONGO_HOST}:27017 --timeout=300 --strict" 
+    else
+        ./wait-for-it.sh "${CLICKHOUSE_HOST}:8123 --timeout=300 --strict" 
+    fi
 fi
-
 
 # Run the main container command.
 exec "$@"


### PR DESCRIPTION
CHECK_DB_LIVNESS(true by default) is marked whether to check database liveness when da server start up. If your mongo or clickhouse is a external SAAS service, **set this value false**.