### PR TITLE
✨feat: optionally prevent empty webhook payloads

### DIFF
--- a/modules/back-end/src/Application/Webhooks/CreateWebhook.cs
+++ b/modules/back-end/src/Application/Webhooks/CreateWebhook.cs
@@ -11,7 +11,7 @@ public class CreateWebhook : WebhookBase, IRequest<WebhookVm>
 
     public Webhook AsWebhook(Guid creatorId)
     {
-        var webhook = new Webhook(OrgId, Name, Scopes, Url, Events, Headers, PayloadTemplateType, PayloadTemplate, Secret, IsActive, creatorId);
+        var webhook = new Webhook(OrgId, Name, Scopes, Url, Events, Headers, PayloadTemplateType, PayloadTemplate, Secret, IsActive, PreventEmptyPayloads, creatorId);
         return webhook;
     }
 }

--- a/modules/back-end/src/Application/Webhooks/UpdateWebhook.cs
+++ b/modules/back-end/src/Application/Webhooks/UpdateWebhook.cs
@@ -41,6 +41,7 @@ public class UpdateWebhookHandler : IRequestHandler<UpdateWebhook, WebhookVm>
             request.PayloadTemplate,
             request.Secret,
             request.IsActive,
+            request.PreventEmptyPayloads,
             _currentUser.Id
         );
 

--- a/modules/back-end/src/Application/Webhooks/WebhookBase.cs
+++ b/modules/back-end/src/Application/Webhooks/WebhookBase.cs
@@ -22,6 +22,8 @@ public class WebhookBase
     public string Secret { get; set; }
 
     public bool IsActive { get; set; }
+
+    public bool PreventEmptyPayloads { get; set; }
 }
 
 public class WebhookBaseValidator : AbstractValidator<WebhookBase>

--- a/modules/back-end/src/Application/Webhooks/WebhookVm.cs
+++ b/modules/back-end/src/Application/Webhooks/WebhookVm.cs
@@ -27,6 +27,8 @@ public class WebhookVm
 
     public bool IsActive { get; set; }
 
+    public bool PreventEmptyPayloads { get; set; }
+
     public LastDelivery LastDelivery { get; set; }
 
     public UserVm Creator { get; set; }

--- a/modules/back-end/src/Domain/Utils/JsonExtensions.cs
+++ b/modules/back-end/src/Domain/Utils/JsonExtensions.cs
@@ -1,0 +1,9 @@
+using System.Text.Json;
+
+namespace Domain.Utils;
+
+public static class JsonExtensions
+{
+    public static bool IsEmptyObject(this JsonElement json)
+        => json.ValueKind == JsonValueKind.Object && !json.EnumerateObject().Any();
+}

--- a/modules/back-end/src/Domain/Webhooks/Webhook.cs
+++ b/modules/back-end/src/Domain/Webhooks/Webhook.cs
@@ -21,6 +21,8 @@ public class Webhook : FullAuditedEntity
     public string Secret { get; set; }
 
     public bool IsActive { get; set; }
+    
+    public bool PreventEmptyPayloads { get; set; }
 
     public LastDelivery LastDelivery { get; set; }
 
@@ -35,6 +37,7 @@ public class Webhook : FullAuditedEntity
         string payloadTemplate,
         string secret,
         bool isActive,
+        bool preventEmptyPayloads,
         Guid creatorId) : base(creatorId)
     {
         OrgId = orgId;
@@ -50,6 +53,7 @@ public class Webhook : FullAuditedEntity
         Secret = secret ?? string.Empty;
 
         IsActive = isActive;
+        PreventEmptyPayloads = preventEmptyPayloads;
         LastDelivery = null;
     }
 
@@ -63,6 +67,7 @@ public class Webhook : FullAuditedEntity
         string payloadTemplate,
         string secret,
         bool isActive,
+        bool preventEmptyPayloads,
         Guid currentUserId)
     {
         Name = name;
@@ -77,6 +82,7 @@ public class Webhook : FullAuditedEntity
         Secret = secret ?? string.Empty;
 
         IsActive = isActive;
+        PreventEmptyPayloads = preventEmptyPayloads;
 
         MarkAsUpdated(currentUserId);
     }

--- a/modules/back-end/src/Domain/Webhooks/WebhookDelivery.cs
+++ b/modules/back-end/src/Domain/Webhooks/WebhookDelivery.cs
@@ -65,4 +65,19 @@ public class WebhookDelivery : Entity
         Error = error;
         Success = false;
     }
+
+    public bool IsIgnored() => WebhookId == Guid.Empty;
+
+    public static WebhookDelivery Ignored(string reason, string url, string payload) =>
+        new(Guid.Empty, string.Empty)
+        {
+            Request = new
+            {
+                url,
+                headers = new { },
+                payload
+            },
+            Success = false,
+            Error = new { message = reason }
+        };
 }

--- a/modules/back-end/src/Domain/Webhooks/WebhookRequest.cs
+++ b/modules/back-end/src/Domain/Webhooks/WebhookRequest.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Domain.Webhooks;
 
 public class WebhookRequest
@@ -19,9 +17,8 @@ public class WebhookRequest
     public string Events { get; set; }
 
     public string Payload { get; set; }
-    
-    [JsonIgnore]
-    public bool? PreventEmptyPayloads { get; set; }
+
+    public bool PreventEmptyPayloads { get; set; }
 
     public WebhookRequest()
     {

--- a/modules/back-end/src/Domain/Webhooks/WebhookRequest.cs
+++ b/modules/back-end/src/Domain/Webhooks/WebhookRequest.cs
@@ -17,6 +17,8 @@ public class WebhookRequest
     public string Events { get; set; }
 
     public string Payload { get; set; }
+    
+    public bool PreventEmptyPayloads { get; set; }
 
     public WebhookRequest()
     {
@@ -36,5 +38,6 @@ public class WebhookRequest
         Headers = webhook.Headers;
         Events = events;
         Payload = payload;
+        PreventEmptyPayloads = webhook.PreventEmptyPayloads;
     }
 }

--- a/modules/back-end/src/Domain/Webhooks/WebhookRequest.cs
+++ b/modules/back-end/src/Domain/Webhooks/WebhookRequest.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Domain.Webhooks;
 
 public class WebhookRequest
@@ -18,7 +20,8 @@ public class WebhookRequest
 
     public string Payload { get; set; }
     
-    public bool PreventEmptyPayloads { get; set; }
+    [JsonIgnore]
+    public bool? PreventEmptyPayloads { get; set; }
 
     public WebhookRequest()
     {

--- a/modules/back-end/src/Infrastructure/Webhooks/WebhookSender.cs
+++ b/modules/back-end/src/Infrastructure/Webhooks/WebhookSender.cs
@@ -182,13 +182,15 @@ public partial class WebhookSender : IWebhookSender
     
     private async Task<WebhookDelivery> PreventEmptyPayload(Guid id, string events, Dictionary<string, object>? dataObject = null)
     {
-        var delivery = new WebhookDelivery(id,  events);
+        var delivery = new WebhookDelivery(id, events);
+        delivery.Started();
         var error = new
         {
             message = "Not allowed to send an empty object payload per webhook settings",
             dataObject = dataObject ?? new Dictionary<string, object>(),
         };
         delivery.SetError(error);
+        delivery.Ended();
         await AddDeliveryAsync(delivery);
         return delivery;
     }

--- a/modules/back-end/src/Infrastructure/Webhooks/WebhookSender.cs
+++ b/modules/back-end/src/Infrastructure/Webhooks/WebhookSender.cs
@@ -62,7 +62,7 @@ public partial class WebhookSender : IWebhookSender
                                    && !jsonDocument.RootElement.EnumerateObject().Any();
         if (shouldPreventPayload)
         {
-            return await PreventEmptyPayload(webhook.Id, events);
+            return await PreventEmptyPayload(webhook.Id, events, webhook.PayloadTemplate, dataObject);
         }
 
         var deliveryId = Guid.NewGuid().ToString("D");
@@ -187,7 +187,7 @@ public partial class WebhookSender : IWebhookSender
         return webhook.PreventEmptyPayloads;
     }
     
-    private async Task<WebhookDelivery> PreventEmptyPayload(Guid id, string events, Dictionary<string, object>? dataObject = null)
+    private async Task<WebhookDelivery> PreventEmptyPayload(Guid id, string events, string? payloadTemplate = default, Dictionary<string, object>? dataObject = default)
     {
         var delivery = new WebhookDelivery(id, events);
         delivery.Started();
@@ -195,6 +195,7 @@ public partial class WebhookSender : IWebhookSender
         {
             message = "Not allowed to send an empty object payload per webhook settings",
             dataObject = dataObject ?? new Dictionary<string, object>(),
+            payloadTempate = payloadTemplate ?? string.Empty,
         };
         delivery.SetError(error);
         delivery.Ended();

--- a/modules/front-end/src/app/core/components/test-webhook-modal/test-webhook-modal.component.ts
+++ b/modules/front-end/src/app/core/components/test-webhook-modal/test-webhook-modal.component.ts
@@ -54,7 +54,8 @@ export class TestWebhookModalComponent {
       secret: this.webhook.secret,
       headers: this.webhook.headers,
       events: this.event,
-      payload: payload
+      payload: payload,
+      preventEmptyPayloads: this.webhook.preventEmptyPayloads
     };
 
     this.sendSubscription = this.webhookService.send(request)

--- a/modules/front-end/src/app/core/components/webhook-drawer/webhook-drawer.component.html
+++ b/modules/front-end/src/app/core/components/webhook-drawer/webhook-drawer.component.html
@@ -176,6 +176,14 @@
         </nz-form-control>
       </nz-form-item>
 
+      <!-- Prevent Empty Payloads -->
+      <nz-form-item>
+        <label nz-checkbox formControlName="preventEmptyPayloads" i18n="@@integrations.webhooks.preventEmptyPayloads">Prevent Empty Payloads</label>
+        <nz-form-control>
+          <nz-form-text i18n="@@integrations.webhooks.preventEmptyPayloads-description">Prevents sending a request if the payload is an empty JSON object.</nz-form-text>
+        </nz-form-control>
+      </nz-form-item>
+
       <!-- Secret -->
       <nz-form-item>
         <nz-form-label i18n="@@integrations.webhooks.secret">Secret</nz-form-label>

--- a/modules/front-end/src/app/core/components/webhook-drawer/webhook-drawer.component.html
+++ b/modules/front-end/src/app/core/components/webhook-drawer/webhook-drawer.component.html
@@ -178,9 +178,9 @@
 
       <!-- Prevent Empty Payloads -->
       <nz-form-item>
-        <label nz-checkbox formControlName="preventEmptyPayloads" i18n="@@integrations.webhooks.preventEmptyPayloads">Prevent Empty Payloads</label>
+        <label nz-checkbox formControlName="preventEmptyPayloads" i18n="@@integrations.webhooks.prevent-empty-payloads">Prevent Empty Payloads</label>
         <nz-form-control>
-          <nz-form-text i18n="@@integrations.webhooks.preventEmptyPayloads-description">Prevents sending a request if the payload is an empty JSON object.</nz-form-text>
+          <nz-form-text i18n="@@integrations.webhooks.prevent-empty-payloads-description">Prevents sending a request if the payload is an empty JSON object.</nz-form-text>
         </nz-form-control>
       </nz-form-item>
 

--- a/modules/front-end/src/app/core/components/webhook-drawer/webhook-drawer.component.less
+++ b/modules/front-end/src/app/core/components/webhook-drawer/webhook-drawer.component.less
@@ -77,7 +77,6 @@
 }
 
 .select-payload-template {
-  margin-left: 10px;
   margin-bottom: 8px;
 
   .title {

--- a/modules/front-end/src/app/core/components/webhook-drawer/webhook-drawer.component.ts
+++ b/modules/front-end/src/app/core/components/webhook-drawer/webhook-drawer.component.ts
@@ -347,7 +347,7 @@ export class WebhookDrawerComponent implements OnInit {
   testWebhook: TestWebhook = null;
   testModalVisible: boolean = false;
   openTestModal() {
-    const { name, url, payloadTemplate, headers, secret } = this.form.value;
+    const { name, url, payloadTemplate, headers, secret, preventEmptyPayloads } = this.form.value;
     this.testWebhook = {
       id: uuidv4(),
       name,
@@ -356,7 +356,8 @@ export class WebhookDrawerComponent implements OnInit {
         .filter(header => header.key)
         .map(header => ({ key: header.key, value: header.value })),
       payloadTemplate,
-      secret
+      secret,
+      preventEmptyPayloads
     };
 
     this.testModalVisible = true;

--- a/modules/front-end/src/app/core/components/webhook-drawer/webhook-drawer.component.ts
+++ b/modules/front-end/src/app/core/components/webhook-drawer/webhook-drawer.component.ts
@@ -39,6 +39,7 @@ export class WebhookDrawerComponent implements OnInit {
     payloadTemplate: FormControl<string>;
     secret: FormControl<string>;
     isActive: FormControl<boolean>;
+    preventEmptyPayloads: FormControl<boolean>;
   }>;
 
   constructor(
@@ -85,7 +86,8 @@ export class WebhookDrawerComponent implements OnInit {
       payloadTemplateType: new FormControl(this._webhook?.payloadTemplateType ?? 'default'),
       payloadTemplate: new FormControl(this._webhook?.payloadTemplate ?? WebhookDefaultPayloadTemplate, [this.jsonHandlebarsTemplateValidator]),
       secret: new FormControl(this._webhook?.secret),
-      isActive: new FormControl(this._webhook?.isActive ?? true)
+      isActive: new FormControl(this._webhook?.isActive ?? true),
+      preventEmptyPayloads: new FormControl(this._webhook?.preventEmptyPayloads ?? false),
     });
 
     if (this._webhook) {
@@ -366,7 +368,7 @@ export class WebhookDrawerComponent implements OnInit {
   }
 
   doSubmit() {
-    const { name, url, scopes, events, headers, payloadTemplateType, payloadTemplate, secret, isActive } = this.form.value;
+    const { name, url, scopes, events, headers, payloadTemplateType, payloadTemplate, secret, isActive, preventEmptyPayloads } = this.form.value;
     const payload = {
       name,
       url,
@@ -380,7 +382,8 @@ export class WebhookDrawerComponent implements OnInit {
       payloadTemplateType,
       payloadTemplate,
       secret,
-      isActive
+      isActive,
+      preventEmptyPayloads,
     };
 
     let responseHandler = {

--- a/modules/front-end/src/app/features/safe/integrations/webhooks/webhooks.ts
+++ b/modules/front-end/src/app/features/safe/integrations/webhooks/webhooks.ts
@@ -161,7 +161,7 @@ export interface PagedWebhookDelivery {
   items: WebhookDelivery[];
 }
 
-export type TestWebhook = Pick<Webhook, 'id' | 'url' | 'name' | 'secret' | 'headers' | 'payloadTemplate'>;
+export type TestWebhook = Pick<Webhook, 'id' | 'url' | 'name' | 'secret' | 'headers' | 'payloadTemplate' | 'preventEmptyPayloads'>;
 
 export interface WebhookRequest {
   id: string;
@@ -172,4 +172,5 @@ export interface WebhookRequest {
   headers: { key: string; value: string; }[];
   events: string;
   payload: string;
+  preventEmptyPayloads: boolean;
 }

--- a/modules/front-end/src/app/features/safe/integrations/webhooks/webhooks.ts
+++ b/modules/front-end/src/app/features/safe/integrations/webhooks/webhooks.ts
@@ -12,6 +12,7 @@ export interface Webhook {
   payloadTemplateType: string;
   payloadTemplate: string;
   isActive: boolean;
+  preventEmptyPayloads: boolean;
   creator: SimpleUser;
   lastDelivery?: LastDelivery;
 }

--- a/modules/front-end/src/locale/messages.xlf
+++ b/modules/front-end/src/locale/messages.xlf
@@ -615,11 +615,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/test-webhook-modal/test-webhook-modal.component.ts</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">66</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">391</context>
+          <context context-type="linenumber">392</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/experiments/metrics/metrics.component.ts</context>
@@ -842,11 +842,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/test-webhook-modal/test-webhook-modal.component.ts</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">68</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">394</context>
+          <context context-type="linenumber">395</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/feature-flags/details/experimentation/experimentation.component.ts</context>
@@ -5390,14 +5390,14 @@
           <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="integrations.webhooks.preventEmptyPayloads" datatype="html">
+      <trans-unit id="integrations.webhooks.prevent-empty-payloads" datatype="html">
         <source>Prevent Empty Payloads</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
           <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="integrations.webhooks.preventEmptyPayloads-description" datatype="html">
+      <trans-unit id="integrations.webhooks.prevent-empty-payloads-description" datatype="html">
         <source>Prevents sending a request if the payload is an empty JSON object.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>

--- a/modules/front-end/src/locale/messages.xlf
+++ b/modules/front-end/src/locale/messages.xlf
@@ -455,7 +455,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">213</context>
+          <context context-type="linenumber">221</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/feature-flags/details/setting/setting.component.html</context>
@@ -619,7 +619,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">388</context>
+          <context context-type="linenumber">391</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/experiments/metrics/metrics.component.ts</context>
@@ -846,7 +846,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">391</context>
+          <context context-type="linenumber">394</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/feature-flags/details/experimentation/experimentation.component.ts</context>
@@ -908,7 +908,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/header/header.component.ts</context>
-          <context context-type="linenumber">165</context>
+          <context context-type="linenumber">171</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/prism/prism.component.ts</context>
@@ -2083,7 +2083,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/header/header.component.ts</context>
-          <context context-type="linenumber">126</context>
+          <context context-type="linenumber">132</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/metric-drawer/metric-drawer.component.ts</context>
@@ -5390,39 +5390,53 @@
           <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="integrations.webhooks.preventEmptyPayloads" datatype="html">
+        <source>Prevent Empty Payloads</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
+          <context context-type="linenumber">181</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="integrations.webhooks.preventEmptyPayloads-description" datatype="html">
+        <source>Prevents sending a request if the payload is an empty JSON object.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
+          <context context-type="linenumber">183</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="integrations.webhooks.secret" datatype="html">
         <source>Secret</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">181</context>
+          <context context-type="linenumber">189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="integrations.webhooks.secret-description" datatype="html">
         <source>Optionally, you can use a webhook secret to verify that a webhook delivery is from FeatBit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="integrations.webhooks.active" datatype="html">
         <source>Active</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">199</context>
         </context-group>
       </trans-unit>
       <trans-unit id="integrations.webhooks.active-description" datatype="html">
         <source>We will deliver event details when this hook is triggered.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.live-debug" datatype="html">
         <source>Live debug</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">199</context>
+          <context context-type="linenumber">207</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/integrations/webhooks/index/index.component.html</context>
@@ -5433,28 +5447,28 @@
         <source>Optionally, you can test your webhook configuration before saving it.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="integrations.webhooks.live-debug-webhook-configuration" datatype="html">
         <source>Live debug webhook configuration</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">205</context>
+          <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
       <trans-unit id="integrations.webhooks.webhook-drawer.edit-title" datatype="html">
         <source>Edit Webhook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">331</context>
+          <context context-type="linenumber">333</context>
         </context-group>
       </trans-unit>
       <trans-unit id="integrations.webhooks.webhook-drawer.add-title" datatype="html">
         <source>Add Webhook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">332</context>
+          <context context-type="linenumber">334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="permissions.no-permissions-to-visit-access-token-page" datatype="html">

--- a/modules/front-end/src/locale/messages.zh.xlf
+++ b/modules/front-end/src/locale/messages.zh.xlf
@@ -5819,7 +5819,7 @@
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
           <context context-type="linenumber">181</context>
         </context-group>
-        <target>阻止发送空的消息体负载</target>
+        <target>阻止发送空的消息体</target>
       </trans-unit>
       <trans-unit id="integrations.webhooks.prevent-empty-payloads-description" datatype="html">
         <source>Prevents sending a request if the payload is an empty JSON object.</source>
@@ -5827,7 +5827,7 @@
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
           <context context-type="linenumber">183</context>
         </context-group>
-        <target>消息体负载如果是空的 JSON 对象则不发送请求。</target>
+        <target>如果消息体是空的 JSON 对象，则不发送请求。</target>
       </trans-unit>
       <trans-unit id="integrations.webhooks.secret" datatype="html">
         <source>Secret</source>

--- a/modules/front-end/src/locale/messages.zh.xlf
+++ b/modules/front-end/src/locale/messages.zh.xlf
@@ -462,7 +462,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">213</context>
+          <context context-type="linenumber">221</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/feature-flags/details/setting/setting.component.html</context>
@@ -634,7 +634,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">388</context>
+          <context context-type="linenumber">391</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/experiments/metrics/metrics.component.ts</context>
@@ -862,7 +862,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">391</context>
+          <context context-type="linenumber">394</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/feature-flags/details/experimentation/experimentation.component.ts</context>
@@ -926,7 +926,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/header/header.component.ts</context>
-          <context context-type="linenumber">165</context>
+          <context context-type="linenumber">171</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/prism/prism.component.ts</context>
@@ -2206,7 +2206,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/header/header.component.ts</context>
-          <context context-type="linenumber">126</context>
+          <context context-type="linenumber">132</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/metric-drawer/metric-drawer.component.ts</context>
@@ -5813,11 +5813,27 @@
         </context-group>
         <target>用于生成 Webhook JSON 请求正文的 Handlebars 模板。</target>
       </trans-unit>
+      <trans-unit id="integrations.webhooks.preventEmptyPayloads" datatype="html">
+        <source>Prevent Empty Payloads</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
+          <context context-type="linenumber">181</context>
+        </context-group>
+        <target>防止空负载</target>
+      </trans-unit>
+      <trans-unit id="integrations.webhooks.preventEmptyPayloads-description" datatype="html">
+        <source>Prevents sending a request if the payload is an empty JSON object.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
+          <context context-type="linenumber">183</context>
+        </context-group>
+        <target>如果有效负载是空 JSON 对象，则阻止发送请求。</target>
+      </trans-unit>
       <trans-unit id="integrations.webhooks.secret" datatype="html">
         <source>Secret</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">181</context>
+          <context context-type="linenumber">189</context>
         </context-group>
         <target>秘钥</target>
       </trans-unit>
@@ -5825,7 +5841,7 @@
         <source>Optionally, you can use a webhook secret to verify that a webhook delivery is from FeatBit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">191</context>
         </context-group>
         <target>（可选）您可以使用改密钥来验证 Webhook 请求是否来自 FeatBit。</target>
       </trans-unit>
@@ -5833,7 +5849,7 @@
         <source>Active</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">199</context>
         </context-group>
         <target>是否启用</target>
       </trans-unit>
@@ -5841,7 +5857,7 @@
         <source>We will deliver event details when this hook is triggered.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">201</context>
         </context-group>
         <target>当触发此 Webhook 时，我们将提供事件详细信息。</target>
       </trans-unit>
@@ -5849,7 +5865,7 @@
         <source>Live debug</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">199</context>
+          <context context-type="linenumber">207</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/integrations/webhooks/index/index.component.html</context>
@@ -5861,7 +5877,7 @@
         <source>Optionally, you can test your webhook configuration before saving it.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">209</context>
         </context-group>
         <target>（可选）您可以在保存之前测试您的 Webhook 配置。</target>
       </trans-unit>
@@ -5869,7 +5885,7 @@
         <source>Live debug webhook configuration</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
-          <context context-type="linenumber">205</context>
+          <context context-type="linenumber">213</context>
         </context-group>
         <target>实时调试 webhook 配置</target>
       </trans-unit>
@@ -5877,7 +5893,7 @@
         <source>Edit Webhook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">331</context>
+          <context context-type="linenumber">333</context>
         </context-group>
         <target>编辑 Webhook</target>
       </trans-unit>
@@ -5885,7 +5901,7 @@
         <source>Add Webhook</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">332</context>
+          <context context-type="linenumber">334</context>
         </context-group>
         <target>添加 Webhook</target>
       </trans-unit>

--- a/modules/front-end/src/locale/messages.zh.xlf
+++ b/modules/front-end/src/locale/messages.zh.xlf
@@ -630,11 +630,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/test-webhook-modal/test-webhook-modal.component.ts</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">66</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">391</context>
+          <context context-type="linenumber">392</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/experiments/metrics/metrics.component.ts</context>
@@ -858,11 +858,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/test-webhook-modal/test-webhook-modal.component.ts</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">68</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.ts</context>
-          <context context-type="linenumber">394</context>
+          <context context-type="linenumber">395</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/feature-flags/details/experimentation/experimentation.component.ts</context>
@@ -5813,21 +5813,21 @@
         </context-group>
         <target>用于生成 Webhook JSON 请求正文的 Handlebars 模板。</target>
       </trans-unit>
-      <trans-unit id="integrations.webhooks.preventEmptyPayloads" datatype="html">
+      <trans-unit id="integrations.webhooks.prevent-empty-payloads" datatype="html">
         <source>Prevent Empty Payloads</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
           <context context-type="linenumber">181</context>
         </context-group>
-        <target>防止空负载</target>
+        <target>阻止发送空的消息体负载</target>
       </trans-unit>
-      <trans-unit id="integrations.webhooks.preventEmptyPayloads-description" datatype="html">
+      <trans-unit id="integrations.webhooks.prevent-empty-payloads-description" datatype="html">
         <source>Prevents sending a request if the payload is an empty JSON object.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/webhook-drawer/webhook-drawer.component.html</context>
           <context context-type="linenumber">183</context>
         </context-group>
-        <target>如果有效负载是空 JSON 对象，则阻止发送请求。</target>
+        <target>消息体负载如果是空的 JSON 对象则不发送请求。</target>
       </trans-unit>
       <trans-unit id="integrations.webhooks.secret" datatype="html">
         <source>Secret</source>


### PR DESCRIPTION
## Summary
Implemented optional prevention of empty webhook payloads as described in #678.

It seems that I cannot add the labels: UI, API

## Testing instructions:
- Create two feature flags in an environment/project scope
	- e.g. keys like `feature-flag-1` and `feature-flag-2`
- Create a webhook
	- Use a valid URL for an API you can verify is being hit or not
	- Use the same project/environment scope as the feature flags
	- Select only the "Toggled" Feature Flag event (though other events should also work)
	- Use a custom payload template that gives an non-empty request for one of the feature flag keys, e.g.:
```
{
    {{#eq data.object.key "feature-flag-1"}}
    "featureFlagKey": "{{ data.object.key }}"
    {{/eq}}
}
```
- Check the "Prevent empty payloads from being sent" checkbox
- Ensure that the Active checkbox is selected
- Save
- Test via Live Debug
	- Open the webhook's Live Debug feature
	- Select an appropriate event (e.g. feature flag toggle)
	- Click "Send test webhook"
	- Confirm that the webhook API did not receive any payload
	- An error response should be presented
	- The Response tab should indicate that the payload was not sent due to settings
	- This could be repeated if the payload template is edited to allow a non-empty response for the test payload's feature flag key of `test`, looking for successful behavior instead of failures
- Test via Feature Flag Toggle
	- Toggle the feature flag that will give an empty response per the template
	- Confirm that the webhook API did not receive a payload
	- Open the webhook's logs (More > View Logs)
	- Confirm that an error response is recorded
	- The Response tab should indicate that the payload was not sent due to settings
	- Repeat for the other feature flag that will give a non-empty response per the template
	- Expect it to give a successful log and API payload should be received

## Screenshots

### Webhook Edit

#### Before
![image](https://github.com/user-attachments/assets/4cd7a4fd-7ebc-4ff6-b0ef-8851abc44bd8)


#### After (Checkbox added, defaults to unchecked)
![image](https://github.com/user-attachments/assets/9ac7c5d2-8ee2-4e58-9ad9-af76d041cc5c)


### Live Debug Empty Payload

#### Before (all requests are always sent)
![image](https://github.com/user-attachments/assets/07fb983d-4943-48d3-900e-25877e20c916)

![image](https://github.com/user-attachments/assets/cdceaf8e-0240-4576-8f6f-cfd6a4baf099)


#### After (empty responses can be prevented)
![image](https://github.com/user-attachments/assets/c894840a-8cfc-45b7-b905-73f175cf34cb)


### Webhook Logs

#### After (Prevented payloads are recorded)
![image](https://github.com/user-attachments/assets/03b9df1b-45bf-455e-a589-5236f4316b67)


## Other
See further discussion in #678.

<!--
# Instructions

1. Pick a meaningful and result oriented title for your pull request. (Use sentence case, don't include any words indicating the way you achived this result, we just want the result. Keep it short < 70 characters)
  - Prefix the title with an emoji to categorize what is being done. (Copy-paste the emoji from the list below.)
  - Assign the appropriate label(s) to the pull request. (Use one of the labels from the list below.)
  
2. Enter a succinct description that says why the PR is necessary, and what it does.
  - Implement aspect X
  - Leave out feature Y because of A
  - Improve performance by B
  - Improve accessibility by C

3. Provide clear testing instructions that include any pertinent information, i.e. seat, roles, etc.
4. Include screenshots of your changes if they impact the UI (Before & After).
5. Update the preview link with your pull request number.
6. Include any JIRA tickets, design documents, GitHub issues, or other related items to the bottom of the PR.

# Available labels
UI
API
Evaluation Server
OLAP
