### PR TITLE
🐛 fix: user can create duplicate key

### DIFF
--- a/modules/back-end/src/Application/Bases/ErrorCodes.cs
+++ b/modules/back-end/src/Application/Bases/ErrorCodes.cs
@@ -55,6 +55,7 @@ public static class ErrorCodes
     public const string InvalidTo = nameof(InvalidTo);
     public const string InvalidFlagKeyFormat = nameof(InvalidFlagKeyFormat);
     public const string InvalidSecretType = nameof(InvalidSecretType);
+    public const string FeatureFlagKeyHasBeenUsed = nameof(FeatureFlagKeyHasBeenUsed);
 
     // triggers
     public const string InvalidTriggerType = nameof(InvalidTriggerType);

--- a/modules/back-end/src/Application/FeatureFlags/CreateFeatureFlag.cs
+++ b/modules/back-end/src/Application/FeatureFlags/CreateFeatureFlag.cs
@@ -2,6 +2,7 @@ using Application.Bases;
 using Application.Users;
 using Domain.AuditLogs;
 using Domain.FeatureFlags;
+using Application.Bases.Exceptions;
 
 namespace Application.FeatureFlags;
 
@@ -50,6 +51,12 @@ public class CreateFeatureFlagHandler : IRequestHandler<CreateFeatureFlag, Featu
 
     public async Task<FeatureFlag> Handle(CreateFeatureFlag request, CancellationToken cancellationToken)
     {
+        var isKeyBeenUsed = await _service.IsFeatureFlagKeyUsedAsync(request.EnvId, request.Key);
+        if (isKeyBeenUsed)
+        {
+            throw new BusinessException(ErrorCodes.FeatureFlagKeyHasBeenUsed);
+        }
+
         var flag = new FeatureFlag(request.EnvId, request.Name, request.Description, request.Key, _currentUser.Id);
         await _service.AddOneAsync(flag);
 

--- a/modules/back-end/src/Application/FeatureFlags/IsFeatureFlagKeyUsed.cs
+++ b/modules/back-end/src/Application/FeatureFlags/IsFeatureFlagKeyUsed.cs
@@ -18,6 +18,6 @@ public class IsFeatureFlagKeyUsedHandler : IRequestHandler<IsFeatureFlagKeyUsed,
 
     public async Task<bool> Handle(IsFeatureFlagKeyUsed request, CancellationToken cancellationToken)
     {
-        return await _service.AnyAsync(x => x.EnvId == request.EnvId && x.Key == request.Key);
+        return await _service.IsFeatureFlagKeyUsedAsync(request.EnvId, request.Key);
     }
 }

--- a/modules/back-end/src/Application/Services/IFeatureFlagService.cs
+++ b/modules/back-end/src/Application/Services/IFeatureFlagService.cs
@@ -10,6 +10,8 @@ public interface IFeatureFlagService : IService<FeatureFlag>
 
     Task<FeatureFlag> GetAsync(Guid envId, string key);
 
+    Task<bool> IsFeatureFlagKeyUsedAsync(Guid envId, string key);
+
     Task DeleteAsync(Guid id);
 
     Task<ICollection<string>> GetAllTagsAsync(Guid envId);

--- a/modules/back-end/src/Infrastructure/FeatureFlags/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/FeatureFlags/FeatureFlagService.cs
@@ -3,6 +3,7 @@ using Application.Bases.Models;
 using Application.FeatureFlags;
 using Domain.FeatureFlags;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 
 namespace Infrastructure.FeatureFlags;
 
@@ -75,6 +76,11 @@ public class FeatureFlagService : MongoDbService<FeatureFlag>, IFeatureFlagServi
         }
 
         return flag;
+    }
+
+    public async Task<bool> IsFeatureFlagKeyUsedAsync(Guid envId, string key)
+    {
+        return await Queryable.AnyAsync(x => x.EnvId == envId && x.Key == key);
     }
 
     public async Task DeleteAsync(Guid id)

--- a/modules/front-end/src/app/features/safe/feature-flags/index/index.component.html
+++ b/modules/front-end/src/app/features/safe/feature-flags/index/index.component.html
@@ -219,7 +219,7 @@
 
   <ng-template #modalFooter>
     <button nz-button nzType="default" (click)="this.closeCreateModal()" i18n="@@common.cancel">Cancel</button>
-    <button nz-button nzType="primary" [nzLoading]="this.creating" [disabled]="featureFlagForm.invalid" (click)="create()" i18n="@@common.save">Save</button>
+    <button nz-button nzType="primary" [nzLoading]="this.creating" [disabled]="!featureFlagForm.valid" (click)="create()" i18n="@@common.save">Save</button>
   </ng-template>
 </nz-modal>
 


### PR DESCRIPTION
This pr fix this bug by:
- Added feature flag key validation before creating it in the API
- Enabled the "Save" button only after successful validation