### PR TITLE
🧹 refactor: replace AnyAsync with CountAsync

### DIFF
--- a/modules/back-end/src/Infrastructure/Bases/MongoDbService.cs
+++ b/modules/back-end/src/Infrastructure/Bases/MongoDbService.cs
@@ -44,7 +44,8 @@ public class MongoDbService<TEntity> : IService<TEntity> where TEntity : Entity
 
     public async Task<bool> AnyAsync(Expression<Func<TEntity, bool>> predicate)
     {
-        return await Queryable.AnyAsync(predicate);
+        // for improved compatibility with CosmosDB, use CountAsync instead of AnyAsync.
+        return await Queryable.CountAsync(predicate) > 0;
     }
 
     public async Task AddOneAsync(TEntity entity)

--- a/modules/back-end/src/Infrastructure/Environments/EnvironmentService.cs
+++ b/modules/back-end/src/Infrastructure/Environments/EnvironmentService.cs
@@ -1,6 +1,5 @@
 using Domain.Environments;
 using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 using Environment = Domain.Environments.Environment;
 
 namespace Infrastructure.Environments;
@@ -25,7 +24,7 @@ public class EnvironmentService : MongoDbService<Environment>, IEnvironmentServi
 
     public async Task<bool> HasKeyBeenUsedAsync(Guid projectId, string key)
     {
-        return await Queryable.AnyAsync(environment =>
+        return await AnyAsync(environment =>
             environment.ProjectId == projectId &&
             string.Equals(environment.Key, key, StringComparison.OrdinalIgnoreCase)
         );

--- a/modules/back-end/src/Infrastructure/FeatureFlags/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/FeatureFlags/FeatureFlagService.cs
@@ -3,7 +3,6 @@ using Application.Bases.Models;
 using Application.FeatureFlags;
 using Domain.FeatureFlags;
 using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 
 namespace Infrastructure.FeatureFlags;
 
@@ -80,7 +79,7 @@ public class FeatureFlagService : MongoDbService<FeatureFlag>, IFeatureFlagServi
 
     public async Task<bool> HasKeyBeenUsedAsync(Guid envId, string key)
     {
-        return await Queryable.AnyAsync(flag =>
+        return await AnyAsync(flag =>
             flag.EnvId == envId &&
             string.Equals(flag.Key, key, StringComparison.OrdinalIgnoreCase)
         );

--- a/modules/back-end/src/Infrastructure/Groups/GroupService.cs
+++ b/modules/back-end/src/Infrastructure/Groups/GroupService.cs
@@ -170,7 +170,7 @@ public class GroupService : MongoDbService<Group>, IGroupService
     public async Task AddMemberAsync(Guid organizationId, Guid groupId, Guid memberId)
     {
         var existed = await MongoDb.QueryableOf<GroupMember>()
-            .AnyAsync(x => x.OrganizationId == organizationId && x.GroupId == groupId && x.MemberId == memberId);
+            .CountAsync(x => x.OrganizationId == organizationId && x.GroupId == groupId && x.MemberId == memberId) > 0;
         if (existed)
         {
             return;
@@ -190,7 +190,7 @@ public class GroupService : MongoDbService<Group>, IGroupService
     public async Task AddPolicyAsync(Guid groupId, Guid policyId)
     {
         var existed = await MongoDb.QueryableOf<GroupPolicy>()
-            .AnyAsync(x => x.GroupId == groupId && x.PolicyId == policyId);
+            .CountAsync(x => x.GroupId == groupId && x.PolicyId == policyId) > 0;
         if (existed)
         {
             return;

--- a/modules/back-end/src/Infrastructure/Members/MemberService.cs
+++ b/modules/back-end/src/Infrastructure/Members/MemberService.cs
@@ -324,9 +324,9 @@ public class MemberService : IMemberService
 
     public async Task AddPolicyAsync(MemberPolicy policy)
     {
-        var existed = await _mongoDb.QueryableOf<MemberPolicy>().AnyAsync(
+        var existed = await _mongoDb.QueryableOf<MemberPolicy>().CountAsync(
             x => x.OrganizationId == policy.OrganizationId && x.MemberId == policy.MemberId && x.PolicyId == policy.PolicyId
-        );
+        ) > 0;
         if (existed)
         {
             return;

--- a/modules/back-end/src/Infrastructure/Projects/ProjectService.cs
+++ b/modules/back-end/src/Infrastructure/Projects/ProjectService.cs
@@ -77,7 +77,7 @@ public class ProjectService : MongoDbService<Project>, IProjectService
 
     public async Task<bool> HasKeyBeenUsedAsync(Guid organizationId, string key)
     {
-        return await Queryable.AnyAsync(project =>
+        return await AnyAsync(project =>
             project.OrganizationId == organizationId &&
             string.Equals(project.Key, key, StringComparison.OrdinalIgnoreCase)
         );


### PR DESCRIPTION
For improved compatibility with CosmosDB, use CountAsync instead of AnyAsync. Thanks @Erik247ts for pointing this out.

fixed #513

 