### PR TITLE
🧹refactor(front-end): add allowedCommonJsDependencies to angular.json

### DIFF
--- a/modules/front-end/angular.json
+++ b/modules/front-end/angular.json
@@ -55,7 +55,11 @@
                 "src/"
               ]
             },
-            "scripts": []
+            "scripts": [],
+            "allowedCommonJsDependencies": [
+              "prismjs",
+              "moment"
+            ]
           },
           "configurations": {
             "production": {
@@ -86,7 +90,9 @@
               "extractLicenses": false,
               "sourceMap": true,
               "namedChunks": true,
-              "localize": ["en"]
+              "localize": [
+                "en"
+              ]
             },
             "zh": {
               "buildOptimizer": false,
@@ -95,7 +101,9 @@
               "extractLicenses": false,
               "sourceMap": true,
               "namedChunks": true,
-              "localize": ["zh"],
+              "localize": [
+                "zh"
+              ],
               "styles": [
                 "src/styles-zh.less"
               ]


### PR DESCRIPTION
The following PR aims to remove the annoying allowed common js dependencies warning (#370)