### PR TITLE
🐛 fix: postgres consumer doesn't use optional password

### DIFF
--- a/modules/evaluation-server/src/Infrastructure/MQ/Postgres/PostgresMessageConsumer.cs
+++ b/modules/evaluation-server/src/Infrastructure/MQ/Postgres/PostgresMessageConsumer.cs
@@ -70,7 +70,7 @@ public partial class PostgresMessageConsumer : BackgroundService
         IEnumerable<IMessageConsumer> handlers,
         ILogger<PostgresMessageConsumer> logger)
     {
-        var builder = new NpgsqlConnectionStringBuilder(configuration["Postgres:ConnectionString"]!)
+        var builder = new NpgsqlConnectionStringBuilder(configuration.GetPostgresConnectionString())
         {
             // override the default keepalive interval and application name
             KeepAlive = KeepAliveIntervalInSeconds,


### PR DESCRIPTION
fixed els postgres consumer will not use the optional password

related to #743 