### PR TITLE
🐛 fix: switch project/env results in a 404

### DIFF
--- a/modules/front-end/README.md
+++ b/modules/front-end/README.md
@@ -63,13 +63,13 @@ Bind the port 8081 or any other available port to 80.
 
 ### Build docker image and run container from the source code
 ```
-docker build -t featbit/ui .
-docker run -d -p 8081:80 -e API_URL="http://localhost:5000" -e DEMO_URL="https://featbit-samples.vercel.app" -e EVALUATION_URL="http://localhost:5100" --name featbit-ui featbit/ui
+docker build -t featbit/ui:local .
+docker run -d -p 8081:80 -e API_URL="http://localhost:5000" -e DEMO_URL="https://featbit-samples.vercel.app" -e EVALUATION_URL="http://localhost:5100" --name featbit-ui featbit/ui:local
 ```
 
 ### Run docker container from our prebuilt docker hub image
 ```
-docker run -d -p 8081:80 -e API_URL="http://localhost:5000" -e DEMO_URL="https://featbit-samples.vercel.app" -e EVALUATION_URL="http://localhost:5100" --name featbit-ui featbitdocker/featbit-ui:latest
+docker run -d -p 8081:80 -e API_URL="http://localhost:5000" -e DEMO_URL="https://featbit-samples.vercel.app" -e EVALUATION_URL="http://localhost:5100" --name featbit-ui featbit/featbit-ui:latest
 ```
 
 Then go to http://localhost:8081

--- a/modules/front-end/src/app/core/components/header/header.component.ts
+++ b/modules/front-end/src/app/core/components/header/header.component.ts
@@ -113,8 +113,14 @@ export class HeaderComponent implements OnInit {
     this.currentProjectEnv = projectEnv;
     this.envModalVisible = false;
 
-    window.location.href = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+    let path = this.router.url.split('/').slice(0, 2);
+    const match = window.location.pathname.match(/^\/(en|zh)\//);
 
+    if (match) {
+      path = [match[1], ...path].filter(x => x !== '');
+    }
+
+    window.location.href = `${window.location.protocol}//${window.location.host}/${path.join('/')}`;
   }
 
   private setCurrentEnv() {

--- a/modules/front-end/src/app/core/components/header/header.component.ts
+++ b/modules/front-end/src/app/core/components/header/header.component.ts
@@ -113,8 +113,8 @@ export class HeaderComponent implements OnInit {
     this.currentProjectEnv = projectEnv;
     this.envModalVisible = false;
 
-    const path = this.router.url.split('/').slice(0, 2).join('/');
-    window.location.href = `${window.location.protocol}//${window.location.host}${path}`;
+    window.location.href = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+
   }
 
   private setCurrentEnv() {


### PR DESCRIPTION
This PR fixes a bug introduced by PR 676.  Prior to 676 changing environments or projects usign the modal presented by clicking the header would navigate users to teh feature flags view regardless of where they were in the applicaiton at the time.  This was not desired as a user may be viewing segments and intended to remain on that view when they switched environments or projects.  The PR to fix this inadvertently causes the browser to show a 404 when another project or environment is selected because the locale prefix is removed from the url. This PR fixes that issue.
  
To test:
1. Create multiple projects and environments and flags or use an existing installation that has these attributes.
2. Navigate the feature flag view
3. Click on the header and select a different environment.
4. Observe that the environment has changed and they data associated with that environment is displayed
5. Navigate to the segments view
6. Click on the  header and select a different environment or project
7. Observe that the environment or project has changed and the associated segment data is displayed.
8. Navigate to any view
9. Click the header and select a different environment or project
10. Observe that the environment has change but the browser remains in the same application area.

