### PR TITLE
🐛 fix: webhooks are not filtered by scope

### DIFF
--- a/modules/back-end/src/Application/Application.csproj
+++ b/modules/back-end/src/Application/Application.csproj
@@ -17,6 +17,7 @@
         <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
         <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
+        <PackageReference Include="System.Linq" Version="4.3.0" />
     </ItemGroup>
 
 </Project>

--- a/modules/back-end/src/Application/Application.csproj
+++ b/modules/back-end/src/Application/Application.csproj
@@ -17,7 +17,6 @@
         <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
         <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
-        <PackageReference Include="System.Linq" Version="4.3.0" />
     </ItemGroup>
 
 </Project>

--- a/modules/back-end/src/Application/Webhooks/WebhookHandlers.cs
+++ b/modules/back-end/src/Application/Webhooks/WebhookHandlers.cs
@@ -72,7 +72,7 @@ public class WebhookHandler : IWebhookHandler
         var resourceDescriptor = await _environmentService.GetResourceDescriptorAsync(flag.EnvId);
         var webhooks = await _webhookService.GetByEventsAsync(resourceDescriptor.Organization.Id, events);
 
-        var environmentScopeStr = $"{resourceDescriptor.Project.Id}.{resourceDescriptor.Project.Name}";
+        var environmentScopeStr = $"{resourceDescriptor.Project.Id}/{resourceDescriptor.Environment.Id}";
         var activeWebhooks = webhooks.Where(x => x.IsActive && x.Scopes.Any(y => string.Equals(y,
             environmentScopeStr, StringComparison.OrdinalIgnoreCase))).ToArray();
         if (!activeWebhooks.Any())

--- a/modules/back-end/src/Application/Webhooks/WebhookHandlers.cs
+++ b/modules/back-end/src/Application/Webhooks/WebhookHandlers.cs
@@ -37,6 +37,16 @@ public class WebhookHandler : IWebhookHandler
         _segmentService = segmentService;
     }
 
+    private static string RemoveProjectPrefix(string input)
+    {
+        int index = input.IndexOf('/');
+        if (index >= 0)
+        {
+            return input.Substring(index + 1);
+        }
+        return input; // Return the original string if '/' is not found
+    }
+
     public async Task HandleAsync(FeatureFlag flag, DataChange dataChange, Guid operatorId)
     {
         string[] events;
@@ -89,7 +99,8 @@ public class WebhookHandler : IWebhookHandler
 
         foreach (var webhook in activeWebhooks)
         {
-            if (webhook.Scopes.Contains(flag.EnvId.ToString()))
+            var scopes = RemoveProjectPrefix(webhook.Scopes[0]).Split(',');
+            if (scopes.Contains(resourceDescriptor.Environment.Id.ToString()))
             {
                 var delivery = await _webhookSender.SendAsync(webhook, dataObject);
 
@@ -152,7 +163,8 @@ public class WebhookHandler : IWebhookHandler
 
         foreach (var webhook in activeWebhooks)
         {
-            if (webhook.Scopes.Contains(segment.EnvId.ToString()))
+            var scopes = RemoveProjectPrefix(webhook.Scopes[0]).Split(',');
+            if (scopes.Contains(resourceDescriptor.Environment.Id.ToString()))
             {
                 var delivery = await _webhookSender.SendAsync(webhook, dataObject);
 

--- a/modules/back-end/src/Application/Webhooks/WebhookHandlers.cs
+++ b/modules/back-end/src/Application/Webhooks/WebhookHandlers.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Text.Json;
 using Domain.AuditLogs;
 using Domain.FeatureFlags;

--- a/modules/back-end/src/Application/Webhooks/WebhookHandlers.cs
+++ b/modules/back-end/src/Application/Webhooks/WebhookHandlers.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json;
 using Domain.AuditLogs;
 using Domain.FeatureFlags;
@@ -88,10 +89,13 @@ public class WebhookHandler : IWebhookHandler
 
         foreach (var webhook in activeWebhooks)
         {
-            var delivery = await _webhookSender.SendAsync(webhook, dataObject);
+            if (webhook.Scopes.Contains(flag.EnvId.ToString()))
+            {
+                var delivery = await _webhookSender.SendAsync(webhook, dataObject);
 
-            webhook.LastDelivery = new LastDelivery(delivery);
-            await _webhookService.UpdateAsync(webhook);
+                webhook.LastDelivery = new LastDelivery(delivery);
+                await _webhookService.UpdateAsync(webhook);
+            }
         }
     }
 
@@ -148,10 +152,13 @@ public class WebhookHandler : IWebhookHandler
 
         foreach (var webhook in activeWebhooks)
         {
-            var delivery = await _webhookSender.SendAsync(webhook, dataObject);
+            if (webhook.Scopes.Contains(segment.EnvId.ToString()))
+            {
+                var delivery = await _webhookSender.SendAsync(webhook, dataObject);
 
-            webhook.LastDelivery = new LastDelivery(delivery);
-            await _webhookService.UpdateAsync(webhook);
+                webhook.LastDelivery = new LastDelivery(delivery);
+                await _webhookService.UpdateAsync(webhook);
+            }
         }
     }
 }

--- a/modules/back-end/src/Domain/Environments/ResourceDescriptor.cs
+++ b/modules/back-end/src/Domain/Environments/ResourceDescriptor.cs
@@ -1,3 +1,5 @@
+using Domain.Organizations;
+
 namespace Domain.Environments;
 
 public record ResourceDescriptor
@@ -7,6 +9,14 @@ public record ResourceDescriptor
     public IdNameKeyProps Project { get; init; }
 
     public IdNameKeyProps Environment { get; set; }
+
+    public bool MatchScope(string scope)
+    {
+        var scopeString = new ScopeString(scope);
+
+        return scopeString.ProjectId == Project.Id &&
+               scopeString.EnvIds.Any(id => Environment.Id == id);
+    }
 }
 
 public record IdNameKeyProps


### PR DESCRIPTION
This PR fixes environment filtering for webhooks.  

To Test Webhooks.

1. Create a project
2. Create more than one environment
3. Create a Webhook, select the project and add one of the environments, select all "Feature Flag" events
4. Save the webhook
5. Make sure the webhook is active
6. Create or manipulate flags in the environment that is in scope
7. View the Logs for the webhook
8. Observe that the webhook was fired for environments that are in scope of the webhook
9. switch to an environment that is not in scope
10. Create or manipulate flags in the environment that is not in scope
11. View the Logs for the webhook
12. Observe that the webhook was not fired for environments that are not in scope of the webhook

1. Create a project or use and existing project
2. Create more than one environment (if no environments have been created)
3. Create a Webhook, select the project and add one of the environments, select all "Segments" events
4. Save the webhook
5. Make sure the webhook is active
6. Create or manipulate a segment in the environment that is in scope
7. View the Logs for the webhook
8. Observe that the webhook was fired for enviroments that are in scope of the webhook
9. switch to an environment that is not in scope
10. Create or manipulate segments in the environment that is not in scope
11. View the Logs for the webhook
12. Observe that the webhook was not fired for environments that are not in scope of the webhook

fixed #674 