### PR TITLE
✨ feat: integrate serilog for api project

### DIFF
--- a/modules/back-end/src/Api/Api.csproj
+++ b/modules/back-end/src/Api/Api.csproj
@@ -20,6 +20,7 @@
 
         <!-- Serilog -->
         <PackageReference Include="Serilog.AspNetCore" Version="6.1.0"/>
+        <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/modules/back-end/src/Api/Api.csproj
+++ b/modules/back-end/src/Api/Api.csproj
@@ -9,11 +9,17 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!-- Api Versioning -->
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="6.0.0"/>
+
+        <!-- Swagger -->
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.6"/>
         <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="6.5.0"/>
+
+        <!-- Serilog -->
+        <PackageReference Include="Serilog.AspNetCore" Version="6.1.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/modules/back-end/src/Api/Program.cs
+++ b/modules/back-end/src/Api/Program.cs
@@ -8,6 +8,8 @@ try
     Log.Logger = new LoggerConfiguration()
         .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
         .Enrich.FromLogContext()
+        .Enrich.WithClientIp("X-Forwarded-For")
+        .Enrich.WithRequestHeader("User-Agent")
         .WriteTo.Console(new CompactJsonFormatter())
         .CreateLogger();
 

--- a/modules/back-end/src/Api/Program.cs
+++ b/modules/back-end/src/Api/Program.cs
@@ -1,10 +1,12 @@
 using Api.Setup;
 using Serilog;
+using Serilog.Events;
 using Serilog.Formatting.Compact;
 
 try
 {
     Log.Logger = new LoggerConfiguration()
+        .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
         .Enrich.FromLogContext()
         .WriteTo.Console(new CompactJsonFormatter())
         .CreateLogger();

--- a/modules/back-end/src/Api/Program.cs
+++ b/modules/back-end/src/Api/Program.cs
@@ -1,11 +1,12 @@
 using Api.Setup;
 using Serilog;
+using Serilog.Formatting.Compact;
 
 try
 {
     Log.Logger = new LoggerConfiguration()
         .Enrich.FromLogContext()
-        .WriteTo.Console()
+        .WriteTo.Console(new CompactJsonFormatter())
         .CreateLogger();
 
     WebApplication.CreateBuilder(args)

--- a/modules/back-end/src/Api/Program.cs
+++ b/modules/back-end/src/Api/Program.cs
@@ -1,10 +1,28 @@
 using Api.Setup;
+using Serilog;
 
-WebApplication.CreateBuilder(args)
-    .RegisterServices()
-    .Build()
-    .SetupMiddleware()
-    .Run();
+try
+{
+    Log.Logger = new LoggerConfiguration()
+        .Enrich.FromLogContext()
+        .WriteTo.Console()
+        .CreateLogger();
+
+    WebApplication.CreateBuilder(args)
+        .ConfigureHost()
+        .RegisterServices()
+        .Build()
+        .SetupMiddleware()
+        .Run();
+}
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Application terminated unexpectedly");
+}
+finally
+{
+    Log.CloseAndFlush();
+}
 
 // https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-6.0#basic-tests-with-the-default-webapplicationfactory
 // Make the implicit Program class public so test projects can access it

--- a/modules/back-end/src/Api/Setup/HostBuilder.cs
+++ b/modules/back-end/src/Api/Setup/HostBuilder.cs
@@ -1,0 +1,13 @@
+using Serilog;
+
+namespace Api.Setup;
+
+public static class HostBuilder
+{
+    public static WebApplicationBuilder ConfigureHost(this WebApplicationBuilder builder)
+    {
+        builder.Host.UseSerilog();
+
+        return builder;
+    }
+}

--- a/modules/back-end/src/Api/Setup/MiddlewaresRegister.cs
+++ b/modules/back-end/src/Api/Setup/MiddlewaresRegister.cs
@@ -1,5 +1,7 @@
 using Api.Middlewares;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Serilog;
+using Serilog.Events;
 using Swashbuckle.AspNetCore.SwaggerUI;
 using OpenApiConstants = Api.Authentication.OpenApiConstants;
 
@@ -49,6 +51,21 @@ public static class MiddlewaresRegister
             options.DocumentTitle = "FeatBit OpenApi Doc";
             options.SpecUrl = $"/swagger/{OpenApiConstants.ApiGroupName}/swagger.json";
             options.ExpandResponses("200");
+        });
+
+        // serilog request logging
+        app.UseSerilogRequestLogging(options =>
+        {
+            options.IncludeQueryInRequestPath = true;
+            options.GetLevel = (ctx, _, ex) =>
+            {
+                if (ex != null || ctx.Response.StatusCode > 499)
+                {
+                    return LogEventLevel.Error;
+                }
+
+                return LogEventLevel.Information;
+            };
         });
 
         // enable cors

--- a/modules/back-end/src/Api/Setup/MiddlewaresRegister.cs
+++ b/modules/back-end/src/Api/Setup/MiddlewaresRegister.cs
@@ -53,6 +53,9 @@ public static class MiddlewaresRegister
             options.ExpandResponses("200");
         });
 
+        // enable cors
+        app.UseCors();
+
         // serilog request logging
         app.UseSerilogRequestLogging(options =>
         {
@@ -67,9 +70,6 @@ public static class MiddlewaresRegister
                 return LogEventLevel.Information;
             };
         });
-
-        // enable cors
-        app.UseCors();
 
         // authentication & authorization
         app.UseAuthentication();


### PR DESCRIPTION
This PR

- integrate serilog for api project
- enable serilog http requst logging
- formatted console output as json

Here is a request log example:

```json
{
   "@t":"2023-07-12T17:20:24.1186356Z",
   "@mt":"HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms",
   "@r":[
      "2.4465"
   ],
   "RequestMethod":"GET",
   "RequestPath":"/api/v1/envs/de594cd8-28a0-467e-b3a3-454751e2a49e/feature-flags/all-tags",
   "StatusCode":200,
   "Elapsed":2.4465,
   "SourceContext":"Serilog.AspNetCore.RequestLoggingMiddleware",
   "RequestId":"0HMS2VH3CBRQ4:0000000C",
   "ConnectionId":"0HMS2VH3CBRQ4",
   "ClientIp":"::1",
   "UserAgent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
}
```