### PR TITLE
🖍 fix: webhook events tooltip style

### DIFF
--- a/modules/front-end/src/app/features/safe/integrations/webhooks/index/index.component.html
+++ b/modules/front-end/src/app/features/safe/integrations/webhooks/index/index.component.html
@@ -118,7 +118,7 @@
             {{ item.events?.join('; ') }}
           </span>
           <ng-template #eventsTooltip>
-            <ul>
+            <ul style="max-height: 100px; overflow: auto">
               <li *ngFor="let event of item.events;">{{ event }}</li>
             </ul>
           </ng-template>


### PR DESCRIPTION
## Before
![before](https://github.com/featbit/featbit/assets/34052208/f5a74d98-5e01-42eb-aae2-cee970d6609a)

## After
![after](https://github.com/featbit/featbit/assets/34052208/5cd9d02d-868a-46fa-9ba5-4b98cd8f71c0)