### PR TITLE
fix: data sync upload returns 415

### DIFF
--- a/modules/back-end/src/Api/Controllers/DataSyncController.cs
+++ b/modules/back-end/src/Api/Controllers/DataSyncController.cs
@@ -27,6 +27,7 @@ public class DataSyncController : ApiControllerBase
     [RequestSizeLimit(510 * 1024 * 1024)]
     // single file max size: 500MB 
     [RequestFormLimits(ValueLengthLimit = 500 * 1024 * 1024)]
+    [Consumes("multipart/form-data")]
     public async Task<ApiResponse<bool>> UploadAsync(Guid envId, IFormFile? file)
     {
         if (file is not { Length: > 0 })


### PR DESCRIPTION
I have found an issue related to the upload of a JSON file using the _/data-sync/upload_ endpoint. In this case, the API consistently returns a _415 - Unsupported Media Type_ error.

The root cause of this issue lies within the **ApiControllerBase** class, where the Consume attribute is set to application/json as the content type. However, the application/json content type is not appropriate for the Upload endpoint, which requires multipart/form-data instead.