### PR TITLE
🐛 fix: trigger didn't update flag correctly

### DIFF
--- a/modules/back-end/src/Application/AuditLogs/GetAuditLogList.cs
+++ b/modules/back-end/src/Application/AuditLogs/GetAuditLogList.cs
@@ -54,7 +54,7 @@ public class GetAuditLogListHandler : IRequestHandler<GetAuditLogList, PagedResu
             }
 
             // An audit log may also be created by an access token
-            var accessToken = await _accessTokenService.GetAsync(item.CreatorId);
+            var accessToken = await _accessTokenService.FindOneAsync(x => x.Id == item.CreatorId);
             if (accessToken != null)
             {
                 item.CreatorName = accessToken.Name;
@@ -62,11 +62,8 @@ public class GetAuditLogListHandler : IRequestHandler<GetAuditLogList, PagedResu
                 continue;
             }
 
-            // If the creator id is empty, it means that the audit log is created by the system
-            if (item.CreatorId == Guid.Empty)
-            {
-                item.CreatorName = "System";
-            }
+            // Otherwise this audit log is created by system user
+            item.CreatorEmail = "System";
         }
 
         return logVms;

--- a/modules/back-end/src/Application/Triggers/RunTrigger.cs
+++ b/modules/back-end/src/Application/Triggers/RunTrigger.cs
@@ -3,6 +3,7 @@ using Application.Bases.Exceptions;
 using Application.FeatureFlags;
 using Domain.AuditLogs;
 using Domain.Triggers;
+using Domain.Users;
 
 namespace Application.Triggers;
 
@@ -57,7 +58,7 @@ public class RunTriggerHandler : IRequestHandler<RunTrigger, bool>
             // publish on feature flag change notification
             var comment = trigger.Action == TriggerActions.TurnOff ? "Turn off by trigger" : "Turn on by trigger";
             var notification =
-                new OnFeatureFlagChanged(flag, Operations.Update, dataChange, Guid.Empty, comment);
+                new OnFeatureFlagChanged(flag, Operations.Update, dataChange, SystemUser.Id, comment);
             await _publisher.Publish(notification, cancellationToken);
         }
 

--- a/modules/back-end/src/Domain/Triggers/Trigger.cs
+++ b/modules/back-end/src/Domain/Triggers/Trigger.cs
@@ -2,6 +2,7 @@
 
 using Domain.AuditLogs;
 using Domain.FeatureFlags;
+using Domain.Users;
 
 namespace Domain.Triggers;
 
@@ -72,14 +73,7 @@ public class Trigger : AuditedEntity
         }
 
         var dataChange = new DataChange(featureFlag);
-
-        featureFlag.IsEnabled = Action switch
-        {
-            TriggerActions.TurnOff => false,
-            TriggerActions.TurnOn => true,
-            _ => featureFlag.IsEnabled
-        };
-        featureFlag.Revision = Guid.NewGuid();
+        featureFlag.Toggle(SystemUser.Id);
 
         TriggeredTimes++;
         LastTriggeredAt = DateTime.UtcNow;

--- a/modules/back-end/src/Domain/Users/SystemUser.cs
+++ b/modules/back-end/src/Domain/Users/SystemUser.cs
@@ -1,0 +1,6 @@
+namespace Domain.Users;
+
+public static class SystemUser
+{
+    public static readonly Guid Id = Guid.Empty;
+}


### PR DESCRIPTION
We need to update the `updatedAt` field when trigger runs, otherwise our SDK will not accept the flag change since they have the same update timestamp.