### PR TITLE
🐛 fix: auto offset store should be disabled by default

### DIFF
--- a/modules/back-end/src/Api/appsettings.Development.json
+++ b/modules/back-end/src/Api/appsettings.Development.json
@@ -25,7 +25,7 @@
       "auto.offset.reset": "earliest",
       "enable.auto.commit": true,
       "auto.commit.interval.ms": "5000",
-      "enable.auto.offset.store": true
+      "enable.auto.offset.store": false
     }
   },
   "OLAP": {

--- a/modules/back-end/src/Api/appsettings.json
+++ b/modules/back-end/src/Api/appsettings.json
@@ -25,7 +25,7 @@
       "auto.offset.reset": "earliest",
       "enable.auto.commit": true,
       "auto.commit.interval.ms": "5000",
-      "enable.auto.offset.store": true
+      "enable.auto.offset.store": false
     }
   },
   "OLAP": {

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/KafkaConfigTests.DefaultProducerConsumerConfig.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/KafkaConfigTests.DefaultProducerConsumerConfig.verified.txt
@@ -28,7 +28,7 @@
     },
     {
       Key: enable.auto.offset.store,
-      Value: True
+      Value: False
     },
     {
       Key: group.id,

--- a/modules/evaluation-server/src/Api/appsettings.Development.json
+++ b/modules/evaluation-server/src/Api/appsettings.Development.json
@@ -15,7 +15,7 @@
       "auto.offset.reset": "latest",
       "enable.auto.commit": true,
       "auto.commit.interval.ms": "5000",
-      "enable.auto.offset.store": true
+      "enable.auto.offset.store": false
     }
   },
   "MongoDb": {

--- a/modules/evaluation-server/src/Api/appsettings.json
+++ b/modules/evaluation-server/src/Api/appsettings.json
@@ -15,7 +15,7 @@
       "auto.offset.reset": "latest",
       "enable.auto.commit": true,
       "auto.commit.interval.ms": "5000",
-      "enable.auto.offset.store": true
+      "enable.auto.offset.store": false
     }
   },
   "MongoDb": {


### PR DESCRIPTION
Since we store offset manually

https://github.com/featbit/featbit/blob/95c0b568b9f67cc1a417a0b5caf6a757c13ecb13/modules/back-end/src/Infrastructure/Kafka/KafkaMessageConsumer.cs#L89-L104

https://github.com/featbit/featbit/blob/95c0b568b9f67cc1a417a0b5caf6a757c13ecb13/modules/evaluation-server/src/Infrastructure/Kafka/KafkaMessageConsumer.cs#L86-L100

Enable auto offset store will cause the following exception

```json
{
   "@t":"2023-11-10T06:02:36.8948936Z",
   "@mt":"Exception occurred when store offset.",
   "@l":"Error",
   "@x":"Confluent.Kafka.KafkaException: Local: Invalid argument or configuration\n   at Confluent.Kafka.Impl.SafeKafkaHandle.StoreOffsets(IEnumerable`1 offsets)\n   at Confluent.Kafka.Consumer`2.StoreOffset(TopicPartitionOffset offset)\n   at Confluent.Kafka.Consumer`2.StoreOffset(ConsumeResult`2 result)\n   at Infrastructure.Kafka.KafkaMessageConsumer.StartConsumerLoop(CancellationToken cancellationToken) in /source/src/Infrastructure/Kafka/KafkaMessageConsumer.cs:line 93",
   "EventId":{
      "Id":4,
      "Name":"ErrorStoreOffset"
   },
   "SourceContext":"Infrastructure.Kafka.KafkaMessageConsumer"
}
```

To solve this issue without modifying the code, users need to set the environment variable `Kafka_Consumer_enable.auto.offset.store` to `false` for both the Api and Evaluation Server services.

This bug was introduced by #503 in v2.5.1




