### PR TITLE
🚀 perf: add mongodb indexes

### DIFF
--- a/infra/mongodb/docker-entrypoint-initdb.d/init.js
+++ b/infra/mongodb/docker-entrypoint-initdb.d/init.js
@@ -239,3 +239,18 @@ db.MemberPolicies.insertOne(
     }
 )
 print('collection seeded: MemberPolicies')
+
+// add indexes
+print('add indexes...')
+db.AuditLogs.createIndex({ createdAt: 1 });
+db.EndUsers.createIndex({ updatedAt: 1 });
+db.ExperimentMetrics.createIndex({ updatedAt: 1 });
+db.FeatureFlags.createIndex({ updatedAt: 1 });
+db.Segments.createIndex({ updatedAt: 1 });
+db.AccessTokens.createIndex({ createdAt: 1 });
+db.Policies.createIndex({ createdAt: 1 });
+db.Projects.createIndex({ createdAt: 1 });
+db.RelayProxies.createIndex({ createdAt: 1 });
+db.Webhooks.createIndex({ createdAt: 1 });
+db.Webhooks.createIndex({ startedAt: 1 });
+print('indexes added')

--- a/kubernetes/pro/infrastructure/mongodb-init-configMap.yaml
+++ b/kubernetes/pro/infrastructure/mongodb-init-configMap.yaml
@@ -247,3 +247,18 @@ data:
         }
     )
     print('collection seeded: MemberPolicies')
+
+    // add indexes
+    print('add indexes...')
+    db.AuditLogs.createIndex({ createdAt: 1 });
+    db.EndUsers.createIndex({ updatedAt: 1 });
+    db.ExperimentMetrics.createIndex({ updatedAt: 1 });
+    db.FeatureFlags.createIndex({ updatedAt: 1 });
+    db.Segments.createIndex({ updatedAt: 1 });
+    db.AccessTokens.createIndex({ createdAt: 1 });
+    db.Policies.createIndex({ createdAt: 1 });
+    db.Projects.createIndex({ createdAt: 1 });
+    db.RelayProxies.createIndex({ createdAt: 1 });
+    db.Webhooks.createIndex({ createdAt: 1 });
+    db.Webhooks.createIndex({ startedAt: 1 });
+    print('indexes added')

--- a/kubernetes/standard/infrastructure/mongodb-init-configMap.yaml
+++ b/kubernetes/standard/infrastructure/mongodb-init-configMap.yaml
@@ -247,3 +247,18 @@ data:
         }
     )
     print('collection seeded: MemberPolicies')
+
+    // add indexes
+    print('add indexes...')
+    db.AuditLogs.createIndex({ createdAt: 1 });
+    db.EndUsers.createIndex({ updatedAt: 1 });
+    db.ExperimentMetrics.createIndex({ updatedAt: 1 });
+    db.FeatureFlags.createIndex({ updatedAt: 1 });
+    db.Segments.createIndex({ updatedAt: 1 });
+    db.AccessTokens.createIndex({ createdAt: 1 });
+    db.Policies.createIndex({ createdAt: 1 });
+    db.Projects.createIndex({ createdAt: 1 });
+    db.RelayProxies.createIndex({ createdAt: 1 });
+    db.Webhooks.createIndex({ createdAt: 1 });
+    db.Webhooks.createIndex({ startedAt: 1 });
+    print('indexes added')


### PR DESCRIPTION
Added MongoDB indexes to all relevant tables that are queried with a particular sorting key.

This improves performance, but is not actually the reason I made this change. This PR adds support for running on Azure CosmosDB for MongoDB.

Azure CosmosDB for MongoDB requires that indexes exist when querying using sorting keys, so before we added these to our setup, it would error when attempting to query the database.

Helm chart PR: https://github.com/featbit/featbit-charts/pull/40