### PR TITLE
✨ feat: add discrete health checks to da-server

### DIFF
--- a/modules/data-analytics/app/__init__.py
+++ b/modules/data-analytics/app/__init__.py
@@ -36,6 +36,9 @@ def _create_app(config_name='default') -> Flask:
     from app.experimentation import get_expt_blueprint
     __app.register_blueprint(get_expt_blueprint(), url_prefix='/api/expt')
 
+    from app.health import get_health_blueprint
+    __app.register_blueprint(get_health_blueprint(), url_prefix='/health')
+
     # https://flask-caching.readthedocs.io/en/latest/
     cache_config = {"CACHE_KEY_PREFIX": CACHE_KEY_PREFIX}
     cache_options = {"ssl": REDIS_SSL, "username": REDIS_USER}

--- a/modules/data-analytics/app/health/__init__.py
+++ b/modules/data-analytics/app/health/__init__.py
@@ -1,0 +1,12 @@
+
+from flask import Blueprint
+
+__blueprint = None
+
+
+def get_health_blueprint() -> Blueprint:
+    global __blueprint
+    if not __blueprint:
+        __blueprint = Blueprint('health', __name__)
+    from app.health import views
+    return __blueprint

--- a/modules/data-analytics/app/health/views.py
+++ b/modules/data-analytics/app/health/views.py
@@ -1,0 +1,14 @@
+from app.health import get_health_blueprint
+from flask import current_app, jsonify
+from utils import internal_error_handler
+
+health = get_health_blueprint()
+health.register_error_handler(500, internal_error_handler)
+
+@health.route('/liveness', methods=['GET'])
+def get_liveness():
+    return jsonify(code=200, error='', data={'state': f'{current_app.config["ENV"]} OK'})
+
+@health.route('/readiness', methods=['GET'])
+def get_readiness():
+    return jsonify(code=200, error='', data={'state': f'{current_app.config["ENV"]} OK'})


### PR DESCRIPTION
This PR adds discrete health check endpoints to the data analytics server at

/health/readiness & /health/liveness

This makes the server consistent with the api and evaluation servers and is helpful to remove noise when filtering traces.

To test run use docker-compose-dev.yml

`docker compose --project-directory . -f ./docker/composes/docker-compose-dev.yml up --build -d `

Then using a browser navigate to http://localhost:8200/health/liveness and http://localhost:8200/health/readiness