### PR TITLE
Vertically align content of number input

### DIFF
--- a/modules/front-end/src/app/core/components/find-rule/serve/serve.component.less
+++ b/modules/front-end/src/app/core/components/find-rule/serve/serve.component.less
@@ -60,6 +60,7 @@ section.rule-item {
                 padding-right:0;
                 border-top-left-radius: 8px;
                 border-bottom-left-radius: 8px;
+                line-height: 36px
               }
             }
           }


### PR DESCRIPTION
🐛 Solves #347 [Bug]: Content of number input is not vertically centered
