### PR TITLE
🏗 infra: shutdown container gracefully

### DIFF
--- a/modules/back-end/start.sh
+++ b/modules/back-end/start.sh
@@ -28,4 +28,4 @@ if [ "$ENABLE_OPENTELEMETRY" = "true" ]; then
     export CORECLR_PROFILER_PATH="$INSTALL_DIR/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so"
 fi
 
-dotnet Api.dll
+exec dotnet Api.dll

--- a/modules/back-end/start.sh
+++ b/modules/back-end/start.sh
@@ -28,4 +28,6 @@ if [ "$ENABLE_OPENTELEMETRY" = "true" ]; then
     export CORECLR_PROFILER_PATH="$INSTALL_DIR/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so"
 fi
 
+# Use 'exec' to replace the shell process with the application process.
+# This ensures proper signal handling (e.g., SIGTERM) and graceful shutdown.
 exec dotnet Api.dll

--- a/modules/evaluation-server/start.sh
+++ b/modules/evaluation-server/start.sh
@@ -28,4 +28,4 @@ if [ "$ENABLE_OPENTELEMETRY" = "true" ]; then
     export CORECLR_PROFILER_PATH="$INSTALL_DIR/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so"
 fi
 
-dotnet Api.dll
+exec dotnet Api.dll

--- a/modules/evaluation-server/start.sh
+++ b/modules/evaluation-server/start.sh
@@ -28,4 +28,6 @@ if [ "$ENABLE_OPENTELEMETRY" = "true" ]; then
     export CORECLR_PROFILER_PATH="$INSTALL_DIR/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so"
 fi
 
+# Use 'exec' to replace the shell process with the application process.
+# This ensures proper signal handling (e.g., SIGTERM) and graceful shutdown.
 exec dotnet Api.dll


### PR DESCRIPTION
How to test

1. build the local images

    ```bash
    cd modules/back-end
    docker build --progress plain -f ./deploy/Dockerfile -t featbit/api:local .
    
    cd modules/evaluation-server
    docker build --progress plain -f ./deploy/Dockerfile -t featbit/evaluation-server:local .
    ```

2. create `docker-compose-local.yml` in `docker/composes` folder with the following content

    ```yml
    name: featbit-local
    services:
      api-server:
        image: featbit/api:local
        container_name: api-local
        build:
          context: ./modules/back-end
          dockerfile: ./deploy/Dockerfile
        environment:
          - SSOEnabled=true
          - DbProvider=Postgres
          - MqProvider=Redis
          - CacheProvider=Redis
          - Postgres__ConnectionString=Host=postgresql;Port=5432;Username=postgres;Password=please_change_me;Database=featbit
        depends_on:
          - postgresql
          - redis
        ports:
          - "5000:5000"
        networks:
          - featbit-network
            
      api-server-1:
        image: featbit/featbit-api-server:5.0.2
        container_name: api-latest
        environment:
          - SSOEnabled=true
          - DbProvider=Postgres
          - MqProvider=Redis
          - CacheProvider=Redis
          - Postgres__ConnectionString=Host=postgresql;Port=5432;Username=postgres;Password=please_change_me;Database=featbit
        depends_on:
          - postgresql
          - redis
        ports:
          - "5001:5000"
        networks:
          - featbit-network
    
      evaluation-server:
        image: featbit/evaluation-server:local
        container_name: evaluation-server-local
        build:
          context: ./modules/evaluation-server
          dockerfile: ./deploy/Dockerfile
        environment:
          - DbProvider=Postgres
          - MqProvider=Redis
          - CacheProvider=Redis
          - Postgres__ConnectionString=Host=postgresql;Port=5432;Username=postgres;Password=please_change_me;Database=featbit
        depends_on:
          - postgresql
          - redis
        ports:
          - "5100:5100"
        networks:
          - featbit-network
      
      evaluation-server-1:
        image: featbit/featbit-evaluation-server:5.0.2
        container_name: evaluation-server-latest
        environment:
          - DbProvider=Postgres
          - MqProvider=Redis
          - CacheProvider=Redis
          - Postgres__ConnectionString=Host=postgresql;Port=5432;Username=postgres;Password=please_change_me;Database=featbit
        depends_on:
          - postgresql
          - redis
        ports:
          - "5101:5100"
        networks:
          - featbit-network
    
      postgresql:
        image: postgres:15.10
        container_name: postgresql
        restart: on-failure
        ports:
          - "5432:5432"
        environment:
          POSTGRES_USER: postgres
          POSTGRES_PASSWORD: please_change_me
        volumes:
          - ./infra/postgresql/docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d/
          - postgres:/var/lib/postgresql/data
        networks:
          - featbit-network
    
      redis:
        image: bitnami/redis:6.2.10
        container_name: redis
        restart: on-failure
        environment:
          - ALLOW_EMPTY_PASSWORD=yes
        networks:
          - featbit-network
        ports:
          - "6379:6379"
        volumes:
          - redis:/bitnami/redis/data
    
    networks:
      featbit-network:
        name: featbit-network
        driver: bridge
        ipam:
          config:
            - subnet: 172.1.0.0/16
    
    volumes:
      redis:
      postgres:
    
    ```
    
3. run the yml and check services readiness status

    ```
    cd featbit
    docker compose --project-directory . -f .\docker\composes\docker-compose-local.yml up -d
    
    curl -v http://localhost:5000/health/readiness
    curl -v http://localhost:5001/health/readiness
    
    curl -v http://localhost:5100/health/readiness
    curl -v http://localhost:5101/health/readiness
    ```

4. Shut down services and you should be able to see the following result

    ```bash
    docker compose --project-directory . -f .\docker\composes\docker-compose-local.yml down
    ```

    ![image](https://github.com/user-attachments/assets/ca238fa5-602e-4eb3-9569-412f45d2cd24)

We can see that `api-local` and `evaluation-server-local` shutdown quickly and gracefully, while the latest version took 10 seconds to shutdown (Docker has a default 10-second timeout when stopping containers).