### PR TITLE
🏗 infra: refactor publish-docker-images.yml

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -40,17 +40,24 @@ jobs:
       - name: Dump GitHub context
         run: echo "${{ toJson(github) }}"
 
-      - name: Set Dockerfile Subdirectory
-        id: set-dockerfile-subdirectory
+      - name: Set Dockerfile Context
+        id: set-dockerfile-context
         run: |
           declare -A app_subdir_map
           app_subdir_map=(
-            ["featbit-api-server"]="modules/back-end/deploy"
+            ["featbit-api-server"]="modules/back-end"
             ["featbit-data-analytics-server"]="modules/data-analytics"
-            ["featbit-evaluation-server"]="modules/evaluation-server/deploy"
-            ["featbit-ui"]="modules/frontend"
+            ["featbit-evaluation-server"]="modules/evaluation-server"
+            ["featbit-ui"]="modules/front-end"
+          )
+          app_file_map=(
+            ["featbit-api-server"]="./deploy/Dockerfile"
+            ["featbit-evaluation-server"]="./deploy/Dockerfile"
+            ["featbit-data-analytics-server"]="Dockerfile"
+            ["featbit-ui"]="Dockerfile"
           )
           echo "subdirectory=${app_subdir_map[${{ matrix.app }}]}" >> $GITHUB_OUTPUT
+          echo "file=${app_file_map[${{ matrix.app }}]}" >> $GITHUB_OUTPUT
 
       - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
         uses: docker/build-push-action@v5
@@ -67,8 +74,8 @@ jobs:
         if: github.event.inputs.build-latest
         uses: docker/build-push-action@v3
         with:
-          context: "{{defaultContext}}:${{ steps.set-dockerfile-subdirectory.outputs.subdirectory }}"
-          file: ./Dockerfile
+          context: "{{defaultContext}}:${{ steps.set-dockerfile-context.outputs.subdir }}"
+          file: ${{ steps.set-dockerfile-context.outputs.file }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.LATEST_TAG }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -56,7 +56,7 @@ jobs:
         run: echo "Always run"
 
       - name: Conditional (run only if build-latest is true)
-        if: github.event.inputs.build-latest
+        if: ${{ github.event.inputs.build-latest == 'true' }}
         run: echo "Run only if build-latest is true"
 
 #      - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -43,16 +43,17 @@ jobs:
       - name: Set Dockerfile Path
         id: set-dockerfile-path
         run: |
+          ls -la
           if [[ "${{ matrix.app }}" == "featbit-ui" || "${{ matrix.app }}" == "featbit-data-analytics-server" ]]; then
-            echo "::set-output name=path::./Dockerfile"
+            echo "path::./Dockerfile" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=path::./deploy/Dockerfile"
+            echo "path::./deploy/Dockerfile" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push - ${{ matrix.app }} (current)
         uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:modules/${{ matrix.app }}"
+          context: "./modules/${{ matrix.app }}"
           file: ${{ steps.set-dockerfile-path.outputs.path }}
           platforms: linux/amd64,linux/arm64
           push: true
@@ -64,7 +65,7 @@ jobs:
         if: github.event.inputs.build-latest
         uses: docker/build-push-action@v3
         with:
-          context: "{{defaultContext}}:modules/${{ matrix.app }}"
+          context: "./modules/${{ matrix.app }}"
           file: ${{ steps.set-dockerfile-path.outputs.path }}
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build and push - ${{ matrix.app }} (${{ env.LATEST_TAG }})
         if: github.event.inputs.build-latest
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: "{{defaultContext}}:${{ steps.set-dockerfile-context.outputs.subdir }}"
           file: ${{ steps.set-dockerfile-context.outputs.file }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -11,6 +11,11 @@ on:
         type: boolean
         default: false
         required: false
+      debug:
+        description: "Debug mode"
+        type: boolean
+        default: false
+        required: false
 
 env:
   LATEST_TAG: latest
@@ -50,16 +55,31 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Dump GitHub context
+        if: ${{ github.event.inputs.debug == 'true' }}
         run: echo "${{ toJson(github) }}"
 
       - name: Normal (always run)
+        if: ${{ github.event.inputs.debug == 'true' }}
         run: echo "Always run"
 
       - name: Conditional (run only if build-latest is true)
-        if: ${{ github.event.inputs.build-latest == 'true' }}
+        if: ${{ github.event.inputs.debug == 'true' && github.event.inputs.build-latest == 'true' }}
         run: echo "Run only if build-latest is true"
 
-#      - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
+      - name: Echo build parameters
+        if: ${{ github.event.inputs.debug == 'true' }}
+        run: |
+          echo "Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})"
+          echo "Context: ${{ github.workspace }}:${{ matrix.build-dir }}"
+          echo "File: ${{ matrix.file }}"
+          echo "Platforms: linux/amd64,linux/arm64"
+          echo "Push: true"
+          echo "Tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}"
+          echo "Cache-from: type=gha"
+          echo "Cache-to: type=gha,mode=max"
+
+      - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
+        run: echo "Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})"
 #        uses: docker/build-push-action@v5
 #        with:
 #          context: "{{defaultContext}}:${{ matrix.build-dir }}"
@@ -69,9 +89,10 @@ jobs:
 #          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}
 #          cache-from: type=gha
 #          cache-to: type=gha,mode=max
-#
-#      - name: Build and push - ${{ matrix.app }} (${{ env.LATEST_TAG }})
-#        if: github.event.inputs.build-latest
+
+      - name: Build and push - ${{ matrix.app }} (${{ env.LATEST_TAG }})
+        if: ${{ github.event.inputs.build-latest == 'true' }}
+        run: echo "Build and push - ${{ matrix.app }} (${{ env.LATEST_TAG }})"
 #        uses: docker/build-push-action@v5
 #        with:
 #          context: "{{defaultContext}}:${{ matrix.build-dir }}"

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set Dockerfile Path
         id: set-dockerfile-path
         run: |
-          if [[ "${{ matrix.app }}" == "featbit-ui" || "${{ featbit-data-analytics-server }}" == "APP_DA" ]]; then
+          if [[ "${{ matrix.app }}" == "featbit-ui" || "${{ matrix.app }}" == "featbit-data-analytics-server" ]]; then
             echo "::set-output name=path::./Dockerfile"
           else
             echo "::set-output name=path::./deploy/Dockerfile"

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -55,7 +55,8 @@ jobs:
       - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
         uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:modules/${{ steps.set-dockerfile-subdirectory.outputs.subdirectory }}"
+          context: "{{defaultContext}}:${{ steps.set-dockerfile-subdirectory.outputs.subdirectory }}"
+          file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}
@@ -67,6 +68,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}:${{ steps.set-dockerfile-subdirectory.outputs.subdirectory }}"
+          file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.LATEST_TAG }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -45,9 +45,9 @@ jobs:
         run: |
           ls -la
           if [[ "${{ matrix.app }}" == "featbit-ui" || "${{ matrix.app }}" == "featbit-data-analytics-server" ]]; then
-            echo "path::./Dockerfile" >> $GITHUB_OUTPUT
+            echo "path=./Dockerfile" >> $GITHUB_OUTPUT
           else
-            echo "path::./deploy/Dockerfile" >> $GITHUB_OUTPUT
+            echo "path=./deploy/Dockerfile" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push - ${{ matrix.app }} (current)

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Set Dockerfile Context
         id: set-dockerfile-context
         run: |
-          declare -A app_subdir_map
-          app_subdir_map=(
+          declare -A app_build_dir_map
+          app_build_dir_map=(
             ["featbit-api-server"]="modules/back-end"
             ["featbit-data-analytics-server"]="modules/data-analytics"
             ["featbit-evaluation-server"]="modules/evaluation-server"
@@ -56,13 +56,13 @@ jobs:
             ["featbit-data-analytics-server"]="Dockerfile"
             ["featbit-ui"]="Dockerfile"
           )
-          echo "subdirectory=${app_subdir_map[${{ matrix.app }}]}" >> $GITHUB_OUTPUT
+          echo "build_dir=${app_build_dir_map[${{ matrix.app }}]}" >> $GITHUB_OUTPUT
           echo "file=${app_file_map[${{ matrix.app }}]}" >> $GITHUB_OUTPUT
 
       - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
         uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:${{ steps.set-dockerfile-context.outputs.subdir }}"
+          context: "{{defaultContext}}:${{ steps.set-dockerfile-context.outputs.build_dir }}"
           file: ${{ steps.set-dockerfile-context.outputs.file }}
           platforms: linux/amd64,linux/arm64
           push: true
@@ -74,7 +74,7 @@ jobs:
         if: github.event.inputs.build-latest
         uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:${{ steps.set-dockerfile-context.outputs.subdir }}"
+          context: "{{defaultContext}}:${{ steps.set-dockerfile-context.outputs.build_dir }}"
           file: ${{ steps.set-dockerfile-context.outputs.file }}
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
         uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:${{ steps.set-dockerfile-subdirectory.outputs.subdirectory }}"
-          file: ./Dockerfile
+          context: "{{defaultContext}}:${{ steps.set-dockerfile-context.outputs.subdir }}"
+          file: ${{ steps.set-dockerfile-context.outputs.file }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -42,6 +42,18 @@ jobs:
             build-dir: modules/evaluation-server
             file: ./deploy/Dockerfile
     steps:
+      - name: Dump GitHub context (run if debug is true)
+        if: ${{ github.event.inputs.debug == 'true' }}
+        run: echo "${{ toJson(github) }}"
+
+      - name: Normal (run if debug is true)
+        if: ${{ github.event.inputs.debug == 'true' }}
+        run: echo "debug is true"
+
+      - name: Conditional (run if debug and build-latest is true)
+        if: ${{ github.event.inputs.debug == 'true' && github.event.inputs.build-latest == 'true' }}
+        run: echo "debug and build-latest is true"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -53,30 +65,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Dump GitHub context
-        if: ${{ github.event.inputs.debug == 'true' }}
-        run: echo "${{ toJson(github) }}"
-
-      - name: Normal (always run)
-        if: ${{ github.event.inputs.debug == 'true' }}
-        run: echo "Always run"
-
-      - name: Conditional (run only if build-latest is true)
-        if: ${{ github.event.inputs.debug == 'true' && github.event.inputs.build-latest == 'true' }}
-        run: echo "Run only if build-latest is true"
-
-      - name: Echo build parameters
-        if: ${{ github.event.inputs.debug == 'true' }}
-        run: |
-          echo "Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})"
-          echo "Context: ${{ github.workspace }}:${{ matrix.build-dir }}"
-          echo "File: ${{ matrix.file }}"
-          echo "Platforms: linux/amd64,linux/arm64"
-          echo "Push: true"
-          echo "Tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}"
-          echo "Cache-from: type=gha"
-          echo "Cache-to: type=gha,mode=max"
 
       - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,40 +1,39 @@
-# Build and publish docker images for the following services:
-# UI
-# API Server
-# Data Analytics Server
-# Evaluation Server
-
 name: Publish Docker Images
 
 on:
-  release:
-    types: [ created ]
   workflow_dispatch:
     inputs:
       version:
         description: "Dockerhub image version (For example: 1.0.0)"
         required: true
+      build-latest:
+        description: "Build and publish the latest image?"
+        type: boolean
+        default: false
+        required: false
 
 env:
   LATEST_TAG: latest
   VERSION_TAG: ${{ github.event.inputs.version || github.ref_name }}
-  APP_UI: featbit-ui
-  APP_API: featbit-api-server
-  APP_DA: featbit-data-analytics-server
-  APP_EVAL: featbit-evaluation-server
+  APPS: |
+    APP_UI: featbit-ui
+    APP_API: featbit-api-server
+    APP_DA: featbit-data-analytics-server
+    APP_EVAL: featbit-evaluation-server
 
 jobs:
   build-publish:
-    name: build and publish image to docker hub
+    name: Build and publish image to Docker Hub
     runs-on: ubuntu-latest
     environment: Production
+    strategy:
+      matrix:
+        app: [${APPS}]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - # Add support for more platforms with QEMU
-        # https://github.com/docker/setup-qemu-action
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
@@ -47,98 +46,27 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+        run: echo "${{ toJson(github) }}"
 
-      - name: Build and push - UI (current)
+      - name: Build and push - ${{ matrix.app }} (current)
         uses: docker/build-push-action@v3
         with:
-          context: "{{defaultContext}}:modules/front-end"
+          context: "{{defaultContext}}:modules/${{ matrix.app }}"
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.APP_UI }}:${{ env.VERSION_TAG }}
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and push - UI (latest)
-        if: github.ref == 'refs/heads/main'
+      - name: Build and push - ${{ matrix.app }} (latest)
+        if: github.event.inputs.build-latest
         uses: docker/build-push-action@v3
         with:
-          context: "{{defaultContext}}:modules/front-end"
+          context: "{{defaultContext}}:modules/${{ matrix.app }}"
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.APP_UI }}:${{ env.LATEST_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push - API-Server (current)
-        uses: docker/build-push-action@v3
-        with:
-          context: "{{defaultContext}}:modules/back-end"
-          file: ./deploy/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.APP_API }}:${{ env.VERSION_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push - API-Server (latest)
-        if: github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v3
-        with:
-          context: "{{defaultContext}}:modules/back-end"
-          file: ./deploy/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.APP_API }}:${{ env.LATEST_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push - Data-Analytics-Server (current)
-        uses: docker/build-push-action@v3
-        with:
-          context: "{{defaultContext}}:modules/data-analytics"
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.APP_DA }}:${{ env.VERSION_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push - Data-Analytics-Server (latest)
-        if: github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v3
-        with:
-          context: "{{defaultContext}}:modules/data-analytics"
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.APP_DA }}:${{ env.LATEST_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push - Evaluation-Server (current)
-        uses: docker/build-push-action@v3
-        with:
-          context: "{{defaultContext}}:modules/evaluation-server"
-          file: ./deploy/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.APP_EVAL }}:${{ env.VERSION_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push - Evaluation-Server (latest)
-        if: github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v3
-        with:
-          context: "{{defaultContext}}:modules/evaluation-server"
-          file: ./deploy/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.APP_EVAL }}:${{ env.LATEST_TAG }}
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.LATEST_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -23,7 +23,19 @@ jobs:
     environment: Production
     strategy:
       matrix:
-        app: [featbit-ui, featbit-api-server, featbit-data-analytics-server, featbit-evaluation-server]
+        include:
+          - app: featbit-ui
+            build-dir: modules/front-end
+            file: ./Dockerfile
+          - app: featbit-api-server
+            build-dir: modules/back-end
+            file: ./deploy/Dockerfile
+          - app: featbit-data-analytics-server
+            build-dir: modules/data-analytics
+            file: ./Dockerfile
+          - app: featbit-evaluation-server
+            build-dir: modules/evaluation-server
+            file: ./deploy/Dockerfile
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -40,30 +52,11 @@ jobs:
       - name: Dump GitHub context
         run: echo "${{ toJson(github) }}"
 
-      - name: Set Dockerfile Context
-        id: set-dockerfile-context
-        run: |
-          declare -A app_build_dir_map
-          app_build_dir_map=(
-            ["featbit-api-server"]="modules/back-end"
-            ["featbit-data-analytics-server"]="modules/data-analytics"
-            ["featbit-evaluation-server"]="modules/evaluation-server"
-            ["featbit-ui"]="modules/front-end"
-          )
-          app_file_map=(
-            ["featbit-api-server"]="./deploy/Dockerfile"
-            ["featbit-evaluation-server"]="./deploy/Dockerfile"
-            ["featbit-data-analytics-server"]="Dockerfile"
-            ["featbit-ui"]="Dockerfile"
-          )
-          echo "build_dir=${app_build_dir_map[${{ matrix.app }}]}" >> $GITHUB_OUTPUT
-          echo "file=${app_file_map[${{ matrix.app }}]}" >> $GITHUB_OUTPUT
-
       - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
         uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:${{ steps.set-dockerfile-context.outputs.build_dir }}"
-          file: ${{ steps.set-dockerfile-context.outputs.file }}
+          context: "{{defaultContext}}:${{ matrix.build-dir }}"
+          file: ${{ matrix.file }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}
@@ -74,8 +67,8 @@ jobs:
         if: github.event.inputs.build-latest
         uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:${{ steps.set-dockerfile-context.outputs.build_dir }}"
-          file: ${{ steps.set-dockerfile-context.outputs.file }}
+          context: "{{defaultContext}}:${{ matrix.build-dir }}"
+          file: ${{ matrix.file }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.LATEST_TAG }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -40,17 +40,19 @@ jobs:
       - name: Dump GitHub context
         run: echo "${{ toJson(github) }}"
 
-      - name: Set Dockerfile Path
-        id: set-dockerfile-path
+      - name: Set Dockerfile Subdirectory
+        id: set-dockerfile-subdirectory
         run: |
-          ls -la
-          if [[ "${{ matrix.app }}" == "featbit-ui" || "${{ matrix.app }}" == "featbit-data-analytics-server" ]]; then
-            echo "path=./Dockerfile" >> $GITHUB_OUTPUT
-          else
-            echo "path=./deploy/Dockerfile" >> $GITHUB_OUTPUT
-          fi
+          declare -A app_subdir_map
+          app_subdir_map=(
+            ["featbit-api-server"]="modules/back-end/deploy"
+            ["featbit-data-analytics-server"]="modules/data-analytics"
+            ["featbit-evaluation-server"]="modules/evaluation-server/deploy"
+            ["featbit-ui"]="modules/frontend/Dockerfile"
+          )
+          echo "subdirectory=${app_subdir_map[${{ matrix.app }}]}"
 
-      - name: Build and push - ${{ matrix.app }} (current)
+      - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
         uses: docker/build-push-action@v5
         with:
           context: "{{defaultContext}}:modules/${{ matrix.app }}"
@@ -61,12 +63,11 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and push - ${{ matrix.app }} (latest)
+      - name: Build and push - ${{ matrix.app }} (${{ env.LATEST_TAG }})
         if: github.event.inputs.build-latest
         uses: docker/build-push-action@v3
         with:
-          context: "{{defaultContext}}:modules/${{ matrix.app }}"
-          file: ${{ steps.set-dockerfile-path.outputs.path }}
+          context: "{{defaultContext}}:${{ steps.set-dockerfile-subdirectory.outputs.subdirectory }}"
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.LATEST_TAG }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -79,26 +79,24 @@ jobs:
           echo "Cache-to: type=gha,mode=max"
 
       - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
-        run: echo "Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})"
-#        uses: docker/build-push-action@v5
-#        with:
-#          context: "{{defaultContext}}:${{ matrix.build-dir }}"
-#          file: ${{ matrix.file }}
-#          platforms: linux/amd64,linux/arm64
-#          push: true
-#          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}:${{ matrix.build-dir }}"
+          file: ${{ matrix.file }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and push - ${{ matrix.app }} (${{ env.LATEST_TAG }})
         if: ${{ github.event.inputs.build-latest == 'true' }}
-        run: echo "Build and push - ${{ matrix.app }} (${{ env.LATEST_TAG }})"
-#        uses: docker/build-push-action@v5
-#        with:
-#          context: "{{defaultContext}}:${{ matrix.build-dir }}"
-#          file: ${{ matrix.file }}
-#          platforms: linux/amd64,linux/arm64
-#          push: true
-#          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.LATEST_TAG }}
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}:${{ matrix.build-dir }}"
+          file: ${{ matrix.file }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.LATEST_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build and push - ${{ matrix.app }} (current)
         uses: docker/build-push-action@v5
         with:
-          context: "./modules/${{ matrix.app }}"
+          context: "{{defaultContext}}:modules/${{ matrix.app }}"
           file: ${{ steps.set-dockerfile-path.outputs.path }}
           platforms: linux/amd64,linux/arm64
           push: true
@@ -65,7 +65,7 @@ jobs:
         if: github.event.inputs.build-latest
         uses: docker/build-push-action@v3
         with:
-          context: "./modules/${{ matrix.app }}"
+          context: "{{defaultContext}}:modules/${{ matrix.app }}"
           file: ${{ steps.set-dockerfile-path.outputs.path }}
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -25,17 +25,14 @@ jobs:
       matrix:
         app: [featbit-ui, featbit-api-server, featbit-data-analytics-server, featbit-evaluation-server]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-actio@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -53,9 +50,9 @@ jobs:
           fi
 
       - name: Build and push - ${{ matrix.app }} (current)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:modules/${{ matrix.app }}"
+          context: "./modules/${{ matrix.app }}"
           file: ${{ steps.set-dockerfile-path.outputs.path }}
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -50,7 +50,7 @@ jobs:
             ["featbit-evaluation-server"]="modules/evaluation-server/deploy"
             ["featbit-ui"]="modules/frontend"
           )
-          echo "subdirectory=${app_subdir_map[${{ matrix.app }}]}"
+          echo "subdirectory=${app_subdir_map[${{ matrix.app }}]}" >> $GITHUB_OUTPUT
 
       - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Dockerhub image version (For example: 1.0.0)"
+        description: "Image version (For example: 1.0.0)"
         required: true
       build-latest:
         description: "Build and publish latest image"
@@ -52,25 +52,32 @@ jobs:
       - name: Dump GitHub context
         run: echo "${{ toJson(github) }}"
 
-      - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
-        uses: docker/build-push-action@v5
-        with:
-          context: "{{defaultContext}}:${{ matrix.build-dir }}"
-          file: ${{ matrix.file }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Normal (always run)
+        run: echo "Always run"
 
-      - name: Build and push - ${{ matrix.app }} (${{ env.LATEST_TAG }})
+      - name: Conditional (run only if build-latest is true)
         if: github.event.inputs.build-latest
-        uses: docker/build-push-action@v5
-        with:
-          context: "{{defaultContext}}:${{ matrix.build-dir }}"
-          file: ${{ matrix.file }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.LATEST_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        run: echo "Run only if build-latest is true"
+
+#      - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
+#        uses: docker/build-push-action@v5
+#        with:
+#          context: "{{defaultContext}}:${{ matrix.build-dir }}"
+#          file: ${{ matrix.file }}
+#          platforms: linux/amd64,linux/arm64
+#          push: true
+#          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max
+#
+#      - name: Build and push - ${{ matrix.app }} (${{ env.LATEST_TAG }})
+#        if: github.event.inputs.build-latest
+#        uses: docker/build-push-action@v5
+#        with:
+#          context: "{{defaultContext}}:${{ matrix.build-dir }}"
+#          file: ${{ matrix.file }}
+#          platforms: linux/amd64,linux/arm64
+#          push: true
+#          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.LATEST_TAG }}
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -14,12 +14,7 @@ on:
 
 env:
   LATEST_TAG: latest
-  VERSION_TAG: ${{ github.event.inputs.version || github.ref_name }}
-  APPS: |
-    APP_UI: featbit-ui
-    APP_API: featbit-api-server
-    APP_DA: featbit-data-analytics-server
-    APP_EVAL: featbit-evaluation-server
+  VERSION_TAG: ${{ github.event.inputs.version }}
 
 jobs:
   build-publish:
@@ -28,7 +23,7 @@ jobs:
     environment: Production
     strategy:
       matrix:
-        app: [${APPS}]
+        app: [featbit-ui, featbit-api-server, featbit-data-analytics-server, featbit-evaluation-server]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -48,11 +43,20 @@ jobs:
       - name: Dump GitHub context
         run: echo "${{ toJson(github) }}"
 
+      - name: Set Dockerfile Path
+        id: set-dockerfile-path
+        run: |
+          if [[ "${{ matrix.app }}" == "featbit-ui" || "${{ featbit-data-analytics-server }}" == "APP_DA" ]]; then
+            echo "::set-output name=path::./Dockerfile"
+          else
+            echo "::set-output name=path::./deploy/Dockerfile"
+          fi
+
       - name: Build and push - ${{ matrix.app }} (current)
         uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}:modules/${{ matrix.app }}"
-          file: ./Dockerfile
+          file: ${{ steps.set-dockerfile-path.outputs.path }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}
@@ -64,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}:modules/${{ matrix.app }}"
-          file: ./Dockerfile
+          file: ${{ steps.set-dockerfile-path.outputs.path }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.LATEST_TAG }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -7,7 +7,7 @@ on:
         description: "Dockerhub image version (For example: 1.0.0)"
         required: true
       build-latest:
-        description: "Build and publish the latest image?"
+        description: "Build and publish latest image"
         type: boolean
         default: false
         required: false

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-actio@v3
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -52,7 +52,7 @@ jobs:
       - name: Build and push - ${{ matrix.app }} (current)
         uses: docker/build-push-action@v5
         with:
-          context: "./modules/${{ matrix.app }}"
+          context: "{{defaultContext}}:modules/${{ matrix.app }}"
           file: ${{ steps.set-dockerfile-path.outputs.path }}
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -48,15 +48,14 @@ jobs:
             ["featbit-api-server"]="modules/back-end/deploy"
             ["featbit-data-analytics-server"]="modules/data-analytics"
             ["featbit-evaluation-server"]="modules/evaluation-server/deploy"
-            ["featbit-ui"]="modules/frontend/Dockerfile"
+            ["featbit-ui"]="modules/frontend"
           )
           echo "subdirectory=${app_subdir_map[${{ matrix.app }}]}"
 
       - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
         uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:modules/${{ matrix.app }}"
-          file: ${{ steps.set-dockerfile-path.outputs.path }}
+          context: "{{defaultContext}}:modules/${{ steps.set-dockerfile-subdirectory.outputs.subdirectory }}"
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.app }}:${{ env.VERSION_TAG }}


### PR DESCRIPTION
This PR

- Always run publish image GitHub Action manually since we need to decide whether to publish latest image
- Make publish-docker-image.yml simpler
- Improving the workflow speed; previously taking 45 minutes, the process now completes in just 22 minutes.

Refer [this](https://github.com/featbit/featbit/actions/runs/7043363396) to check out an example run. Additionally, compare the performance with a previous run (v3.0.0) [here](https://github.com/featbit/featbit/actions/runs/6906276351).