### PR TITLE
🧹 refactor: change the way audit logs are written

### DIFF
--- a/modules/back-end/src/Application/AuditLogs/GetAuditLogList.cs
+++ b/modules/back-end/src/Application/AuditLogs/GetAuditLogList.cs
@@ -59,6 +59,13 @@ public class GetAuditLogListHandler : IRequestHandler<GetAuditLogList, PagedResu
             {
                 item.CreatorName = accessToken.Name;
                 item.CreatorEmail = "Access token";
+                continue;
+            }
+
+            // If the creator id is empty, it means that the audit log is created by the system
+            if (item.CreatorId == Guid.Empty)
+            {
+                item.CreatorName = "System";
             }
         }
 

--- a/modules/back-end/src/Application/Caches/ICacheService.cs
+++ b/modules/back-end/src/Application/Caches/ICacheService.cs
@@ -12,6 +12,8 @@ public interface ICacheService
 
     Task UpsertSegmentAsync(Segment segment);
 
+    Task DeleteSegmentAsync(Guid envId, Guid segmentId);
+
     Task UpsertLicenseAsync(Organization organization);
 
     Task<string> GetLicenseAsync(Guid orgId);

--- a/modules/back-end/src/Application/FeatureFlags/ArchiveFeatureFlag.cs
+++ b/modules/back-end/src/Application/FeatureFlags/ArchiveFeatureFlag.cs
@@ -15,33 +15,26 @@ public class ArchiveFeatureFlagHandler : IRequestHandler<ArchiveFeatureFlag, boo
     private readonly IFeatureFlagService _service;
     private readonly ICurrentUser _currentUser;
     private readonly IPublisher _publisher;
-    private readonly IAuditLogService _auditLogService;
 
     public ArchiveFeatureFlagHandler(
         IFeatureFlagService service,
         ICurrentUser currentUser,
-        IPublisher publisher,
-        IAuditLogService auditLogService)
+        IPublisher publisher)
     {
         _service = service;
         _currentUser = currentUser;
         _publisher = publisher;
-        _auditLogService = auditLogService;
     }
 
     public async Task<bool> Handle(ArchiveFeatureFlag request, CancellationToken cancellationToken)
     {
         var flag = await _service.GetAsync(request.EnvId, request.Key);
         var dataChange = flag.Archive(_currentUser.Id);
-
         await _service.UpdateAsync(flag);
 
-        // write audit log
-        var auditLog = AuditLog.ForArchive(flag, dataChange, _currentUser.Id);
-        await _auditLogService.AddOneAsync(auditLog);
-
         // publish on feature flag change notification
-        await _publisher.Publish(new OnFeatureFlagChanged(flag), cancellationToken);
+        var notification = new OnFeatureFlagChanged(flag, Operations.Archive, dataChange, _currentUser.Id);
+        await _publisher.Publish(notification, cancellationToken);
 
         return true;
     }

--- a/modules/back-end/src/Application/FeatureFlags/CopyToEnv.cs
+++ b/modules/back-end/src/Application/FeatureFlags/CopyToEnv.cs
@@ -46,8 +46,9 @@ public class CopyToEnvHandler : IRequestHandler<CopyToEnv, CopyToEnvResult>
             await _service.AddOneAsync(targetFlag);
 
             // publish on feature flag change notification
+            var dataChange = new DataChange(null).To(targetFlag);
             var notification =
-                new OnFeatureFlagChanged(targetFlag, Operations.Create, DataChange.Empty, _currentUser.Id);
+                new OnFeatureFlagChanged(targetFlag, Operations.Create, dataChange, _currentUser.Id);
             await _publisher.Publish(notification, cancellationToken);
         }
 

--- a/modules/back-end/src/Application/FeatureFlags/CopyToEnv.cs
+++ b/modules/back-end/src/Application/FeatureFlags/CopyToEnv.cs
@@ -46,9 +46,8 @@ public class CopyToEnvHandler : IRequestHandler<CopyToEnv, CopyToEnvResult>
             await _service.AddOneAsync(targetFlag);
 
             // publish on feature flag change notification
-            var dataChange = new DataChange(null).To(targetFlag);
             var notification =
-                new OnFeatureFlagChanged(targetFlag, Operations.Create, dataChange, _currentUser.Id);
+                new OnFeatureFlagChanged(targetFlag, Operations.Create, DataChange.Empty, _currentUser.Id);
             await _publisher.Publish(notification, cancellationToken);
         }
 

--- a/modules/back-end/src/Application/FeatureFlags/CreateFeatureFlag.cs
+++ b/modules/back-end/src/Application/FeatureFlags/CreateFeatureFlag.cs
@@ -81,18 +81,15 @@ public class CreateFeatureFlagHandler : IRequestHandler<CreateFeatureFlag, Featu
     private readonly IFeatureFlagService _service;
     private readonly ICurrentUser _currentUser;
     private readonly IPublisher _publisher;
-    private readonly IAuditLogService _auditLogService;
 
     public CreateFeatureFlagHandler(
         IFeatureFlagService service,
         ICurrentUser currentUser,
-        IPublisher publisher,
-        IAuditLogService auditLogService)
+        IPublisher publisher)
     {
         _service = service;
         _currentUser = currentUser;
         _publisher = publisher;
-        _auditLogService = auditLogService;
     }
 
     public async Task<FeatureFlag> Handle(CreateFeatureFlag request, CancellationToken cancellationToken)
@@ -106,12 +103,9 @@ public class CreateFeatureFlagHandler : IRequestHandler<CreateFeatureFlag, Featu
         var flag = request.AsFeatureFlag(_currentUser.Id);
         await _service.AddOneAsync(flag);
 
-        // write audit log
-        var auditLog = AuditLog.ForCreate(flag, _currentUser.Id);
-        await _auditLogService.AddOneAsync(auditLog);
-
         // publish on feature flag change notification
-        await _publisher.Publish(new OnFeatureFlagChanged(flag), cancellationToken);
+        var notification = new OnFeatureFlagChanged(flag, Operations.Create, DataChange.Empty, _currentUser.Id);
+        await _publisher.Publish(notification, cancellationToken);
 
         return flag;
     }

--- a/modules/back-end/src/Application/FeatureFlags/CreateFeatureFlag.cs
+++ b/modules/back-end/src/Application/FeatureFlags/CreateFeatureFlag.cs
@@ -104,7 +104,8 @@ public class CreateFeatureFlagHandler : IRequestHandler<CreateFeatureFlag, Featu
         await _service.AddOneAsync(flag);
 
         // publish on feature flag change notification
-        var notification = new OnFeatureFlagChanged(flag, Operations.Create, DataChange.Empty, _currentUser.Id);
+        var dataChange = new DataChange(null).To(flag);
+        var notification = new OnFeatureFlagChanged(flag, Operations.Create, dataChange, _currentUser.Id);
         await _publisher.Publish(notification, cancellationToken);
 
         return flag;

--- a/modules/back-end/src/Application/FeatureFlags/DeleteFeatureFlag.cs
+++ b/modules/back-end/src/Application/FeatureFlags/DeleteFeatureFlag.cs
@@ -1,7 +1,6 @@
 using Application.Bases;
 using Application.Bases.Exceptions;
 using Application.Users;
-using Domain.AuditLogs;
 
 namespace Application.FeatureFlags;
 
@@ -17,18 +16,15 @@ public class DeleteFeatureFlagHandler : IRequestHandler<DeleteFeatureFlag, bool>
     private readonly IFeatureFlagService _service;
     private readonly IPublisher _publisher;
     private readonly ICurrentUser _currentUser;
-    private readonly IAuditLogService _auditLogService;
 
     public DeleteFeatureFlagHandler(
         IFeatureFlagService service,
         IPublisher publisher,
-        ICurrentUser currentUser,
-        IAuditLogService auditLogService)
+        ICurrentUser currentUser)
     {
         _service = service;
         _publisher = publisher;
         _currentUser = currentUser;
-        _auditLogService = auditLogService;
     }
 
     public async Task<bool> Handle(DeleteFeatureFlag request, CancellationToken cancellationToken)
@@ -41,12 +37,8 @@ public class DeleteFeatureFlagHandler : IRequestHandler<DeleteFeatureFlag, bool>
 
         await _service.DeleteAsync(flag.Id);
 
-        // write audit log
-        var auditLog = AuditLog.ForRemove(flag, _currentUser.Id);
-        await _auditLogService.AddOneAsync(auditLog);
-
         // publish on feature flag delete notification
-        await _publisher.Publish(new OnFeatureFlagDeleted(request.EnvId, flag.Id), cancellationToken);
+        await _publisher.Publish(new OnFeatureFlagDeleted(flag, _currentUser.Id), cancellationToken);
 
         return true;
     }

--- a/modules/back-end/src/Application/FeatureFlags/OnFeatureFlagChanged.cs
+++ b/modules/back-end/src/Application/FeatureFlags/OnFeatureFlagChanged.cs
@@ -1,4 +1,5 @@
 using Application.Caches;
+using Domain.AuditLogs;
 using Domain.FeatureFlags;
 using Domain.FlagRevisions;
 using Domain.Messages;
@@ -9,12 +10,33 @@ public class OnFeatureFlagChanged : INotification
 {
     public FeatureFlag Flag { get; set; }
 
+    public string Operation { get; set; }
+
+    public DataChange DataChange { get; set; }
+
+    public Guid OperatorId { get; set; }
+
     public string Comment { get; set; }
 
-    public OnFeatureFlagChanged(FeatureFlag flag, string comment = "")
+    public OnFeatureFlagChanged(
+        FeatureFlag flag,
+        string operation,
+        DataChange dataChange,
+        Guid operatorId,
+        string comment = "")
     {
         Flag = flag;
+        Operation = operation;
+        DataChange = dataChange;
+        OperatorId = operatorId;
         Comment = comment;
+    }
+
+    public AuditLog GetAuditLog()
+    {
+        var auditLog = AuditLog.For(Flag, Operation, DataChange, Comment, OperatorId);
+
+        return auditLog;
     }
 }
 
@@ -23,20 +45,26 @@ public class OnFeatureFlagChangedHandler : INotificationHandler<OnFeatureFlagCha
     private readonly IFlagRevisionService _flagRevisionService;
     private readonly IMessageProducer _messageProducer;
     private readonly ICacheService _cache;
+    private readonly IAuditLogService _auditLogService;
 
     public OnFeatureFlagChangedHandler(
         IFlagRevisionService flagRevisionService,
         IMessageProducer messageProducer,
-        ICacheService cache)
+        ICacheService cache,
+        IAuditLogService auditLogService)
     {
         _flagRevisionService = flagRevisionService;
         _messageProducer = messageProducer;
         _cache = cache;
+        _auditLogService = auditLogService;
     }
 
     public async Task Handle(OnFeatureFlagChanged notification, CancellationToken cancellationToken)
     {
         var flag = notification.Flag;
+
+        // write audit log
+        await _auditLogService.AddOneAsync(notification.GetAuditLog());
 
         // update cache
         await _cache.UpsertFlagAsync(flag);

--- a/modules/back-end/src/Application/FeatureFlags/OnFeatureFlagDeleted.cs
+++ b/modules/back-end/src/Application/FeatureFlags/OnFeatureFlagDeleted.cs
@@ -18,8 +18,9 @@ public class OnFeatureFlagDeleted : INotification
 
     public AuditLog GetAuditLog()
     {
-        var auditLog = AuditLog.For(Flag, Operations.Remove, DataChange.Empty, string.Empty, OperatorId);
+        var dataChange = new DataChange(Flag).To(null);
 
+        var auditLog = AuditLog.For(Flag, Operations.Remove, dataChange, string.Empty, OperatorId);
         return auditLog;
     }
 }

--- a/modules/back-end/src/Application/FeatureFlags/OnFeatureFlagDeleted.cs
+++ b/modules/back-end/src/Application/FeatureFlags/OnFeatureFlagDeleted.cs
@@ -1,32 +1,48 @@
 using Application.Caches;
+using Domain.AuditLogs;
+using Domain.FeatureFlags;
 
 namespace Application.FeatureFlags;
 
 public class OnFeatureFlagDeleted : INotification
 {
-    public Guid EnvId { get; set; }
+    public FeatureFlag Flag { get; set; }
 
-    public Guid FlagId { get; set; }
+    public Guid OperatorId { get; set; }
 
-    public OnFeatureFlagDeleted(Guid envId, Guid flagId)
+    public OnFeatureFlagDeleted(FeatureFlag flag, Guid operatorId)
     {
-        EnvId = envId;
-        FlagId = flagId;
+        Flag = flag;
+        OperatorId = operatorId;
+    }
+
+    public AuditLog GetAuditLog()
+    {
+        var auditLog = AuditLog.For(Flag, Operations.Remove, DataChange.Empty, string.Empty, OperatorId);
+
+        return auditLog;
     }
 }
 
 public class OnFeatureFlagDeletedHandler : INotificationHandler<OnFeatureFlagDeleted>
 {
     private readonly ICacheService _cache;
+    private readonly IAuditLogService _auditLogService;
 
-    public OnFeatureFlagDeletedHandler(ICacheService cache)
+    public OnFeatureFlagDeletedHandler(ICacheService cache, IAuditLogService auditLogService)
     {
         _cache = cache;
+        _auditLogService = auditLogService;
     }
 
     public async Task Handle(OnFeatureFlagDeleted notification, CancellationToken cancellationToken)
     {
+        // write audit log
+        await _auditLogService.AddOneAsync(notification.GetAuditLog());
+
         // delete cache
-        await _cache.DeleteFlagAsync(notification.EnvId, notification.FlagId);
+        var envId = notification.Flag.EnvId;
+        var flagId = notification.Flag.Id;
+        await _cache.DeleteFlagAsync(envId, flagId);
     }
 }

--- a/modules/back-end/src/Application/FeatureFlags/SetTags.cs
+++ b/modules/back-end/src/Application/FeatureFlags/SetTags.cs
@@ -39,7 +39,7 @@ public class SetTagsHandler : IRequestHandler<SetTags, bool>
         await _service.UpdateAsync(flag);
 
         // write audit log
-        var auditLog = AuditLog.ForUpdate(flag, dataChange, string.Empty, _currentUser.Id);
+        var auditLog = AuditLog.For(flag, Operations.Update, dataChange, string.Empty, _currentUser.Id);
         await _auditLogService.AddOneAsync(auditLog);
 
         // add flag revision

--- a/modules/back-end/src/Application/FeatureFlags/ToggleFeatureFlag.cs
+++ b/modules/back-end/src/Application/FeatureFlags/ToggleFeatureFlag.cs
@@ -35,12 +35,9 @@ public class ToggleFeatureFlagHandler : IRequestHandler<ToggleFeatureFlag, bool>
         var dataChange = flag.Toggle(_currentUser.Id);
         await _service.UpdateAsync(flag);
 
-        // write audit log
-        var auditLog = AuditLog.ForUpdate(flag, dataChange, string.Empty, _currentUser.Id);
-        await _auditLogService.AddOneAsync(auditLog);
-
         // publish on feature flag change notification
-        await _publisher.Publish(new OnFeatureFlagChanged(flag), cancellationToken);
+        var notification = new OnFeatureFlagChanged(flag, Operations.Update, dataChange, _currentUser.Id);
+        await _publisher.Publish(notification, cancellationToken);
 
         return true;
     }

--- a/modules/back-end/src/Application/FeatureFlags/ToggleFeatureFlag.cs
+++ b/modules/back-end/src/Application/FeatureFlags/ToggleFeatureFlag.cs
@@ -15,18 +15,15 @@ public class ToggleFeatureFlagHandler : IRequestHandler<ToggleFeatureFlag, bool>
     private readonly IFeatureFlagService _service;
     private readonly ICurrentUser _currentUser;
     private readonly IPublisher _publisher;
-    private readonly IAuditLogService _auditLogService;
 
     public ToggleFeatureFlagHandler(
         IFeatureFlagService service,
         ICurrentUser currentUser,
-        IPublisher publisher,
-        IAuditLogService auditLogService)
+        IPublisher publisher)
     {
         _service = service;
         _currentUser = currentUser;
         _publisher = publisher;
-        _auditLogService = auditLogService;
     }
 
     public async Task<bool> Handle(ToggleFeatureFlag request, CancellationToken cancellationToken)

--- a/modules/back-end/src/Application/FeatureFlags/UpdateTargeting.cs
+++ b/modules/back-end/src/Application/FeatureFlags/UpdateTargeting.cs
@@ -27,18 +27,15 @@ public class UpdateTargeting : IRequest<bool>
 public class UpdateTargetingHandler : IRequestHandler<UpdateTargeting, bool>
 {
     private readonly IFeatureFlagService _flagService;
-    private readonly IAuditLogService _auditLogService;
     private readonly ICurrentUser _currentUser;
     private readonly IPublisher _publisher;
 
     public UpdateTargetingHandler(
         IFeatureFlagService flagService,
-        IAuditLogService auditLogService,
         ICurrentUser currentUser,
         IPublisher publisher)
     {
         _flagService = flagService;
-        _auditLogService = auditLogService;
         _currentUser = currentUser;
         _publisher = publisher;
     }
@@ -56,12 +53,10 @@ public class UpdateTargetingHandler : IRequestHandler<UpdateTargeting, bool>
 
         await _flagService.UpdateAsync(flag);
 
-        // write audit log
-        var auditLog = AuditLog.ForUpdate(flag, dataChange, request.Comment, _currentUser.Id);
-        await _auditLogService.AddOneAsync(auditLog);
-
         // publish on feature flag change notification
-        await _publisher.Publish(new OnFeatureFlagChanged(flag, request.Comment), cancellationToken);
+        var notification =
+            new OnFeatureFlagChanged(flag, Operations.Update, dataChange, _currentUser.Id, request.Comment);
+        await _publisher.Publish(notification, cancellationToken);
 
         return true;
     }

--- a/modules/back-end/src/Application/FeatureFlags/UpdateVariations.cs
+++ b/modules/back-end/src/Application/FeatureFlags/UpdateVariations.cs
@@ -30,18 +30,15 @@ public class UpdateVariationsHandler : IRequestHandler<UpdateVariations, bool>
     private readonly IFeatureFlagService _service;
     private readonly ICurrentUser _currentUser;
     private readonly IPublisher _publisher;
-    private readonly IAuditLogService _auditLogService;
 
     public UpdateVariationsHandler(
         IFeatureFlagService service,
         ICurrentUser currentUser,
-        IPublisher publisher,
-        IAuditLogService auditLogService)
+        IPublisher publisher)
     {
         _service = service;
         _currentUser = currentUser;
         _publisher = publisher;
-        _auditLogService = auditLogService;
     }
 
     public async Task<bool> Handle(UpdateVariations request, CancellationToken cancellationToken)
@@ -50,12 +47,9 @@ public class UpdateVariationsHandler : IRequestHandler<UpdateVariations, bool>
         var dataChange = flag.UpdateVariations(request.Variations, _currentUser.Id);
         await _service.UpdateAsync(flag);
 
-        // write audit log
-        var auditLog = AuditLog.ForUpdate(flag, dataChange, string.Empty, _currentUser.Id);
-        await _auditLogService.AddOneAsync(auditLog);
-
         // publish on feature flag change notification
-        await _publisher.Publish(new OnFeatureFlagChanged(flag), cancellationToken);
+        var notification = new OnFeatureFlagChanged(flag, Operations.Update, dataChange, _currentUser.Id);
+        await _publisher.Publish(notification, cancellationToken);
 
         return true;
     }

--- a/modules/back-end/src/Application/Segments/CreateSegment.cs
+++ b/modules/back-end/src/Application/Segments/CreateSegment.cs
@@ -47,17 +47,14 @@ public class CreateSegmentHandler : IRequestHandler<CreateSegment, Segment>
     private readonly ISegmentService _service;
     private readonly IPublisher _publisher;
     private readonly ICurrentUser _currentUser;
-    private readonly IAuditLogService _auditLogService;
 
     public CreateSegmentHandler(
         ISegmentService service,
         IPublisher publisher,
-        ICurrentUser currentUser,
-        IAuditLogService auditLogService)
+        ICurrentUser currentUser)
     {
         _service = service;
         _publisher = publisher;
-        _auditLogService = auditLogService;
         _currentUser = currentUser;
     }
 
@@ -66,12 +63,9 @@ public class CreateSegmentHandler : IRequestHandler<CreateSegment, Segment>
         var segment = request.AsSegment();
         await _service.AddOneAsync(segment);
 
-        // write audit log
-        var auditLog = AuditLog.ForCreate(segment, _currentUser.Id);
-        await _auditLogService.AddOneAsync(auditLog);
-
         // publish on segment created message
-        await _publisher.Publish(new OnSegmentChange(segment), cancellationToken);
+        var notification = new OnSegmentChange(segment, Operations.Create, DataChange.Empty, _currentUser.Id);
+        await _publisher.Publish(notification, cancellationToken);
 
         return segment;
     }

--- a/modules/back-end/src/Application/Segments/CreateSegment.cs
+++ b/modules/back-end/src/Application/Segments/CreateSegment.cs
@@ -64,7 +64,8 @@ public class CreateSegmentHandler : IRequestHandler<CreateSegment, Segment>
         await _service.AddOneAsync(segment);
 
         // publish on segment created message
-        var notification = new OnSegmentChange(segment, Operations.Create, DataChange.Empty, _currentUser.Id);
+        var dataChange = new DataChange(null).To(segment);
+        var notification = new OnSegmentChange(segment, Operations.Create, dataChange, _currentUser.Id);
         await _publisher.Publish(notification, cancellationToken);
 
         return segment;

--- a/modules/back-end/src/Application/Segments/OnSegmentChange.cs
+++ b/modules/back-end/src/Application/Segments/OnSegmentChange.cs
@@ -26,10 +26,18 @@ public class OnSegmentChange : INotification
         AffectedFlagIds = Array.Empty<Guid>();
     }
 
-    public OnSegmentChange(Segment segment, IEnumerable<Guid> affectedFlagIds)
+    public OnSegmentChange(
+        Segment segment,
+        IEnumerable<Guid> affectedFlagIds,
+        string operation,
+        DataChange dataChange,
+        Guid operatorId)
     {
         Segment = segment;
         AffectedFlagIds = affectedFlagIds;
+        Operation = operation;
+        DataChange = dataChange;
+        OperatorId = operatorId;
     }
 
     public AuditLog GetAuditLog()

--- a/modules/back-end/src/Application/Segments/OnSegmentChange.cs
+++ b/modules/back-end/src/Application/Segments/OnSegmentChange.cs
@@ -20,10 +20,10 @@ public class OnSegmentChange : INotification
     public OnSegmentChange(Segment segment, string operation, DataChange dataChange, Guid operatorId)
     {
         Segment = segment;
+        AffectedFlagIds = Array.Empty<Guid>();
         Operation = operation;
         DataChange = dataChange;
         OperatorId = operatorId;
-        AffectedFlagIds = Array.Empty<Guid>();
     }
 
     public OnSegmentChange(

--- a/modules/back-end/src/Application/Segments/OnSegmentChange.cs
+++ b/modules/back-end/src/Application/Segments/OnSegmentChange.cs
@@ -72,8 +72,7 @@ public class OnSegmentChangeHandler : INotificationHandler<OnSegmentChange>
     public async Task Handle(OnSegmentChange notification, CancellationToken cancellationToken)
     {
         // write audit log
-        var auditLog = notification.GetAuditLog();
-        await _auditLogService.AddOneAsync(auditLog);
+        await _auditLogService.AddOneAsync(notification.GetAuditLog());
 
         // update cache
         await _cache.UpsertSegmentAsync(notification.Segment);

--- a/modules/back-end/src/Application/Segments/OnSegmentChange.cs
+++ b/modules/back-end/src/Application/Segments/OnSegmentChange.cs
@@ -9,21 +9,24 @@ public class OnSegmentChange : INotification
 {
     public Segment Segment { get; set; }
 
+    public IEnumerable<Guid> AffectedFlagIds { get; set; }
+
     public string Operation { get; set; }
 
     public DataChange DataChange { get; set; }
 
     public Guid OperatorId { get; set; }
 
-    public IEnumerable<Guid> AffectedFlagIds { get; set; }
+    public string Comment { get; set; }
 
-    public OnSegmentChange(Segment segment, string operation, DataChange dataChange, Guid operatorId)
+    public OnSegmentChange(Segment segment, string operation, DataChange dataChange, Guid operatorId, string comment = "")
     {
         Segment = segment;
         AffectedFlagIds = Array.Empty<Guid>();
         Operation = operation;
         DataChange = dataChange;
         OperatorId = operatorId;
+        Comment = comment;
     }
 
     public OnSegmentChange(
@@ -31,18 +34,20 @@ public class OnSegmentChange : INotification
         IEnumerable<Guid> affectedFlagIds,
         string operation,
         DataChange dataChange,
-        Guid operatorId)
+        Guid operatorId,
+        string comment = "")
     {
         Segment = segment;
         AffectedFlagIds = affectedFlagIds;
         Operation = operation;
         DataChange = dataChange;
         OperatorId = operatorId;
+        Comment = comment;
     }
 
     public AuditLog GetAuditLog()
     {
-        var auditLog = AuditLog.For(Segment, Operations.Update, DataChange, string.Empty, OperatorId);
+        var auditLog = AuditLog.For(Segment, Operations.Update, DataChange, Comment, OperatorId);
 
         return auditLog;
     }

--- a/modules/back-end/src/Application/Segments/OnSegmentChange.cs
+++ b/modules/back-end/src/Application/Segments/OnSegmentChange.cs
@@ -47,7 +47,7 @@ public class OnSegmentChange : INotification
 
     public AuditLog GetAuditLog()
     {
-        var auditLog = AuditLog.For(Segment, Operations.Update, DataChange, Comment, OperatorId);
+        var auditLog = AuditLog.For(Segment, Operation, DataChange, Comment, OperatorId);
 
         return auditLog;
     }

--- a/modules/back-end/src/Application/Segments/OnSegmentChange.cs
+++ b/modules/back-end/src/Application/Segments/OnSegmentChange.cs
@@ -1,4 +1,5 @@
 using Application.Caches;
+using Domain.AuditLogs;
 using Domain.Messages;
 using Domain.Segments;
 
@@ -8,11 +9,20 @@ public class OnSegmentChange : INotification
 {
     public Segment Segment { get; set; }
 
+    public string Operation { get; set; }
+
+    public DataChange DataChange { get; set; }
+
+    public Guid OperatorId { get; set; }
+
     public IEnumerable<Guid> AffectedFlagIds { get; set; }
 
-    public OnSegmentChange(Segment segment)
+    public OnSegmentChange(Segment segment, string operation, DataChange dataChange, Guid operatorId)
     {
         Segment = segment;
+        Operation = operation;
+        DataChange = dataChange;
+        OperatorId = operatorId;
         AffectedFlagIds = Array.Empty<Guid>();
     }
 
@@ -20,6 +30,13 @@ public class OnSegmentChange : INotification
     {
         Segment = segment;
         AffectedFlagIds = affectedFlagIds;
+    }
+
+    public AuditLog GetAuditLog()
+    {
+        var auditLog = AuditLog.For(Segment, Operations.Update, DataChange, string.Empty, OperatorId);
+
+        return auditLog;
     }
 }
 

--- a/modules/back-end/src/Application/Segments/OnSegmentChange.cs
+++ b/modules/back-end/src/Application/Segments/OnSegmentChange.cs
@@ -44,15 +44,24 @@ public class OnSegmentChangeHandler : INotificationHandler<OnSegmentChange>
 {
     private readonly IMessageProducer _messageProducer;
     private readonly ICacheService _cache;
+    private readonly IAuditLogService _auditLogService;
 
-    public OnSegmentChangeHandler(IMessageProducer messageProducer, ICacheService cache)
+    public OnSegmentChangeHandler(
+        IMessageProducer messageProducer,
+        ICacheService cache,
+        IAuditLogService auditLogService)
     {
         _messageProducer = messageProducer;
         _cache = cache;
+        _auditLogService = auditLogService;
     }
 
     public async Task Handle(OnSegmentChange notification, CancellationToken cancellationToken)
     {
+        // write audit log
+        var auditLog = notification.GetAuditLog();
+        await _auditLogService.AddOneAsync(auditLog);
+
         // update cache
         await _cache.UpsertSegmentAsync(notification.Segment);
 

--- a/modules/back-end/src/Application/Segments/OnSegmentDeleted.cs
+++ b/modules/back-end/src/Application/Segments/OnSegmentDeleted.cs
@@ -1,0 +1,48 @@
+using Application.Caches;
+using Domain.AuditLogs;
+using Domain.Segments;
+
+namespace Application.Segments;
+
+public class OnSegmentDeleted : INotification
+{
+    public Segment Segment { get; set; }
+
+    public Guid OperatorId { get; set; }
+
+    public OnSegmentDeleted(Segment segment, Guid currentUserId)
+    {
+        Segment = segment;
+        OperatorId = currentUserId;
+    }
+
+    public AuditLog GetAuditLog()
+    {
+        var auditLog = AuditLog.For(Segment, Operations.Remove, DataChange.Empty, string.Empty, OperatorId);
+
+        return auditLog;
+    }
+}
+
+public class OnSegmentDeletedHandler : INotificationHandler<OnSegmentDeleted>
+{
+    private readonly ICacheService _cache;
+    private readonly IAuditLogService _auditLogService;
+
+    public OnSegmentDeletedHandler(ICacheService cache, IAuditLogService auditLogService)
+    {
+        _cache = cache;
+        _auditLogService = auditLogService;
+    }
+
+    public async Task Handle(OnSegmentDeleted notification, CancellationToken cancellationToken)
+    {
+        // write audit log
+        await _auditLogService.AddOneAsync(notification.GetAuditLog());
+
+        // delete cache
+        var envId = notification.Segment.EnvId;
+        var segmentId = notification.Segment.Id;
+        await _cache.DeleteSegmentAsync(envId, segmentId);
+    }
+}

--- a/modules/back-end/src/Application/Segments/OnSegmentDeleted.cs
+++ b/modules/back-end/src/Application/Segments/OnSegmentDeleted.cs
@@ -18,8 +18,9 @@ public class OnSegmentDeleted : INotification
 
     public AuditLog GetAuditLog()
     {
-        var auditLog = AuditLog.For(Segment, Operations.Remove, DataChange.Empty, string.Empty, OperatorId);
+        var dataChange = new DataChange(Segment).To(null);
 
+        var auditLog = AuditLog.For(Segment, Operations.Remove, dataChange, string.Empty, OperatorId);
         return auditLog;
     }
 }

--- a/modules/back-end/src/Application/Segments/OnSegmentDeleted.cs
+++ b/modules/back-end/src/Application/Segments/OnSegmentDeleted.cs
@@ -10,10 +10,10 @@ public class OnSegmentDeleted : INotification
 
     public Guid OperatorId { get; set; }
 
-    public OnSegmentDeleted(Segment segment, Guid currentUserId)
+    public OnSegmentDeleted(Segment segment, Guid operatorId)
     {
         Segment = segment;
-        OperatorId = currentUserId;
+        OperatorId = operatorId;
     }
 
     public AuditLog GetAuditLog()

--- a/modules/back-end/src/Application/Segments/UpdateSegment.cs
+++ b/modules/back-end/src/Application/Segments/UpdateSegment.cs
@@ -64,7 +64,7 @@ public class UpdateSegmentHandler : IRequestHandler<UpdateSegment, Segment>
         // publish segment updated notification
         var flagReferences = await _service.GetFlagReferencesAsync(segment.EnvId, segment.Id);
         var notification = new OnSegmentChange(
-            segment, flagReferences.Select(x => x.Id), Operations.Update, dataChange, _currentUser.Id
+            segment, flagReferences.Select(x => x.Id), Operations.Update, dataChange, _currentUser.Id, request.Comment
         );
         await _publisher.Publish(notification, cancellationToken);
 

--- a/modules/back-end/src/Application/Segments/UpdateSegment.cs
+++ b/modules/back-end/src/Application/Segments/UpdateSegment.cs
@@ -44,18 +44,15 @@ public class UpdateSegmentHandler : IRequestHandler<UpdateSegment, Segment>
     private readonly ISegmentService _service;
     private readonly IPublisher _publisher;
     private readonly ICurrentUser _currentUser;
-    private readonly IAuditLogService _auditLogService;
 
     public UpdateSegmentHandler(
         ISegmentService service,
         IPublisher publisher,
-        ICurrentUser currentUser,
-        IAuditLogService auditLogService)
+        ICurrentUser currentUser)
     {
         _service = service;
         _publisher = publisher;
         _currentUser = currentUser;
-        _auditLogService = auditLogService;
     }
 
     public async Task<Segment> Handle(UpdateSegment request, CancellationToken cancellationToken)
@@ -64,13 +61,12 @@ public class UpdateSegmentHandler : IRequestHandler<UpdateSegment, Segment>
         var dataChange = segment.Update(request.Name, request.Included, request.Excluded, request.Rules, request.Description);
         await _service.UpdateAsync(segment);
 
-        // write audit log
-        var auditLog = AuditLog.ForUpdate(segment, dataChange, request.Comment, _currentUser.Id);
-        await _auditLogService.AddOneAsync(auditLog);
-
         // publish segment updated notification
         var flagReferences = await _service.GetFlagReferencesAsync(segment.EnvId, segment.Id);
-        await _publisher.Publish(new OnSegmentChange(segment, flagReferences.Select(x => x.Id)), cancellationToken);
+        var notification = new OnSegmentChange(
+            segment, flagReferences.Select(x => x.Id), Operations.Update, dataChange, _currentUser.Id
+        );
+        await _publisher.Publish(notification, cancellationToken);
 
         return segment;
     }

--- a/modules/back-end/src/Application/Triggers/RunTrigger.cs
+++ b/modules/back-end/src/Application/Triggers/RunTrigger.cs
@@ -45,13 +45,12 @@ public class RunTriggerHandler : IRequestHandler<RunTrigger, bool>
         {
             var flag = await _flagService.GetAsync(trigger.TargetId);
 
-            // If we needn't to run this trigger
-            if (!trigger.NeedToRun(flag))
+            var dataChange = trigger.Run(flag);
+            if (dataChange == null)
             {
                 return true;
             }
 
-            var dataChange = trigger.Run(flag);
             await _flagService.UpdateAsync(flag);
             await _triggerService.UpdateAsync(trigger);
 

--- a/modules/back-end/src/Application/Triggers/RunTrigger.cs
+++ b/modules/back-end/src/Application/Triggers/RunTrigger.cs
@@ -1,6 +1,7 @@
 using Application.Bases;
 using Application.Bases.Exceptions;
 using Application.FeatureFlags;
+using Domain.AuditLogs;
 using Domain.Triggers;
 
 namespace Application.Triggers;
@@ -48,7 +49,9 @@ public class RunTriggerHandler : IRequestHandler<RunTrigger, bool>
 
             // publish on feature flag change notification
             var comment = trigger.Action == TriggerActions.TurnOff ? "Turn off by trigger" : "Turn on by trigger";
-            await _publisher.Publish(new OnFeatureFlagChanged(featureFlag, comment), cancellationToken);
+            var notification =
+                new OnFeatureFlagChanged(featureFlag, Operations.Update, DataChange.Empty, Guid.Empty, comment);
+            await _publisher.Publish(notification, cancellationToken);
         }
 
         await _triggerService.UpdateAsync(trigger);

--- a/modules/back-end/src/Domain/AuditLogs/AuditLog.cs
+++ b/modules/back-end/src/Domain/AuditLogs/AuditLog.cs
@@ -77,8 +77,6 @@ public class AuditLog : Entity
         return auditLog;
     }
 
-    #region segment
-
     public static AuditLog For(
         Segment segment,
         string operation,
@@ -99,48 +97,4 @@ public class AuditLog : Entity
 
         return auditLog;
     }
-
-    public static AuditLog ForCreate(Segment segment, Guid creatorId)
-    {
-        var dataChange = new DataChange(null).To(segment);
-
-        var auditLog = For(segment, Operations.Create, dataChange, string.Empty, creatorId);
-        return auditLog;
-    }
-
-    public static AuditLog ForUpdate(
-        Segment segment,
-        DataChange dataChange,
-        string comment,
-        Guid creatorId)
-    {
-        var auditLog = For(segment, Operations.Update, dataChange, comment, creatorId);
-
-        return auditLog;
-    }
-
-    public static AuditLog ForArchive(Segment segment, DataChange dataChange, Guid operatorId)
-    {
-        var auditLog = For(segment, Operations.Archive, dataChange, string.Empty, operatorId);
-
-        return auditLog;
-    }
-
-    public static AuditLog ForRestore(Segment segment, DataChange dataChange, Guid operatorId)
-    {
-        var auditLog = For(segment, Operations.Restore, dataChange, string.Empty, operatorId);
-
-        return auditLog;
-    }
-    
-    public static AuditLog ForRemove(Segment segment, Guid operatorId)
-    {
-        var dataChange = new DataChange(segment).To(null);
-
-        var auditLog = For(segment, Operations.Remove, dataChange, string.Empty, operatorId);
-
-        return auditLog;
-    }
-    
-    #endregion
 }

--- a/modules/back-end/src/Domain/AuditLogs/AuditLog.cs
+++ b/modules/back-end/src/Domain/AuditLogs/AuditLog.cs
@@ -56,8 +56,6 @@ public class AuditLog : Entity
         CreatedAt = DateTime.UtcNow;
     }
 
-    #region feature flag
-
     public static AuditLog For(
         FeatureFlag flag,
         string operation,
@@ -78,50 +76,6 @@ public class AuditLog : Entity
 
         return auditLog;
     }
-
-    public static AuditLog ForUpdate(
-        FeatureFlag flag,
-        DataChange dataChange,
-        string comment,
-        Guid creatorId)
-    {
-        var auditLog = For(flag, Operations.Update, dataChange, comment, creatorId);
-
-        return auditLog;
-    }
-
-    public static AuditLog ForCreate(FeatureFlag flag, Guid creatorId)
-    {
-        var dataChange = new DataChange(null).To(flag);
-
-        var auditLog = For(flag, Operations.Create, dataChange, string.Empty, creatorId);
-        return auditLog;
-    }
-
-    public static AuditLog ForArchive(FeatureFlag flag, DataChange dataChange, Guid operatorId)
-    {
-        var auditLog = For(flag, Operations.Archive, dataChange, string.Empty, operatorId);
-
-        return auditLog;
-    }
-
-    public static AuditLog ForRestore(FeatureFlag flag, DataChange dataChange, Guid operatorId)
-    {
-        var auditLog = For(flag, Operations.Restore, dataChange, string.Empty, operatorId);
-
-        return auditLog;
-    }
-
-    public static AuditLog ForRemove(FeatureFlag flag, Guid operatorId)
-    {
-        var dataChange = new DataChange(flag).To(null);
-
-        var auditLog = For(flag, Operations.Remove, dataChange, string.Empty, operatorId);
-
-        return auditLog;
-    }
-
-    #endregion
 
     #region segment
 

--- a/modules/back-end/src/Domain/AuditLogs/DataChange.cs
+++ b/modules/back-end/src/Domain/AuditLogs/DataChange.cs
@@ -8,6 +8,8 @@ public class DataChange
 
     public string Current { get; set; }
 
+    public static DataChange Empty => new();
+
     public DataChange()
     {
         Previous = string.Empty;

--- a/modules/back-end/src/Domain/AuditLogs/DataChange.cs
+++ b/modules/back-end/src/Domain/AuditLogs/DataChange.cs
@@ -8,8 +8,6 @@ public class DataChange
 
     public string Current { get; set; }
 
-    public static DataChange Empty => new();
-
     public DataChange()
     {
         Previous = string.Empty;

--- a/modules/back-end/src/Domain/Triggers/Trigger.cs
+++ b/modules/back-end/src/Domain/Triggers/Trigger.cs
@@ -1,3 +1,4 @@
+using Domain.AuditLogs;
 using Domain.FeatureFlags;
 
 namespace Domain.Triggers;
@@ -54,21 +55,44 @@ public class Trigger : AuditedEntity
         return true;
     }
 
-    public void Run(FeatureFlag featureFlag)
+    public bool NeedToRun(FeatureFlag featureFlag)
     {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        switch (featureFlag.IsEnabled)
+        {
+            case false when Action == TriggerActions.TurnOff:
+            case true when Action == TriggerActions.TurnOn:
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    public DataChange Run(FeatureFlag featureFlag)
+    {
+        var dataChange = new DataChange(featureFlag);
+
         switch (Action)
         {
             case TriggerActions.TurnOff:
                 featureFlag.IsEnabled = false;
+                featureFlag.Revision = Guid.NewGuid();
                 break;
 
             case TriggerActions.TurnOn:
                 featureFlag.IsEnabled = true;
+                featureFlag.Revision = Guid.NewGuid();
                 break;
         }
 
         TriggeredTimes++;
         LastTriggeredAt = DateTime.UtcNow;
+
+        return dataChange.To(featureFlag);
     }
 
     public void Update(bool isEnabled)

--- a/modules/back-end/src/Domain/Triggers/Trigger.cs
+++ b/modules/back-end/src/Domain/Triggers/Trigger.cs
@@ -60,12 +60,10 @@ public class Trigger : AuditedEntity
         {
             case TriggerActions.TurnOff:
                 featureFlag.IsEnabled = false;
-                featureFlag.UpdatedAt = DateTime.UtcNow;
                 break;
 
             case TriggerActions.TurnOn:
                 featureFlag.IsEnabled = true;
-                featureFlag.UpdatedAt = DateTime.UtcNow;
                 break;
         }
 

--- a/modules/back-end/src/Infrastructure/Redis/RedisCacheService.cs
+++ b/modules/back-end/src/Infrastructure/Redis/RedisCacheService.cs
@@ -51,6 +51,17 @@ public class RedisCacheService : ICacheService
         await _redis.SortedSetAddAsync(index.Key, index.Member, index.Score);
     }
 
+    public async Task DeleteSegmentAsync(Guid envId, Guid segmentId)
+    {
+        // delete cache
+        var cacheKey = RedisKeys.Segment(segmentId);
+        await _redis.KeyDeleteAsync(cacheKey);
+
+        // delete index
+        var index = RedisKeys.SegmentIndex(envId);
+        await _redis.SortedSetRemoveAsync(index, segmentId.ToString());
+    }
+
     public async Task UpsertLicenseAsync(Organization organization)
     {
         var key = RedisKeys.License(organization.Id);


### PR DESCRIPTION
This new way helps us eliminate more code and makes it easier to maintain. In addition to this, this PR also deletes the segment cache when a segment is deleted.