### PR TITLE
🔥 hotfix: ui cannot start in azure app service

### DIFF
--- a/modules/front-end/nginx.conf
+++ b/modules/front-end/nginx.conf
@@ -28,8 +28,8 @@ server {
         try_files $uri$args $uri$args/index.html $uri$args/ /$1/index.html =404;
     }
 
-    # Keep this at the end of the server block, it returns 444 for all unknown requests
+    # Keep this at the end of the server block, it returns 404 for all unknown requests
     location / {
-        return 444;
+        return 404;
     }
 }


### PR DESCRIPTION
This pull request addresses an issue where the UI fails to start in Azure App Service due to the use of a 444 status code for unknown requests. To resolve this, the PR updates the response to return a 404 status code instead.

Reference: [Azure App Service - Configure Robots.txt](https://github.com/MicrosoftDocs/azure-docs/blob/main/includes/app-service-web-configure-robots933456.md)