### PR TITLE
Remove rule exposing redis ports to the host when running in docker.

### DIFF
--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -92,8 +92,6 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
     networks:
       - featbit-network
-    ports:
-      - "6379:6379"
     volumes:
       - redis:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,8 +83,6 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
     networks:
       - featbit-network
-    ports:
-      - "6379:6379"
     volumes:
       - redis:/data
 


### PR DESCRIPTION
This PR removes the rule/config in the docker compose files that exposes the redis port to the host. This isn't required due to the redis image automatically exposing the port to the other containers in its network. Exposing them to the host is a security issue and also seemed to cause log spam like below:

```
redis-1              | 132103:C 17 Feb 2024 16:25:41.039 # Failed opening the RDB file crontab (in server root dir /etc) for saving: Permission denied
redis-1              | 1:M 17 Feb 2024 16:25:41.139 # Background saving error
redis-1              | 1:M 17 Feb 2024 16:25:47.060 * 1 changes in 3600 seconds. Saving...
redis-1              | 1:M 17 Feb 2024 16:25:47.061 * Background saving started by pid 132104
redis-1              | 132104:C 17 Feb 2024 16:25:47.061 # Failed opening the RDB file crontab (in server root dir /etc) for saving: Permission denied
redis-1              | 1:M 17 Feb 2024 16:25:47.161 # Background saving error
redis-1              | 1:M 17 Feb 2024 16:25:53.079 * 1 changes in 3600 seconds. Saving...
redis-1              | 1:M 17 Feb 2024 16:25:53.079 * Background saving started by pid 132105
redis-1              | 132105:C 17 Feb 2024 16:25:53.079 # Failed opening the RDB file crontab (in server root dir /etc) for saving: Permission denied
```

You can see this ticket here which explains that this is caused by exposing the ports. - https://github.com/docker-library/redis/issues/314#issuecomment-1116336682