### PR TITLE
🔧 deps: bump dependency versions

### DIFF
--- a/modules/back-end/src/Api/appsettings.Development.json
+++ b/modules/back-end/src/Api/appsettings.Development.json
@@ -8,7 +8,7 @@
   "Jwt": {
     "Issuer": "featbit",
     "Audience": "featbit-api",
-    "Key": "featbit-identity-key"
+    "Key": "featbit-identity-key-must-longer-than-32-characters"
   },
   "MongoDb": {
     "ConnectionString": "mongodb://admin:password@localhost:27017",

--- a/modules/back-end/src/Api/appsettings.json
+++ b/modules/back-end/src/Api/appsettings.json
@@ -8,7 +8,7 @@
   "Jwt": {
     "Issuer": "featbit",
     "Audience": "featbit-api",
-    "Key": "featbit-identity-key"
+    "Key": "featbit-identity-key-must-longer-than-32-characters"
   },
   "MongoDb": {
     "ConnectionString": "mongodb://admin:password@mongodb:27017",

--- a/modules/back-end/src/Infrastructure/Infrastructure.csproj
+++ b/modules/back-end/src/Infrastructure/Infrastructure.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="Confluent.Kafka" Version="1.9.3"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.9"/>
         <PackageReference Include="MongoDB.Driver" Version="2.24.0"/>
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.23.1"/>
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
         <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
         <PackageReference Include="StackExchange.Redis" Version="2.7.33"/>
     </ItemGroup>

--- a/modules/back-end/src/Infrastructure/Infrastructure.csproj
+++ b/modules/back-end/src/Infrastructure/Infrastructure.csproj
@@ -15,10 +15,10 @@
     <ItemGroup>
         <PackageReference Include="Confluent.Kafka" Version="1.9.3"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.9"/>
-        <PackageReference Include="MongoDB.Driver" Version="2.17.1"/>
+        <PackageReference Include="MongoDB.Driver" Version="2.24.0"/>
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.23.1"/>
         <PackageReference Include="Handlebars.Net" Version="2.1.4"/>
-        <PackageReference Include="StackExchange.Redis" Version="2.6.96"/>
+        <PackageReference Include="StackExchange.Redis" Version="2.7.33"/>
     </ItemGroup>
 
 </Project>

--- a/modules/back-end/src/Infrastructure/Redis/RedisMessageProducer.cs
+++ b/modules/back-end/src/Infrastructure/Redis/RedisMessageProducer.cs
@@ -24,7 +24,7 @@ public partial class RedisMessageProducer : IMessageProducer
             var jsonMessage = JsonSerializer.Serialize(message, ReusableJsonSerializerOptions.Web);
 
             // Publish message to topic
-            await _database.PublishAsync(topic, jsonMessage);
+            await _database.PublishAsync(RedisChannel.Literal(topic), jsonMessage);
 
             Log.MessagePublished(_logger, jsonMessage);
         }

--- a/modules/back-end/tests/Application.UnitTests/Identity/IdentityServiceTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/Identity/IdentityServiceTests.cs
@@ -11,19 +11,12 @@ public class IdentityServiceTests
     private readonly Mock<IPasswordHasher<User>> _passwordHasherMock = new();
     private readonly IdentityService _identityService;
 
-    private readonly JwtOptions _jwtOptions = new()
-    {
-        Issuer = "test runner",
-        Audience = "test",
-        Key = "featbit-identity-key"
-    };
-
     public IdentityServiceTests()
     {
         _identityService = new IdentityService(
             null!,
             _passwordHasherMock.Object,
-            Options.Create(_jwtOptions)
+            Options.Create(new JwtOptions())
         );
     }
 

--- a/modules/evaluation-server/src/Infrastructure/Infrastructure.csproj
+++ b/modules/evaluation-server/src/Infrastructure/Infrastructure.csproj
@@ -13,8 +13,8 @@
         <PackageReference Include="Confluent.Kafka" Version="1.9.3"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0"/>
-        <PackageReference Include="MongoDB.Driver" Version="2.22.0"/>
-        <PackageReference Include="StackExchange.Redis" Version="2.6.70"/>
+        <PackageReference Include="MongoDB.Driver" Version="2.24.0"/>
+        <PackageReference Include="StackExchange.Redis" Version="2.7.33"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
To fix some vulnerabilities.

Note that the `System.IdentityModel.Tokens.Jwt` introduce a breaking change that could negatively impact our users.

- https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/2072
- https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/IDX10720