### PR TITLE
✨ feat: Improve operator fallback logic for empty strings

### DIFF
--- a/modules/back-end/src/Infrastructure/Users/UserService.cs
+++ b/modules/back-end/src/Infrastructure/Users/UserService.cs
@@ -22,7 +22,7 @@ public class UserService : MongoDbService<User>, IUserService
         var user = await FindOneAsync(x => x.Id == operatorId);
         if (user is not null)
         {
-            return user.Name ?? user.Email;
+            return !string.IsNullOrWhiteSpace(user.Name) ? user.Name : user.Email;
         }
 
         // An operation can also be made by an access token through our Open Api, see "OpenApiHandler"


### PR DESCRIPTION
# Allow falling back to email when the user name is an empty string.

I noticed this when user names were not populated by default.
It was not possible to be used as a way to notify my team of who made the change.

## Why this is necessary
If a user's name is not populated (i.e. an empty string), webhook integrations will not have any record of who performed the change, reducing their effectiveness as notifications that can be followed up on.

## How to test
1. Clear out your user name.
2. Set up and enable a [webhook integration for a feature flag](https://docs.featbit.co/integrations/webhooks).
3. Use the `operator` variable in the body's template.
4. Trigger the webhook to fire with a real request (Note: The Live Debug feature will not work, as it will always use "Webhook tester" for `operator`).
5. Observe that the value used for the `operator` falls back to your email.
