### PR TITLE
✨ feat: display variation names instead of values in insights page

### DIFF
--- a/modules/back-end/src/Application/FeatureFlags/GetInsights.cs
+++ b/modules/back-end/src/Application/FeatureFlags/GetInsights.cs
@@ -58,7 +58,7 @@ public class GetInsightsHandler : IRequestHandler<GetInsights, IEnumerable<Insig
             Time = s.Time,
             Variations = featureFlag.Variations.Select(v => new VariationInsightsVm
             {
-                Variation = v.Value,
+                Variation = v.Name,
                 Count = s.Variations.FirstOrDefault(x => x.Id == v.Id)?.Val ?? 0
             })
         });

--- a/modules/front-end/src/app/features/safe/feature-flags/details/insights/insights.component.ts
+++ b/modules/front-end/src/app/features/safe/feature-flags/details/insights/insights.component.ts
@@ -1,12 +1,12 @@
-import {Component, OnInit} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
-import {ChartConfig} from "@core/components/g2-chart/g2-line-chart/g2-line-chart";
-import {FeatureFlagService} from "@services/feature-flag.service";
-import {IVariation} from "@shared/rules";
-import {EnvUserService} from "@services/env-user.service";
-import {Subject} from "rxjs";
-import {debounceTime} from "rxjs/operators";
-import {uuidv4} from "@utils/index";
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { ChartConfig } from "@core/components/g2-chart/g2-line-chart/g2-line-chart";
+import { FeatureFlagService } from "@services/feature-flag.service";
+import { IVariation } from "@shared/rules";
+import { EnvUserService } from "@services/env-user.service";
+import { Subject } from "rxjs";
+import { debounceTime } from "rxjs/operators";
+import { uuidv4 } from "@utils/index";
 import {
   IFeatureFlagEndUserPagedResult,
   IntervalType,
@@ -21,9 +21,9 @@ import {
 })
 export class InsightsComponent implements OnInit {
 
-  public usage: string = '';
+  usage: string = '';
 
-  public isLoading: boolean = true;
+  isLoading: boolean = true;
 
   chartConfig: ChartConfig;
   variations: IVariation[] = [];
@@ -188,14 +188,14 @@ export class InsightsComponent implements OnInit {
     this.$endUserSearch.next();
   }
 
-  public loadFeatureFlagUsage() {
+  loadFeatureFlagUsage() {
     this.isLoading = true;
 
-    this.featureFlagService.getInsights(this.filter.filter)
-      .subscribe((res) => {
-        const source = res.flatMap((stat) => {
+    this.featureFlagService.getInsights(this.filter.filter).subscribe({
+      next: (insights) => {
+        const source = insights.flatMap((stat) => {
           const sum = stat.variations.reduce((acc, cur) => acc + cur.count, 0);
-          return [...stat.variations, { variation: $localize `:@@common.total:Total`, count: sum}].map((v) => {
+          return [...stat.variations, { variation: $localize`:@@common.total:Total`, count: sum }].map((v) => {
             return {
               label: v.variation,
               time: stat.time,
@@ -214,16 +214,16 @@ export class InsightsComponent implements OnInit {
 
         this.chartConfig = {
           xAxis: {
-            name: $localize `:@@common.time:Time`,
+            name: $localize`:@@common.time:Time`,
             field: 'time',
             position: 'end',
-            scale: {type: "timeCat", nice: true, range: [0.05, 0.95], mask: this.getXAxisMask()}
+            scale: { type: "timeCat", nice: true, range: [0.05, 0.95], mask: this.getXAxisMask() }
           },
           yAxis: {
             name: '',
             position: 'end',
             field: 'value',
-            scale: {nice: true}
+            scale: { nice: true }
           },
           source: source as any,
           dataGroupBy: 'label',
@@ -234,7 +234,9 @@ export class InsightsComponent implements OnInit {
 
         // data loaded
         this.isLoading = false;
-      }, () => this.isLoading = false);
+      },
+      error: () => this.isLoading = false
+    });
   }
 
   private getXAxisMask() {


### PR DESCRIPTION
Instead of showing variation values, we will now display the corresponding variation names.

## Before
![image](https://github.com/featbit/featbit/assets/34052208/3db824af-ec74-4f0a-8fc4-d7efd054d0b1)

## After

![image](https://github.com/featbit/featbit/assets/34052208/a3985a99-2fa4-4d28-a70e-8fbb2749cea8)