### PR TITLE
🔧 refactor: upgrade api server to .NET 8

### DIFF
--- a/modules/back-end/deploy/Dockerfile
+++ b/modules/back-end/deploy/Dockerfile
@@ -2,7 +2,7 @@
 # https://hub.docker.com/_/microsoft-dotnet
 ARG INSTALL_DIR=/app
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /source
 
 # copy sln
@@ -29,7 +29,7 @@ WORKDIR /source/src/Api
 RUN dotnet publish -c Release --no-build -o $INSTALL_DIR
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 
 RUN apt-get update && apt-get install -y curl unzip && rm -rf /var/lib/apt/lists/*
 

--- a/modules/back-end/src/Api/Api.csproj
+++ b/modules/back-end/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -10,21 +10,21 @@
 
     <ItemGroup>
         <!-- Api Versioning -->
-        <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="6.0.0" />
+        <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
 
         <!-- Swagger -->
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.6" />
-        <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="6.5.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="6.7.3" />
 
         <!-- Serilog -->
-        <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
-        <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.0.0" />
-        <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="1.1.0" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
+        <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.1.1" />
+        <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.0.0" />
 
-        <PackageReference Include="Grpc.Net.Client" Version="2.60.0" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+        <PackageReference Include="Grpc.Net.Client" Version="2.65.0" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/modules/back-end/src/Api/Api.csproj
+++ b/modules/back-end/src/Api/Api.csproj
@@ -21,7 +21,7 @@
         <!-- Serilog -->
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
         <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.1.1" />
-        <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.0.0" />
+        <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.0" />
 
         <PackageReference Include="Grpc.Net.Client" Version="2.65.0" />
         <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />

--- a/modules/back-end/src/Api/Authentication/OpenApiHandler.cs
+++ b/modules/back-end/src/Api/Authentication/OpenApiHandler.cs
@@ -18,10 +18,9 @@ public class OpenApiHandler : AuthenticationHandler<OpenApiOptions>
         IOptionsMonitor<OpenApiOptions> options,
         ILoggerFactory logger,
         UrlEncoder encoder,
-        ISystemClock clock,
         IOrganizationService organizationService,
         IAccessTokenService accessTokenService,
-        IMemberService memberService) : base(options, logger, encoder, clock)
+        IMemberService memberService) : base(options, logger, encoder)
     {
         _organizationService = organizationService;
         _accessTokenService = accessTokenService;
@@ -32,7 +31,7 @@ public class OpenApiHandler : AuthenticationHandler<OpenApiOptions>
     {
         try
         {
-            string token = Request.Headers.Authorization;
+            string? token = Request.Headers.Authorization;
 
             // If no authorization header found, nothing to process further
             if (string.IsNullOrEmpty(token))
@@ -49,8 +48,8 @@ public class OpenApiHandler : AuthenticationHandler<OpenApiOptions>
 
             // set workspace, organization id header & store permissions
             var org = await _organizationService.GetAsync(accessToken.OrganizationId);
-            Context.Request.Headers.Add(ApiConstants.WorkspaceHeaderKey, org.WorkspaceId.ToString());
-            Context.Request.Headers.Add(ApiConstants.OrgIdHeaderKey, org.ToString());
+            Context.Request.Headers.TryAdd(ApiConstants.WorkspaceHeaderKey, org.WorkspaceId.ToString());
+            Context.Request.Headers.TryAdd(ApiConstants.OrgIdHeaderKey, org.ToString());
             if (accessToken.Type == AccessTokenTypes.Service)
             {
                 Context.Items[OpenApiConstants.PermissionStoreKey] = accessToken.Permissions;

--- a/modules/back-end/src/Api/Program.cs
+++ b/modules/back-end/src/Api/Program.cs
@@ -49,7 +49,7 @@ void InitializeSerilog()
                                    | IncludedData.TraceIdField
                                    | IncludedData.SpanIdField;
             options.BatchingOptions.BatchSizeLimit = 2;
-            options.BatchingOptions.Period = TimeSpan.FromSeconds(2);
+            options.BatchingOptions.BufferingTimeLimit = TimeSpan.FromSeconds(2);
             options.BatchingOptions.QueueLimit = 10;
 
             options.ResourceAttributes = new Dictionary<string, object>
@@ -64,4 +64,5 @@ void InitializeSerilog()
 
 // https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-6.0#basic-tests-with-the-default-webapplicationfactory
 // Make the implicit Program class public so test projects can access it
-public partial class Program { }
+public partial class Program
+{ }

--- a/modules/back-end/src/Api/Program.cs
+++ b/modules/back-end/src/Api/Program.cs
@@ -64,5 +64,4 @@ void InitializeSerilog()
 
 // https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-6.0#basic-tests-with-the-default-webapplicationfactory
 // Make the implicit Program class public so test projects can access it
-public partial class Program
-{ }
+public partial class Program { }

--- a/modules/back-end/src/Api/Setup/ServicesRegister.cs
+++ b/modules/back-end/src/Api/Setup/ServicesRegister.cs
@@ -12,7 +12,6 @@ using Infrastructure.License;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.Net.Http.Headers;
 using Swashbuckle.AspNetCore.Filters;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -78,7 +77,7 @@ public static class ServicesRegister
             {
                 options.ForwardDefaultSelector = context =>
                 {
-                    string authorization = context.Request.Headers[HeaderNames.Authorization];
+                    string? authorization = context.Request.Headers.Authorization;
                     if (!string.IsNullOrEmpty(authorization) && authorization.StartsWith("Bearer "))
                     {
                         return Schemes.JwtBearer;
@@ -100,7 +99,7 @@ public static class ServicesRegister
                     ValidAudience = jwtOption["Audience"],
 
                     ValidateIssuerSigningKey = true,
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOption["Key"]))
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOption["Key"]!))
                 };
             })
             .AddOpenApi(Schemes.OpenApi);

--- a/modules/back-end/src/Application/Application.csproj
+++ b/modules/back-end/src/Application/Application.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -13,10 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-        <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.15" />
+        <PackageReference Include="AutoMapper" Version="13.0.1" />
+        <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+        <PackageReference Include="MediatR" Version="12.4.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
     </ItemGroup>
 
 </Project>

--- a/modules/back-end/src/Application/Application.csproj
+++ b/modules/back-end/src/Application/Application.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="13.0.1" />
         <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-        <PackageReference Include="MediatR" Version="12.4.0" />
+        <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
     </ItemGroup>
 

--- a/modules/back-end/src/Application/Bases/Behaviours/ValidationBehaviour.cs
+++ b/modules/back-end/src/Application/Bases/Behaviours/ValidationBehaviour.cs
@@ -1,7 +1,7 @@
 namespace Application.Bases.Behaviours;
 
 public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-    where TRequest : IRequest<TResponse>
+    where TRequest : notnull
 {
     private readonly IEnumerable<IValidator<TRequest>> _validators;
 
@@ -11,9 +11,9 @@ public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TReque
     }
 
     public async Task<TResponse> Handle(
-        TRequest request, 
-        CancellationToken cancellationToken,
-        RequestHandlerDelegate<TResponse> next)
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
     {
         if (_validators.Any())
         {

--- a/modules/back-end/src/Application/ConfigureServices.cs
+++ b/modules/back-end/src/Application/ConfigureServices.cs
@@ -19,7 +19,7 @@ public static class ConfigureServices
         services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 
         // MediatR
-        services.AddMediatR(Assembly.GetExecutingAssembly());
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
 
         // custom services

--- a/modules/back-end/src/Domain/Domain.csproj
+++ b/modules/back-end/src/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/modules/back-end/src/Infrastructure/ConfigurationExtensions.cs
+++ b/modules/back-end/src/Infrastructure/ConfigurationExtensions.cs
@@ -8,6 +8,6 @@ public static class ConfigurationExtensions
     {
         var isPro = configuration["IS_PRO"];
 
-        return isPro.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(isPro, bool.TrueString, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/modules/back-end/src/Infrastructure/ConfigureServices.cs
+++ b/modules/back-end/src/Infrastructure/ConfigureServices.cs
@@ -71,7 +71,7 @@ public static class ConfigureServices
         // typed http clients
         services.AddHttpClient<IOlapService, OlapService>(httpClient =>
         {
-            httpClient.BaseAddress = new Uri(configuration["OLAP:ServiceHost"]);
+            httpClient.BaseAddress = new Uri(configuration["OLAP:ServiceHost"]!);
         });
         services.AddHttpClient<IAgentService, AgentService>();
         services.AddHttpClient<IWebhookSender, WebhookSender>();

--- a/modules/back-end/src/Infrastructure/HealthCheckBuilderExtensions.cs
+++ b/modules/back-end/src/Infrastructure/HealthCheckBuilderExtensions.cs
@@ -19,6 +19,11 @@ public static class HealthCheckBuilderExtensions
         var mongoDbConnectionString = configuration.GetValue<string>("MongoDb:ConnectionString");
         var redisConnectionString = configuration.GetValue<string>("Redis:ConnectionString");
 
+        if (string.IsNullOrEmpty(mongoDbConnectionString) || string.IsNullOrEmpty(redisConnectionString))
+        {
+            throw new InvalidOperationException("MongoDb and Redis connection strings must be configured.");
+        }
+
         builder.Services
             .AddHealthChecks()
             .AddMongoDb(

--- a/modules/back-end/src/Infrastructure/Infrastructure.csproj
+++ b/modules/back-end/src/Infrastructure/Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -13,15 +13,15 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNetCore.HealthChecks.Kafka" Version="6.0.0" />
-        <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="6.0.0" />
-        <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="6.0.0" />
-        <PackageReference Include="Confluent.Kafka" Version="1.9.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.9" />
-        <PackageReference Include="MongoDB.Driver" Version="2.24.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
-        <PackageReference Include="Handlebars.Net" Version="2.1.4" />
-        <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
+        <PackageReference Include="AspNetCore.HealthChecks.Kafka" Version="8.0.1" />
+        <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
+        <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
+        <PackageReference Include="Confluent.Kafka" Version="2.5.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+        <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
+        <PackageReference Include="Handlebars.Net" Version="2.1.6" />
+        <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
     </ItemGroup>
 
 </Project>

--- a/modules/back-end/src/Infrastructure/Infrastructure.csproj
+++ b/modules/back-end/src/Infrastructure/Infrastructure.csproj
@@ -16,12 +16,12 @@
         <PackageReference Include="AspNetCore.HealthChecks.Kafka" Version="8.0.1" />
         <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
         <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
-        <PackageReference Include="Confluent.Kafka" Version="2.5.2" />
+        <PackageReference Include="Confluent.Kafka" Version="2.5.3" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
-        <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+        <PackageReference Include="MongoDB.Driver" Version="2.29.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
         <PackageReference Include="Handlebars.Net" Version="2.1.6" />
-        <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
+        <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
     </ItemGroup>
 
 </Project>

--- a/modules/back-end/src/Infrastructure/Kafka/KafkaHealthCheckBuilderExtensions.cs
+++ b/modules/back-end/src/Infrastructure/Kafka/KafkaHealthCheckBuilderExtensions.cs
@@ -48,7 +48,13 @@ public static class KafkaHealthCheckBuilderExtensions
             BootstrapServers = bootstrapServers
         };
 
-        var checker = new KafkaHealthCheck(producerConfig, DefaultTopic);
+        var kafkaConfig = new KafkaHealthCheckOptions
+        {
+            Configuration = producerConfig,
+            Topic = DefaultTopic
+        };
+
+        var checker = new KafkaHealthCheck(kafkaConfig);
         var registration = new HealthCheckRegistration(
             name,
             checker,

--- a/modules/back-end/src/Infrastructure/Kafka/KafkaHealthCheckBuilderExtensions.cs
+++ b/modules/back-end/src/Infrastructure/Kafka/KafkaHealthCheckBuilderExtensions.cs
@@ -19,6 +19,11 @@ public static class KafkaHealthCheckBuilderExtensions
         var producerServer = configuration.GetValue<string>("Kafka:Producer:bootstrap.servers");
         var consumerServer = configuration.GetValue<string>("Kafka:Consumer:bootstrap.servers");
 
+        if (string.IsNullOrEmpty(producerServer) || string.IsNullOrEmpty(consumerServer))
+        {
+            throw new InvalidOperationException("Kafka producer and consumer servers must be configured.");
+        }
+
         builder
             .AddKafka(
                 "Kafka Producer Cluster",

--- a/modules/back-end/src/Infrastructure/MongoDb/MongoDbClient.cs
+++ b/modules/back-end/src/Infrastructure/MongoDb/MongoDbClient.cs
@@ -37,11 +37,7 @@ public class MongoDbClient
     {
         var value = options.Value;
 
-        // linq provider v3 has many improvement in version 2.14.x we should use it
-        var clientSettings = MongoClientSettings.FromConnectionString(value.ConnectionString);
-        clientSettings.LinqProvider = LinqProvider.V3;
-
-        MongoClient = new MongoClient(clientSettings);
+        MongoClient = new MongoClient(value.ConnectionString);
         Database = MongoClient.GetDatabase(value.Database);
     }
 

--- a/modules/back-end/src/Infrastructure/Redis/DefaultRedisClient.cs
+++ b/modules/back-end/src/Infrastructure/Redis/DefaultRedisClient.cs
@@ -13,9 +13,9 @@ public class DefaultRedisClient : IRedisClient
     public DefaultRedisClient(IConfiguration configuration)
     {
         var connectionString = configuration["Redis:ConnectionString"];
-        var options = ConfigurationOptions.Parse(connectionString);
+        var options = ConfigurationOptions.Parse(connectionString!);
 
-        // if user has specified a password in the configuration, use it
+        // if we specified a password in the configuration, use it
         var password = configuration["Redis:Password"];
         if (!string.IsNullOrWhiteSpace(password))
         {

--- a/modules/back-end/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
+++ b/modules/back-end/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/modules/back-end/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
+++ b/modules/back-end/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     </ItemGroup>
 

--- a/modules/back-end/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
+++ b/modules/back-end/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/modules/back-end/tests/Application.IntegrationTests/Basics/BasicControllerTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Basics/BasicControllerTests.cs
@@ -3,7 +3,6 @@ using Api.Controllers;
 namespace Application.IntegrationTests.Basics;
 
 [Collection(nameof(TestApp))]
-[UsesVerify]
 public class BasicControllerTests
 {
     private readonly TestApp _app;

--- a/modules/back-end/tests/Application.IntegrationTests/Configuration/KafkaConfigTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Configuration/KafkaConfigTests.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Application.IntegrationTests.Configuration;
 
 [Collection(nameof(TestApp))]
-[UsesVerify]
 public class KafkaConfigTests
 {
     private readonly TestApp _app;

--- a/modules/back-end/tests/Application.IntegrationTests/Identity/IdentityControllerTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Identity/IdentityControllerTests.cs
@@ -3,7 +3,6 @@ using Application.Identity;
 namespace Application.IntegrationTests.Identity;
 
 [Collection(nameof(TestApp))]
-[UsesVerify]
 public class IdentityControllerTests
 {
     private readonly TestApp _app;

--- a/modules/back-end/tests/Application.IntegrationTests/Identity/IdentityControllerTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Identity/IdentityControllerTests.cs
@@ -32,6 +32,12 @@ public class IdentityControllerTests
         };
         var response = await _app.PostAsync("/api/v1/identity/login-by-email", request, false);
 
-        await Verify(response);
+
+        var settings = new VerifySettings();
+        settings.ScrubLinesWithReplace(
+            x => x.StartsWith("eyJ") && x.Split('.').Length == 3 ? "[Scrubbed JWT]" : x
+        );
+
+        await Verify(response, settings: settings);
     }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Initialization.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Initialization.cs
@@ -7,7 +7,7 @@ public static class Initialization
     [ModuleInitializer]
     public static void Run()
     {
-        VerifierSettings.DerivePathInfo((sourceFile, projectDirectory, type, method) => new PathInfo(
+        Verifier.DerivePathInfo((sourceFile, projectDirectory, type, method) => new PathInfo(
             directory: Path.Combine(projectDirectory, "Snapshots"),
             typeName: type.Name,
             methodName: method.Name)
@@ -17,7 +17,16 @@ public static class Initialization
             x => x.StartsWith("eyJ") && x.Split('.').Length == 3 ? "[Scrubbed JWT]" : x
         );
         VerifierSettings.ScrubLinesWithReplace(x => x.StartsWith("Bearer ") ? "Bearer [Scrubbed Token]" : x);
-        
-        VerifyHttp.Enable();
+
+        // needed for errors[]
+        VerifierSettings.DontIgnoreEmptyCollections();
+        // needed to ignore cookies that could be added along with empty errors[]
+        VerifierSettings.IgnoreMember("Cookies");
+
+        // Sort properties and json objects alphabetically to make the snapshot matching more accurate
+        VerifierSettings.SortPropertiesAlphabetically();
+        VerifierSettings.SortJsonObjects();
+
+        VerifyHttp.Initialize();
     }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Initialization.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Initialization.cs
@@ -7,20 +7,13 @@ public static class Initialization
     [ModuleInitializer]
     public static void Run()
     {
-        Verifier.DerivePathInfo((sourceFile, projectDirectory, type, method) => new PathInfo(
+        DerivePathInfo((_, projectDirectory, type, method) => new PathInfo(
             directory: Path.Combine(projectDirectory, "Snapshots"),
             typeName: type.Name,
             methodName: method.Name)
         );
 
-        VerifierSettings.ScrubLinesWithReplace(
-            x => x.StartsWith("eyJ") && x.Split('.').Length == 3 ? "[Scrubbed JWT]" : x
-        );
-        VerifierSettings.ScrubLinesWithReplace(x => x.StartsWith("Bearer ") ? "Bearer [Scrubbed Token]" : x);
-
-        // needed for errors[]
         VerifierSettings.DontIgnoreEmptyCollections();
-        // needed to ignore cookies that could be added along with empty errors[]
         VerifierSettings.IgnoreMember("Cookies");
 
         // Sort properties and json objects alphabetically to make the snapshot matching more accurate

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.AllowAnonymous.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.AllowAnonymous.verified.txt
@@ -1,5 +1,4 @@
 ﻿{
-  Version: 1.1,
   Status: 200 OK,
   Headers: {
     api-supported-versions: 1.0, 2.0
@@ -13,6 +12,5 @@
       errors: [],
       success: true
     }
-  },
-  Request: http://localhost/api/v1/basic/allow-anonymous
+  }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.ApiVersioning.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.ApiVersioning.verified.txt
@@ -1,6 +1,5 @@
 {
   v1: {
-    Version: 1.1,
     Status: 200 OK,
     Headers: {
       api-supported-versions: 1.0, 2.0
@@ -14,16 +13,9 @@
         errors: [],
         success: true
       }
-    },
-    Request: {
-      Uri: http://localhost/api/v1/basic/string,
-      Headers: {
-        Authorization: Bearer [Scrubbed Token]
-      }
     }
   },
   v2: {
-    Version: 1.1,
     Status: 200 OK,
     Headers: {
       api-supported-versions: 1.0, 2.0
@@ -36,12 +28,6 @@
         data: v2,
         errors: [],
         success: true
-      }
-    },
-    Request: {
-      Uri: http://localhost/api/v2/basic/string,
-      Headers: {
-        Authorization: Bearer [Scrubbed Token]
       }
     }
   }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.Authorized.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.Authorized.verified.txt
@@ -1,5 +1,4 @@
 ﻿{
-  Version: 1.1,
   Status: 200 OK,
   Headers: {
     api-supported-versions: 1.0, 2.0
@@ -14,12 +13,6 @@
       },
       errors: [],
       success: true
-    }
-  },
-  Request: {
-    Uri: http://localhost/api/v1/basic/authorized,
-    Headers: {
-      Authorization: Bearer [Scrubbed Token]
     }
   }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.HandleException.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.HandleException.verified.txt
@@ -1,5 +1,4 @@
 {
-  Version: 1.1,
   Status: 500 Internal Server Error,
   Headers: {
     api-supported-versions: 1.0, 2.0,
@@ -17,12 +16,6 @@
         InternalServerError
       ],
       success: false
-    }
-  },
-  Request: {
-    Uri: http://localhost/api/v1/basic/exception,
-    Headers: {
-      Authorization: Bearer [Scrubbed Token]
     }
   }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.ModelBinding.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.ModelBinding.verified.txt
@@ -1,5 +1,4 @@
 ﻿{
-  Version: 1.1,
   Status: 200 OK,
   Headers: {
     api-supported-versions: 1.0, 2.0
@@ -15,20 +14,6 @@
       },
       errors: [],
       success: true
-    }
-  },
-  Request: {
-    Method: POST,
-    Uri: http://localhost/api/v2/basic/bar,
-    Headers: {
-      Authorization: Bearer [Scrubbed Token]
-    },
-    Content: {
-      Headers: {
-        Content-Length: 23,
-        Content-Type: application/json; charset=utf-8
-      },
-      Value: 
     }
   }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.NeedAuthentication.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.NeedAuthentication.verified.txt
@@ -1,5 +1,4 @@
 ﻿{
-  Version: 1.1,
   Status: 401 Unauthorized,
   Headers: {
     WWW-Authenticate: Bearer
@@ -15,6 +14,5 @@
       ],
       success: false
     }
-  },
-  Request: http://localhost/api/v1/basic/authorized
+  }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.NeedLicense.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/BasicControllerTests.NeedLicense.verified.txt
@@ -1,6 +1,6 @@
 ﻿{
-  Version: 1.1,
   Status: 403 Forbidden,
+  Headers: {},
   Content: {
     Headers: {
       Content-Type: application/json; charset=utf-8
@@ -11,12 +11,6 @@
         Forbidden
       ],
       success: false
-    }
-  },
-  Request: {
-    Uri: http://localhost/api/v1/basic/license-feature-check,
-    Headers: {
-      Authorization: Bearer [Scrubbed Token]
     }
   }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/IdentityControllerTests.LoginByEmail_RequestValidation.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/IdentityControllerTests.LoginByEmail_RequestValidation.verified.txt
@@ -1,5 +1,4 @@
 ﻿{
-  Version: 1.1,
   Status: 400 Bad Request,
   Headers: {
     api-supported-versions: 1.0,
@@ -18,17 +17,6 @@
         password_is_required
       ],
       success: false
-    }
-  },
-  Request: {
-    Method: POST,
-    Uri: http://localhost/api/v1/identity/login-by-email,
-    Content: {
-      Headers: {
-        Content-Length: 44,
-        Content-Type: application/json; charset=utf-8
-      },
-      Value: 
     }
   }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/IdentityControllerTests.LoginByEmail_Success.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/IdentityControllerTests.LoginByEmail_Success.verified.txt
@@ -1,5 +1,4 @@
 ﻿{
-  Version: 1.1,
   Status: 200 OK,
   Headers: {
     api-supported-versions: 1.0
@@ -15,17 +14,6 @@
       },
       errors: [],
       success: true
-    }
-  },
-  Request: {
-    Method: POST,
-    Uri: http://localhost/api/v1/identity/login-by-email,
-    Content: {
-      Headers: {
-        Content-Length: 67,
-        Content-Type: application/json; charset=utf-8
-      },
-      Value: 
     }
   }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/IdentityControllerTests.LoginByPassword_RequestValidation.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/IdentityControllerTests.LoginByPassword_RequestValidation.verified.txt
@@ -1,5 +1,4 @@
 {
-  Version: 1.1,
   Status: 400 Bad Request,
   Headers: {
     api-supported-versions: 1.0,
@@ -18,17 +17,6 @@
         PasswordIsRequired
       ],
       success: false
-    }
-  },
-  Request: {
-    Method: POST,
-    Uri: http://localhost/api/v1/identity/login-by-password,
-    Content: {
-      Headers: {
-        Content-Length: 29,
-        Content-Type: application/json; charset=utf-8
-      },
-      Value: 
     }
   }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/IdentityControllerTests.LoginByPassword_Success.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/IdentityControllerTests.LoginByPassword_Success.verified.txt
@@ -1,5 +1,4 @@
 {
-  Version: 1.1,
   Status: 200 OK,
   Headers: {
     api-supported-versions: 1.0
@@ -14,17 +13,6 @@
       },
       errors: [],
       success: true
-    }
-  },
-  Request: {
-    Method: POST,
-    Uri: http://localhost/api/v1/identity/login-by-password,
-    Content: {
-      Headers: {
-        Content-Length: 40,
-        Content-Type: application/json; charset=utf-8
-      },
-      Value: 
     }
   }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/KafkaConfigTests.DefaultProducerConsumerConfig.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/KafkaConfigTests.DefaultProducerConsumerConfig.verified.txt
@@ -1,38 +1,30 @@
 ﻿{
-  producerConfig: [
-    {
-      Key: bootstrap.servers,
-      Value: localhost:29092
-    },
-    {
-      Key: linger.ms,
-      Value: 50
-    }
-  ],
   consumerConfig: [
     {
-      Key: auto.commit.interval.ms,
-      Value: 5000
+      auto.commit.interval.ms: 5000
     },
     {
-      Key: auto.offset.reset,
-      Value: earliest
+      auto.offset.reset: earliest
     },
     {
-      Key: bootstrap.servers,
-      Value: localhost:29092
+      bootstrap.servers: localhost:29092
     },
     {
-      Key: enable.auto.commit,
-      Value: True
+      enable.auto.commit: True
     },
     {
-      Key: enable.auto.offset.store,
-      Value: False
+      enable.auto.offset.store: False
     },
     {
-      Key: group.id,
-      Value: featbit-api
+      group.id: featbit-api
+    }
+  ],
+  producerConfig: [
+    {
+      bootstrap.servers: localhost:29092
+    },
+    {
+      linger.ms: 50
     }
   ]
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/UserControllerTests.GetUserProfile.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/UserControllerTests.GetUserProfile.verified.txt
@@ -1,5 +1,4 @@
 ﻿{
-  Version: 1.1,
   Status: 200 OK,
   Headers: {
     api-supported-versions: 1.0
@@ -18,12 +17,6 @@
       },
       errors: [],
       success: true
-    }
-  },
-  Request: {
-    Uri: http://localhost/api/v1/user/profile,
-    Headers: {
-      Authorization: Bearer [Scrubbed Token]
     }
   }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Snapshots/UserControllerTests.GetUserProfile_NotExist.verified.txt
+++ b/modules/back-end/tests/Application.IntegrationTests/Snapshots/UserControllerTests.GetUserProfile_NotExist.verified.txt
@@ -1,5 +1,4 @@
 ﻿{
-  Version: 1.1,
   Status: 404 Not Found,
   Headers: {
     api-supported-versions: 1.0,
@@ -17,12 +16,6 @@
         ResourceNotFound
       ],
       success: false
-    }
-  },
-  Request: {
-    Uri: http://localhost/api/v1/user/profile,
-    Headers: {
-      Authorization: Bearer [Scrubbed Token]
     }
   }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Users/UserControllerTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Users/UserControllerTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 namespace Application.IntegrationTests.Users;
 
 [Collection(nameof(TestApp))]
-[UsesVerify]
 public class UserControllerTests
 {
     private readonly TestApp _app;

--- a/modules/back-end/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/modules/back-end/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/modules/back-end/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/modules/back-end/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/modules/back-end/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/modules/back-end/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/modules/back-end/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/modules/back-end/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/modules/back-end/tests/TestBase/TestBase.csproj
+++ b/modules/back-end/tests/TestBase/TestBase.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/modules/back-end/tests/TestBase/TestBase.csproj
+++ b/modules/back-end/tests/TestBase/TestBase.csproj
@@ -12,9 +12,9 @@
     <!-- test suits -->
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="Moq" Version="4.20.71" />
+        <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Verify.Http" Version="6.3.0" />
-        <PackageReference Include="Verify.Xunit" Version="26.3.1" />
+        <PackageReference Include="Verify.Xunit" Version="26.5.0" />
         <PackageReference Include="xunit" Version="2.9.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
           <PrivateAssets>all</PrivateAssets>

--- a/modules/back-end/tests/TestBase/TestBase.csproj
+++ b/modules/back-end/tests/TestBase/TestBase.csproj
@@ -11,13 +11,19 @@
 
     <!-- test suits -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
-        <PackageReference Include="Verify.Http" Version="2.5.0" />
-        <PackageReference Include="Verify.Xunit" Version="17.10.2" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Moq" Version="4.20.71" />
+        <PackageReference Include="Verify.Http" Version="6.3.0" />
+        <PackageReference Include="Verify.Xunit" Version="26.3.1" />
+        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR upgrade the API server and related dependencies to dotnet 8. 

Integration tests have been modified to account for changes in the VerifyTests/Verify and Verify.Http package referenced below

Default version removed from Verify.Http in PR 567 `HttpResponseMessageConverter.cs` 
https://github.com/VerifyTests/Verify.Http/pull/567

Response.Request removed from Verify.Http in PR 566 `HttpResponseMessageConverter.cs` 
https://github.com/VerifyTests/Verify.Http/pull/566


