### PR TITLE
🐛 fix variation rollout compare bug

### DIFF
--- a/modules/back-end/src/Domain/SemanticPatch/FlagComparer.cs
+++ b/modules/back-end/src/Domain/SemanticPatch/FlagComparer.cs
@@ -174,7 +174,16 @@ public static class FlagComparer
             return true;
         }
 
-        return original.Any(p => current.Any(c => !p.IsRolloutEquals(c)));
+        for (var i = 0; i < original.Count; i++)
+        {
+            var isRolloutNotEquals = !original.ElementAt(i).IsRolloutEquals(current.ElementAt(i));
+            if (isRolloutNotEquals)
+            {
+                return true;
+            }
+        }
+        
+        return false;
     }
 
     public static IEnumerable<FlagInstruction> CompareTargetUsers(

--- a/modules/back-end/src/Domain/SemanticPatch/FlagComparer.cs
+++ b/modules/back-end/src/Domain/SemanticPatch/FlagComparer.cs
@@ -179,8 +179,8 @@ public static class FlagComparer
             var rollout1 = original.ElementAt(i);
             var rollout2 = current.ElementAt(i);
 
-            var isRolloutNotEquals = !rollout1.IsRolloutEquals(rollout2);
-            if (isRolloutNotEquals)
+            var isRolloutEquals = rollout1.IsRolloutEquals(rollout2);
+            if (!isRolloutEquals)
             {
                 return true;
             }

--- a/modules/back-end/src/Domain/SemanticPatch/FlagComparer.cs
+++ b/modules/back-end/src/Domain/SemanticPatch/FlagComparer.cs
@@ -176,13 +176,16 @@ public static class FlagComparer
 
         for (var i = 0; i < original.Count; i++)
         {
-            var isRolloutNotEquals = !original.ElementAt(i).IsRolloutEquals(current.ElementAt(i));
+            var rollout1 = original.ElementAt(i);
+            var rollout2 = current.ElementAt(i);
+
+            var isRolloutNotEquals = !rollout1.IsRolloutEquals(rollout2);
             if (isRolloutNotEquals)
             {
                 return true;
             }
         }
-        
+
         return false;
     }
 


### PR DESCRIPTION
The FlagComparer would always return UpdateDefaultRuleVariationOrRolloutInstruction if both original and new values are percentage rollouts even they have the same value 

<!--
# Instructions

1. Pick a meaningful and result oriented title for your pull request. (Use sentence case, don't include any words indicating the way you achived this result, we just want the result. Keep it short < 70 characters)
  - Prefix the title with an emoji to categorize what is being done. (Copy-paste the emoji from the list below.)
  - Assign the appropriate label(s) to the pull request. (Use one of the labels from the list below.)
  
2. Enter a succinct description that says why the PR is necessary, and what it does.
  - Implement aspect X
  - Leave out feature Y because of A
  - Improve performance by B
  - Improve accessibility by C

3. Provide clear testing instructions that include any pertinent information, i.e. seat, roles, etc.
4. Include screenshots of your changes if they impact the UI (Before & After).
5. Update the preview link with your pull request number.
6. Include any JIRA tickets, design documents, GitHub issues, or other related items to the bottom of the PR.

# Available labels
UI
API
Evaluation Server
OLAP

# Emojis for categorizing pull requests

✨ New feature or functionality
🐛 Bugfix
🔥 P0 fix
✅ Tests
🚀 Performance improvements
🖍 CSS / Styling
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
↩️ Reverting a previous change
🧹 Refactoring / Housekeeping
🔧 Package Upgrades / Maintenance
🗑️ Deleting code

-->
