### PR TITLE
✨ Add ClientHost, ClientIP, EnvId to eval server logs

### DIFF
--- a/modules/evaluation-server/src/Streaming/Connections/Connection.cs
+++ b/modules/evaluation-server/src/Streaming/Connections/Connection.cs
@@ -19,6 +19,10 @@ public class Connection
     /// </summary>
     public EndUser? User { get; set; }
 
+    public string ClientIpAddress { get; }
+    
+    public string ClientHost { get; }
+    
     public string Type { get; }
 
     public string Version { get; }
@@ -33,7 +37,9 @@ public class Connection
         string type,
         string version,
         long? connectAt = null,
-        long? closeAt = null)
+        long? closeAt = null,
+        string clientIpAddress = "",
+        string clientHost = "")
     {
         Id = Guid.NewGuid().ToString("D");
 
@@ -43,6 +49,8 @@ public class Connection
         Version = version;
         ConnectAt = connectAt ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         CloseAt = closeAt ?? 0;
+        ClientIpAddress = clientIpAddress;
+        ClientHost = clientHost;
     }
 
     public async Task SendAsync(Message message, CancellationToken cancellationToken)

--- a/modules/evaluation-server/src/Streaming/Connections/ConnectionHandler.Log.cs
+++ b/modules/evaluation-server/src/Streaming/Connections/ConnectionHandler.Log.cs
@@ -6,25 +6,25 @@ public partial class ConnectionHandler
 {
     public static partial class Log
     {
-        [LoggerMessage(1, LogLevel.Error, "{ConnectionId}: exception occurred when process message. {Error}", EventName = "ErrorProcessMessage")]
-        public static partial void ErrorProcessMessage(ILogger logger, string connectionId, string error);
+        [LoggerMessage(1, LogLevel.Error, "{ConnectionId}: exception occurred when process message. {Error} [EnvId: {EnvId}, ClientIP: {ClientIP}, ClientHost: {ClientHost}]", EventName = "ErrorProcessMessage")]
+        public static partial void ErrorProcessMessage(ILogger logger, string connectionId, string error, Guid envId, string clientIp, string clientHost);
         
-        [LoggerMessage(2, LogLevel.Trace, "{ConnectionId}: receive empty message", EventName = "ReceiveEmptyMessage")]
-        public static partial void ReceiveEmptyMessage(ILogger logger, string connectionId);
+        [LoggerMessage(2, LogLevel.Trace, "{ConnectionId}: receive empty message [EnvId: {EnvId}, ClientIP: {ClientIP}, ClientHost: {ClientHost}]", EventName = "ReceiveEmptyMessage")]
+        public static partial void ReceiveEmptyMessage(ILogger logger, string connectionId, Guid envId, string clientIp, string clientHost);
 
-        [LoggerMessage(3, LogLevel.Trace, "{ConnectionId}: receive close message", EventName = "ReceiveCloseMessage")]
-        public static partial void ReceiveCloseMessage(ILogger logger, string connectionId);
+        [LoggerMessage(3, LogLevel.Trace, "{ConnectionId}: receive close message [EnvId: {EnvId}, ClientIP: {ClientIP}, ClientHost: {ClientHost}]", EventName = "ReceiveCloseMessage")]
+        public static partial void ReceiveCloseMessage(ILogger logger, string connectionId, Guid envId, string clientIp, string clientHost);
         
-        [LoggerMessage(4, LogLevel.Warning, "{ConnectionId}: error occurred while read message. {Error}", EventName = "ErrorReadMessage")]
-        public static partial void ErrorReadMessage(ILogger logger, string connectionId, string error);
+        [LoggerMessage(4, LogLevel.Warning, "{ConnectionId}: error occurred while read message. {Error} [EnvId: {EnvId}, ClientIP: {ClientIP}, ClientHost: {ClientHost}]", EventName = "ErrorReadMessage")]
+        public static partial void ErrorReadMessage(ILogger logger, string connectionId, string error, Guid envId, string clientIp, string clientHost);
         
-        [LoggerMessage(5, LogLevel.Warning, "{ConnectionId}: receive invalid message.", EventName = "ReceiveInvalidMessage")]
-        public static partial void ReceiveInvalidMessage(ILogger logger, string connectionId, Exception exception);
+        [LoggerMessage(5, LogLevel.Warning, "{ConnectionId}: receive invalid message. [EnvId: {EnvId}, ClientIP: {ClientIP}, ClientHost: {ClientHost}]", EventName = "ReceiveInvalidMessage")]
+        public static partial void ReceiveInvalidMessage(ILogger logger, string connectionId, Guid envId, string clientIp, string clientHost, Exception exception);
 
-        [LoggerMessage(6, LogLevel.Error, "{ConnectionId}: failed handle message.", EventName = "ErrorHandleMessage")]
-        public static partial void ErrorHandleMessage(ILogger logger, string connectionId, Exception exception);
+        [LoggerMessage(6, LogLevel.Error, "{ConnectionId}: failed handle message. [EnvId: {EnvId}, ClientIP: {ClientIP}, ClientHost: {ClientHost}]", EventName = "ErrorHandleMessage")]
+        public static partial void ErrorHandleMessage(ILogger logger, string connectionId, Guid envId, string clientIp, string clientHost, Exception exception);
 
-        [LoggerMessage(7, LogLevel.Warning, "{ConnectionId}: cannot find message handler for type {MessageType}", EventName = "CannotFindMessageHandler")]
-        public static partial void CannotFindMessageHandler(ILogger logger, string connectionId, string messageType);
+        [LoggerMessage(7, LogLevel.Warning, "{ConnectionId}: cannot find message handler for type {MessageType} [EnvId: {EnvId}, ClientIP: {ClientIP}, ClientHost: {ClientHost}]", EventName = "CannotFindMessageHandler")]
+        public static partial void CannotFindMessageHandler(ILogger logger, string connectionId, string messageType, Guid envId, string clientIp, string clientHost);
     }
 }

--- a/modules/evaluation-server/src/Streaming/Connections/ConnectionHandler.cs
+++ b/modules/evaluation-server/src/Streaming/Connections/ConnectionHandler.cs
@@ -55,7 +55,7 @@ public partial class ConnectionHandler : IConnectionHandler
             }
             catch (Exception ex)
             {
-                Log.ErrorProcessMessage(_logger, connection.Id, ex.Message);
+                Log.ErrorProcessMessage(_logger, connection.Id, ex.Message, connection.EnvId, connection.ClientIpAddress, connection.ClientHost);
             }
         }
 
@@ -74,13 +74,13 @@ public partial class ConnectionHandler : IConnectionHandler
     {
         if (message.Type == WebSocketMessageType.Close)
         {
-            Log.ReceiveCloseMessage(_logger, connection.Id);
+            Log.ReceiveCloseMessage(_logger, connection.Id, connection.EnvId, connection.ClientIpAddress, connection.ClientHost);
             return;
         }
 
         if (message.Bytes.IsEmpty)
         {
-            Log.ReceiveEmptyMessage(_logger, connection.Id);
+            Log.ReceiveEmptyMessage(_logger, connection.Id, connection.EnvId, connection.ClientIpAddress, connection.ClientHost);
             return;
         }
 
@@ -93,7 +93,7 @@ public partial class ConnectionHandler : IConnectionHandler
 
     public void OnMessageError(Connection connection, string error)
     {
-        Log.ErrorReadMessage(_logger, connection.Id, error);
+        Log.ErrorReadMessage(_logger, connection.Id, error, connection.EnvId, connection.ClientIpAddress, connection.ClientHost);
     }
 
     public async Task HandleMessageAsync(Connection connection, Message message, CancellationToken token)
@@ -116,7 +116,7 @@ public partial class ConnectionHandler : IConnectionHandler
             var handler = _messageHandlers.FirstOrDefault(x => x.Type == messageType);
             if (handler == null)
             {
-                Log.CannotFindMessageHandler(_logger, connection.Id, messageType ?? "");
+                Log.CannotFindMessageHandler(_logger, connection.Id, messageType ?? "", connection.EnvId, connection.ClientIpAddress, connection.ClientHost);
                 return;
             }
 
@@ -126,12 +126,12 @@ public partial class ConnectionHandler : IConnectionHandler
         catch (JsonException ex)
         {
             // ignore invalid json
-            Log.ReceiveInvalidMessage(_logger, connection.Id, ex);
+            Log.ReceiveInvalidMessage(_logger, connection.Id, connection.EnvId, connection.ClientIpAddress, connection.ClientHost, ex);
         }
         catch (Exception ex)
         {
             // error when handle message
-            Log.ErrorHandleMessage(_logger, connection.Id, ex);
+            Log.ErrorHandleMessage(_logger, connection.Id, connection.EnvId, connection.ClientIpAddress, connection.ClientHost, ex);
         }
     }
 }

--- a/modules/evaluation-server/src/Streaming/Shared/RequestHandler.cs
+++ b/modules/evaluation-server/src/Streaming/Shared/RequestHandler.cs
@@ -11,7 +11,9 @@ public class RequestHandler
         string version,
         string tokenString,
         // for testability
-        long? currentTimestamp = null)
+        long? currentTimestamp = null,
+        string clientIpAddress = "",
+        string clientHost = "")
     {
         // connection type
         if (!ConnectionType.IsRegistered(sdkType))
@@ -45,7 +47,7 @@ public class RequestHandler
             return null;
         }
 
-        var connection = new Connection(webSocket, token.Secret.EnvId, sdkType, version, current);
+        var connection = new Connection(webSocket, token.Secret.EnvId, sdkType, version, current, null, clientIpAddress, clientHost);
         return connection;
     }
 }

--- a/modules/evaluation-server/tests/Streaming.UnitTests/Connections/ConnectionBuilder.cs
+++ b/modules/evaluation-server/tests/Streaming.UnitTests/Connections/ConnectionBuilder.cs
@@ -1,0 +1,76 @@
+using System.Net.WebSockets;
+using Moq;
+using Streaming.Connections;
+
+namespace Streaming.UnitTests.Connections;
+
+public class ConnectionBuilder
+{
+    private Mock<WebSocket> _wsMock = new();
+    private string _ip = "10.0.0.7";
+    private string _host = "test.client.host";
+    private string _connectionType = ConnectionType.Server;
+    private Guid _envId = TestData.DevEnvId;
+    private long _connectAt = DateTime.UtcNow.Ticks;
+    private string _version = "1.0";
+
+    public ConnectionBuilder WithClientIp(string ip)
+    {
+        _ip = ip;
+        return this;
+    }
+
+    public ConnectionBuilder WithClientHost(string host)
+    {
+        _host = host;
+        return this;
+    }
+
+    public ConnectionBuilder WithEnvId(Guid envId)
+    {
+        _envId = envId;
+        return this;
+    }
+
+    public ConnectionBuilder WithMockWebSocket(Mock<WebSocket> ws)
+    {
+        _wsMock = ws;
+        return this;
+    }
+
+    public ConnectionBuilder WithConnectionType(string connectionType)
+    {
+        if (!ConnectionType.IsRegistered(connectionType))
+        {
+            throw new Exception("Invalid ConnectionType.");
+        }
+
+        _connectionType = connectionType;
+        return this;
+    }
+
+    public ConnectionBuilder WithConnectAt(long connectAt)
+    {
+        this._connectAt = connectAt;
+        return this;
+    }
+    
+    public ConnectionBuilder WithVersion(string version)
+    {
+        _version = version;
+        return this;
+    }
+
+    public Connection Build()
+    {
+        return new Connection(
+            _wsMock.Object, 
+            _envId, 
+            _connectionType, 
+            _version,
+            _connectAt,
+            null, 
+            _ip, 
+            _host);
+    }
+}

--- a/modules/evaluation-server/tests/Streaming.UnitTests/Connections/ConnectionHandlerTests.cs
+++ b/modules/evaluation-server/tests/Streaming.UnitTests/Connections/ConnectionHandlerTests.cs
@@ -1,0 +1,109 @@
+using System.Net.WebSockets;
+using System.Text;
+using Moq;
+using Streaming.Connections;
+using Streaming.Messages;
+using TestBase;
+
+namespace Streaming.UnitTests.Connections;
+
+public class ConnectionHandlerTests
+{
+    [Fact]
+    public void OnMessageErrorLogTests()
+    {
+        var (handler, logger) = Arrange();
+        var connection = new ConnectionBuilder()
+            .WithClientIp("10.0.0.7")
+            .WithClientHost("my.client.host")
+            .WithEnvId(TestData.DevEnvId)
+            .Build();
+        
+        handler.OnMessageError(connection, "error");
+            
+        Assert.NotNull(logger.Message);
+        Assert.Contains("10.0.0.7", logger.Message);
+        Assert.Contains("my.client.host", logger.Message);
+        Assert.Contains(TestData.DevEnvId.ToString(), logger.Message);
+    }
+
+    [Theory]
+    [ClassData(typeof(Messages))]
+    public async Task OnMessageAsyncLogTests(Message message, bool threwException)
+    {
+        var (handler, logger) = Arrange(new ErrorThrowingMessageHandler());
+        var connection = new ConnectionBuilder()
+            .WithClientIp("10.0.0.7")
+            .WithClientHost("my.client.host")
+            .WithEnvId(TestData.DevEnvId)
+            .Build();
+        
+        await handler.OnMessageAsync(connection, message,default);
+
+        Assert.NotNull(logger.Message);
+        if (threwException)
+        {
+            Assert.NotNull(logger.Ex);
+        }
+        else
+        {
+            Assert.Null(logger.Ex);
+        }
+        Assert.Contains("10.0.0.7", logger.Message);
+        Assert.Contains("my.client.host", logger.Message);
+        Assert.Contains(TestData.DevEnvId.ToString(), logger.Message);
+    }
+
+    private (ConnectionHandler handler, InMemoryFakeLogger<ConnectionHandler> logger) Arrange(params IMessageHandler[] handlers)
+    {
+        var logger = new InMemoryFakeLogger<ConnectionHandler>();
+        var mockManager = new Mock<IConnectionManager>();
+        var handler = new ConnectionHandler(mockManager.Object, handlers, logger);
+        return (handler, logger);
+    }
+}
+
+
+public class Messages : TheoryData<Message, bool>
+{
+    public Messages()
+    {
+        // close message log scenario
+        var closeMessage = new Message(new byte[16], WebSocketMessageType.Close);
+        Add(closeMessage, false);
+
+        // empty message log scenario
+        Add(Message.EmptyText, false);
+
+        // missing handler message log scenario
+        var missingHandlerMessage = new Message(
+            Encoding.UTF8.GetBytes("{\"messageType\":\"unregistered\",\"data\":{}}"), 
+            WebSocketMessageType.Text
+        );
+        Add(missingHandlerMessage, false);
+        
+        // invalid json message log scenario
+        var invalidJsonMessage = new Message(
+            Encoding.UTF8.GetBytes("{this is not ][valid json}"),
+            WebSocketMessageType.Text 
+        );
+        Add(invalidJsonMessage, true);
+        
+        // error-throwing message log scenario
+        var errorThrowingMessage = new Message(
+            Encoding.UTF8.GetBytes("{\"messageType\":\"error-throwing\",\"data\":{}}"), 
+            WebSocketMessageType.Text
+        );
+        Add(errorThrowingMessage, true);
+    }
+}
+
+public class ErrorThrowingMessageHandler : IMessageHandler
+{
+    public string Type => "error-throwing";
+
+    public Task HandleAsync(MessageContext ctx)
+    {
+        throw new Exception("Test Error!");
+    }
+}


### PR DESCRIPTION
ClientIP, ClientHost, and EnvId are logged in the ConnectionHandler.  Tests were added for ConnectionHandler to ensure functionality works as expected.

EnvId was chosen over EnvKey because the UI does not allow searching on env.

Once work is done to add ProjectId/ProjectKey to Connection, we could add project related info to the logs in a future PR.

fixes #604 