### PR TITLE
🧹 refactor: updated "Feature flags and segments" label to more concise one

### DIFF
--- a/modules/front-end/src/app/core/components/user-segments-flags-drawer/user-segments-flags-drawer.component.html
+++ b/modules/front-end/src/app/core/components/user-segments-flags-drawer/user-segments-flags-drawer.component.html
@@ -7,7 +7,7 @@
   [nzWidth]="950"
   [nzVisible]="visible"
   (nzOnClose)="close.emit()">
-  <ng-template #drawTitle><ng-container i18n="@@users.idx.ff-segments">Feature flags and segments</ng-container>: <span style="display:inline-block;padding: 0 5px; font-weight: 600">{{user?.name}} ({{user?.keyId}})</span></ng-template>
+  <ng-template #drawTitle><ng-container i18n="@@users.idx.ff-segments">Evaluate on flags and segments</ng-container>: <span style="display:inline-block;padding: 0 5px; font-weight: 600">{{user?.name}} ({{user?.keyId}})</span></ng-template>
   <ng-container *nzDrawerContent>
     <nz-tabset class="no-bottom-line">
       <nz-tab i18n-nzTitle="@@common.feature-flag" nzTitle="Feature flag">

--- a/modules/front-end/src/app/core/components/user-segments-flags-drawer/user-segments-flags-drawer.component.html
+++ b/modules/front-end/src/app/core/components/user-segments-flags-drawer/user-segments-flags-drawer.component.html
@@ -7,7 +7,7 @@
   [nzWidth]="950"
   [nzVisible]="visible"
   (nzOnClose)="close.emit()">
-  <ng-template #drawTitle><ng-container i18n="@@users.idx.ff-segments">Evaluate on flags and segments</ng-container>: <span style="display:inline-block;padding: 0 5px; font-weight: 600">{{user?.name}} ({{user?.keyId}})</span></ng-template>
+  <ng-template #drawTitle><span style="display:inline-block;padding: 0 5px; font-weight: 600">{{user?.name}} ({{user?.keyId}})</span></ng-template>
   <ng-container *nzDrawerContent>
     <nz-tabset class="no-bottom-line">
       <nz-tab i18n-nzTitle="@@common.feature-flag" nzTitle="Feature flag">

--- a/modules/front-end/src/app/features/safe/end-users/index/index.component.html
+++ b/modules/front-end/src/app/features/safe/end-users/index/index.component.html
@@ -120,7 +120,7 @@
               <td>{{ user.keyId }}</td>
               <td *ngFor="let prop of extraColumns">{{getCustomizePropertyValue(user, prop)}}</td>
               <td>
-                <a class="primary-link-btn" (click)="onSegmentsAndFlagsClick(user)" i18n="@@users.idx.ff-segments">Feature flags and segments</a>
+                <a class="primary-link-btn" (click)="onSegmentsAndFlagsClick(user)" i18n="@@users.idx.ff-segments">Evaluate on flags and segments</a>
                 <nz-divider nzType="vertical"></nz-divider>
                 <a class="primary-link-btn" nz-button nzType="link" (click)="navigateToUserDetail(user)" i18n="@@common.details">Details</a>
               </td>

--- a/modules/front-end/src/locale/messages.xlf
+++ b/modules/front-end/src/locale/messages.xlf
@@ -3127,7 +3127,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="users.idx.ff-segments" datatype="html">
-        <source>Feature flags and segments</source>
+        <source>Evaluate on flags and segments</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/user-segments-flags-drawer/user-segments-flags-drawer.component.html</context>
           <context context-type="linenumber">10</context>

--- a/modules/front-end/src/locale/messages.zh.xlf
+++ b/modules/front-end/src/locale/messages.zh.xlf
@@ -3362,7 +3362,7 @@
           <context context-type="sourcefile">src/app/features/safe/end-users/index/index.component.html</context>
           <context context-type="linenumber">123</context>
         </context-group>
-        <target>开关和用户组：</target>
+        <target>评估开关和用户组：</target>
       </trans-unit>
       <trans-unit id="common.feature-flag" datatype="html">
         <source>Feature flag</source>

--- a/modules/front-end/src/locale/messages.zh.xlf
+++ b/modules/front-end/src/locale/messages.zh.xlf
@@ -3353,7 +3353,7 @@
         <target>上传成功</target>
       </trans-unit>
       <trans-unit id="users.idx.ff-segments" datatype="html">
-        <source>Feature flags and segments</source>
+        <source>Evaluate on flags and segments</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/user-segments-flags-drawer/user-segments-flags-drawer.component.html</context>
           <context context-type="linenumber">10</context>


### PR DESCRIPTION
- Change text from "Feature flags and segments" to "Evaluate on flags and segments"
- Remove the text "Feature flags and segments: " from the user segment flags drawer title
- Update the Chinese translation to 评估开关和用户组

Fixed #337 