### PR TITLE
Get Started page environment switch corner visible

### DIFF
--- a/modules/front-end/src/app/features/safe/safe.component.less
+++ b/modules/front-end/src/app/features/safe/safe.component.less
@@ -26,6 +26,7 @@
   }
 
   section.right-container {
+    min-width: -webkit-fill-available;
     height: 100vh;
     padding-right: 4px;
 


### PR DESCRIPTION
🐛 Fixes #368 : The get started page has made the environment switch corner invisible.
