### PR TITLE
✨ feat: protect workspace with IAM permissions

### DIFF
--- a/infra/mongodb/docker-entrypoint-initdb.d/init.js
+++ b/infra/mongodb/docker-entrypoint-initdb.d/init.js
@@ -121,6 +121,27 @@ db.Policies.insertOne(
         statements: [
             {
                 _id: getUUIDString(),
+                resourceType: "workspace",
+                effect: "allow",
+                actions: ["UpdateWorkspaceGeneralSettings"],
+                resources: ["workspace/*"]
+            },
+			{
+                _id: getUUIDString(),
+                resourceType: "workspace",
+                effect: "allow",
+                actions: ["UpdateWorkspaceLicense"],
+                resources: ["workspace/*"]
+            },
+			{
+                _id: getUUIDString(),
+                resourceType: "workspace",
+                effect: "allow",
+                actions: ["UpdateWorkspaceSSOSettings"],
+                resources: ["workspace/*"]
+            },
+            {
+                _id: getUUIDString(),
                 resourceType: "organization",
                 effect: "allow",
                 actions: ["UpdateOrgName"],

--- a/infra/mongodb/docker-entrypoint-initdb.d/init.js
+++ b/infra/mongodb/docker-entrypoint-initdb.d/init.js
@@ -123,21 +123,11 @@ db.Policies.insertOne(
                 _id: getUUIDString(),
                 resourceType: "workspace",
                 effect: "allow",
-                actions: ["UpdateWorkspaceGeneralSettings"],
-                resources: ["workspace/*"]
-            },
-			{
-                _id: getUUIDString(),
-                resourceType: "workspace",
-                effect: "allow",
-                actions: ["UpdateWorkspaceLicense"],
-                resources: ["workspace/*"]
-            },
-			{
-                _id: getUUIDString(),
-                resourceType: "workspace",
-                effect: "allow",
-                actions: ["UpdateWorkspaceSSOSettings"],
+                actions: [
+                    "UpdateWorkspaceGeneralSettings",
+                    "UpdateWorkspaceLicense",
+                    "UpdateWorkspaceSSOSettings"
+				],
                 resources: ["workspace/*"]
             },
             {

--- a/infra/mongodb/docker-entrypoint-initdb.d/init.js
+++ b/infra/mongodb/docker-entrypoint-initdb.d/init.js
@@ -127,7 +127,7 @@ db.Policies.insertOne(
                     "UpdateWorkspaceGeneralSettings",
                     "UpdateWorkspaceLicense",
                     "UpdateWorkspaceSSOSettings"
-				],
+                ],
                 resources: ["workspace/*"]
             },
             {

--- a/infra/mongodb/docker-entrypoint-initdb.d/init.js
+++ b/infra/mongodb/docker-entrypoint-initdb.d/init.js
@@ -121,17 +121,6 @@ db.Policies.insertOne(
         statements: [
             {
                 _id: getUUIDString(),
-                resourceType: "workspace",
-                effect: "allow",
-                actions: [
-                    "UpdateWorkspaceGeneralSettings",
-                    "UpdateWorkspaceLicense",
-                    "UpdateWorkspaceSSOSettings"
-                ],
-                resources: ["workspace/*"]
-            },
-            {
-                _id: getUUIDString(),
                 resourceType: "organization",
                 effect: "allow",
                 actions: ["UpdateOrgName"],

--- a/infra/postgresql/docker-entrypoint-initdb.d/c_seed_data.sql
+++ b/infra/postgresql/docker-entrypoint-initdb.d/c_seed_data.sql
@@ -63,21 +63,7 @@ VALUES
                      'id', gen_random_uuid(),
                      'resourceType', 'workspace',
                      'effect', 'allow',
-                     'actions', ARRAY['UpdateWorkspaceGeneralSettings'],
-                     'resources', ARRAY['workspace/*']
-             ),
-            jsonb_build_object(
-                     'id', gen_random_uuid(),
-                     'resourceType', 'workspace',
-                     'effect', 'allow',
-                     'actions', ARRAY['UpdateWorkspaceLicense'],
-                     'resources', ARRAY['workspace/*']
-             ),
-            jsonb_build_object(
-                     'id', gen_random_uuid(),
-                     'resourceType', 'workspace',
-                     'effect', 'allow',
-                     'actions', ARRAY['UpdateWorkspaceSSOSettings'],
+                     'actions', ARRAY['UpdateWorkspaceGeneralSettings', 'UpdateWorkspaceLicense', 'UpdateWorkspaceSSOSettings'],
                      'resources', ARRAY['workspace/*']
              ),
              jsonb_build_object(

--- a/infra/postgresql/docker-entrypoint-initdb.d/c_seed_data.sql
+++ b/infra/postgresql/docker-entrypoint-initdb.d/c_seed_data.sql
@@ -59,6 +59,27 @@ VALUES
      'Contains all the permissions required by an administrator',
      'SysManaged',
      jsonb_build_array(
+            jsonb_build_object(
+                     'id', gen_random_uuid(),
+                     'resourceType', 'workspace',
+                     'effect', 'allow',
+                     'actions', ARRAY['UpdateWorkspaceGeneralSettings'],
+                     'resources', ARRAY['workspace/*']
+             ),
+            jsonb_build_object(
+                     'id', gen_random_uuid(),
+                     'resourceType', 'workspace',
+                     'effect', 'allow',
+                     'actions', ARRAY['UpdateWorkspaceLicense'],
+                     'resources', ARRAY['workspace/*']
+             ),
+            jsonb_build_object(
+                     'id', gen_random_uuid(),
+                     'resourceType', 'workspace',
+                     'effect', 'allow',
+                     'actions', ARRAY['UpdateWorkspaceSSOSettings'],
+                     'resources', ARRAY['workspace/*']
+             ),
              jsonb_build_object(
                      'id', gen_random_uuid(),
                      'resourceType', 'organization',

--- a/infra/postgresql/docker-entrypoint-initdb.d/c_seed_data.sql
+++ b/infra/postgresql/docker-entrypoint-initdb.d/c_seed_data.sql
@@ -59,13 +59,6 @@ VALUES
      'Contains all the permissions required by an administrator',
      'SysManaged',
      jsonb_build_array(
-            jsonb_build_object(
-                     'id', gen_random_uuid(),
-                     'resourceType', 'workspace',
-                     'effect', 'allow',
-                     'actions', ARRAY['UpdateWorkspaceGeneralSettings', 'UpdateWorkspaceLicense', 'UpdateWorkspaceSSOSettings'],
-                     'resources', ARRAY['workspace/*']
-             ),
              jsonb_build_object(
                      'id', gen_random_uuid(),
                      'resourceType', 'organization',

--- a/modules/back-end/src/Domain/Resources/Resource.cs
+++ b/modules/back-end/src/Domain/Resources/Resource.cs
@@ -18,6 +18,14 @@ public class Resource
         Type = ResourceTypes.All
     };
 
+    public static readonly Resource Workspace = new()
+    {
+        Id = new Guid("5208c66b-ae1e-4985-a253-9250f02f354d"),
+        Name = "workspace",
+        Rn = "workspace/*",
+        Type = ResourceTypes.Workspace
+    };
+    
     public static readonly Resource AllOrganizations = new()
     {
         Id = new Guid("e394832e-bd98-43de-b174-e0c98e03d19d"),

--- a/modules/back-end/src/Domain/Resources/ResourceTypes.cs
+++ b/modules/back-end/src/Domain/Resources/ResourceTypes.cs
@@ -4,6 +4,8 @@ public static class ResourceTypes
 {
     public const string All = "*";
 
+    public const string Workspace = "workspace";
+    
     public const string Organization = "organization";
 
     public const string Iam = "iam";

--- a/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/ResourceService.cs
+++ b/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/ResourceService.cs
@@ -18,6 +18,7 @@ public class ResourceService(AppDbContext dbContext) : IResourceService
         return filter.Type switch
         {
             ResourceTypes.All => new[] { Resource.All },
+            ResourceTypes.Workspace => new[] { Resource.Workspace },
             ResourceTypes.Organization => new[] { Resource.AllOrganizations },
             ResourceTypes.Iam => new[] { Resource.AllIam },
             ResourceTypes.AccessToken => new[] { Resource.AllAccessToken },

--- a/modules/back-end/src/Infrastructure/Services/MongoDb/ResourceService.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/ResourceService.cs
@@ -17,6 +17,7 @@ public class ResourceService(MongoDbClient mongoDb) : IResourceService
         return filter.Type switch
         {
             ResourceTypes.All => new[] { Resource.All },
+            ResourceTypes.Workspace => new[] { Resource.Workspace },
             ResourceTypes.Organization => new[] { Resource.AllOrganizations },
             ResourceTypes.Iam => new[] { Resource.AllIam },
             ResourceTypes.AccessToken => new[] { Resource.AllAccessToken },

--- a/modules/front-end/src/app/features/safe/workspaces/workspace/workspace.component.html
+++ b/modules/front-end/src/app/features/safe/workspaces/workspace/workspace.component.html
@@ -28,55 +28,57 @@
         </ng-template>
       </nz-form-control>
     </nz-form-item>
-    <button nz-button class="name-key-btn" nzType="primary" [nzLoading]="isNameKeyLoading">
+    <button nz-button class="name-key-btn" nzType="primary" [nzLoading]="isNameKeyLoading" [disabled]="!canUpdateGeneralSettings">
       <i nz-icon nzType="icons:icon-sync"></i>
       <ng-container i18n="@@common.update">Update</ng-container>
     </button>
   </form>
 </div>
-<div class="standard-div rows" *ngIf="!isLoading; else loadingTem;">
-  <h5 nz-typography i18n="@@common.license-settings">License settings</h5>
-  <div class="row">
-    <div class="row-title">
-      <span i18n="@@common.id">Id</span>
-      <i nz-icon i18n-nz-tooltip="@@common.workspace-id-copy-hint" nz-tooltip="You will need to provide this Id to generate the license, please contact us to get a license." nzType="icons:icon-info-outline"></i>
-    </div>
-    <div class="row-content">
-      <nz-form-item class="extend">
-        <nz-input-group class="row-input-group" [nzPrefix]="idIcon">
-          <input disabled type="text" nz-input [ngModel]="workspace?.id" placeholder="License" i18n-placeholder="@@common.license"/>
-          <ng-template #idIcon>
-            <i nz-icon nzType="icons:icon-id"></i>
-          </ng-template>
-        </nz-input-group>
-      </nz-form-item>
-      <button nz-button class="copy-id-btn" nzType="primary" (click)="copyText(workspace?.id)">
-        <i nz-icon nzType="icons:icon-copy"></i>
-        <ng-container i18n="@@common.copy">Copy</ng-container>
-      </button>
-    </div>
-  </div>
-  <div class="row">
-    <div class="row-title" i18n="@@common.license">License</div>
-    <form class="row-content" nz-form [formGroup]="licenseForm" [nzLayout]="'inline'" (ngSubmit)="updateLicense()">
-      <nz-form-item class="extend">
-        <nz-form-control nzErrorTip="License is mandatory!" i18n-nzErrorTip="@@common.license-mandatory">
-          <nz-input-group class="row-input-group" [nzPrefix]="licenseIcon">
-            <input type="text" nz-input formControlName="license" placeholder="License" i18n-placeholder="@@common.license"/>
-            <ng-template #licenseIcon>
-              <i nz-icon nzType="icons:icon-license"></i>
+<ng-container *ngIf="canUpdateLicense">
+  <div class="standard-div rows" *ngIf="!isLoading; else loadingTem;">
+    <h5 nz-typography i18n="@@common.license-settings">License settings</h5>
+    <div class="row">
+      <div class="row-title">
+        <span i18n="@@common.id">Id</span>
+        <i nz-icon i18n-nz-tooltip="@@common.workspace-id-copy-hint" nz-tooltip="You will need to provide this Id to generate the license, please contact us to get a license." nzType="icons:icon-info-outline"></i>
+      </div>
+      <div class="row-content">
+        <nz-form-item class="extend">
+          <nz-input-group class="row-input-group" [nzPrefix]="idIcon">
+            <input disabled type="text" nz-input [ngModel]="workspace?.id" placeholder="License" i18n-placeholder="@@common.license"/>
+            <ng-template #idIcon>
+              <i nz-icon nzType="icons:icon-id"></i>
             </ng-template>
           </nz-input-group>
-        </nz-form-control>
-      </nz-form-item>
-      <button nz-button class="update-license-btn" nzType="primary" [nzLoading]="isLicenseLoading">
-        <i nz-icon nzType="icons:icon-sync"></i>
-        <ng-container i18n="@@common.updateLicense">Update</ng-container>
-      </button>
-    </form>
+        </nz-form-item>
+        <button nz-button class="copy-id-btn" nzType="primary" (click)="copyText(workspace?.id)">
+          <i nz-icon nzType="icons:icon-copy"></i>
+          <ng-container i18n="@@common.copy">Copy</ng-container>
+        </button>
+      </div>
+    </div>
+    <div class="row">
+      <div class="row-title" i18n="@@common.license">License</div>
+      <form class="row-content" nz-form [formGroup]="licenseForm" [nzLayout]="'inline'" (ngSubmit)="updateLicense()">
+        <nz-form-item class="extend">
+          <nz-form-control nzErrorTip="License is mandatory!" i18n-nzErrorTip="@@common.license-mandatory">
+            <nz-input-group class="row-input-group" [nzPrefix]="licenseIcon">
+              <input type="text" nz-input formControlName="license" placeholder="License" i18n-placeholder="@@common.license"/>
+              <ng-template #licenseIcon>
+                <i nz-icon nzType="icons:icon-license"></i>
+              </ng-template>
+            </nz-input-group>
+          </nz-form-control>
+        </nz-form-item>
+        <button nz-button class="update-license-btn" nzType="primary" [nzLoading]="isLicenseLoading">
+          <i nz-icon nzType="icons:icon-sync"></i>
+          <ng-container i18n="@@common.updateLicense">Update</ng-container>
+        </button>
+      </form>
+    </div>
   </div>
-</div>
-<ng-container *ngIf="isSsoGranted">
+</ng-container>
+<ng-container *ngIf="canUpdateSSOSettings && isSsoGranted">
   <div class="standard-div rows" *ngIf="!isLoading; else loadingTem;">
     <h5 nz-typography i18n="@@common.sso-settings">SSO (OIDC) settings</h5>
     <form nz-form [formGroup]="ssoForm" [nzLayout]="'vertical'" (ngSubmit)="updateOidcSetting()">

--- a/modules/front-end/src/app/features/safe/workspaces/workspace/workspace.component.ts
+++ b/modules/front-end/src/app/features/safe/workspaces/workspace/workspace.component.ts
@@ -6,6 +6,8 @@ import { IWorkspace, License, LicenseFeatureEnum } from '@shared/types';
 import { MessageQueueService } from '@core/services/message-queue.service';
 import { WorkspaceService } from "@services/workspace.service";
 import { debounceTime, first, map, switchMap } from "rxjs/operators";
+import { generalResourceRNPattern, permissionActions } from "@shared/policy";
+import { PermissionsService } from "@services/permissions.service";
 
 @Component({
   selector: 'workspace',
@@ -18,6 +20,10 @@ export class WorkspaceComponent implements OnInit {
   nameKeyForm!: FormGroup;
   ssoForm!: FormGroup;
   licenseForm!: FormGroup;
+
+  canUpdateGeneralSettings: boolean = false;
+  canUpdateLicense: boolean = false;
+  canUpdateSSOSettings: boolean = false;
 
   isSsoGranted: boolean = false;
 
@@ -32,6 +38,7 @@ export class WorkspaceComponent implements OnInit {
   constructor(
     private messageQueueService: MessageQueueService,
     private workspaceService: WorkspaceService,
+    private permissionsService: PermissionsService,
     private message: NzMessageService
   ) { }
 
@@ -41,6 +48,11 @@ export class WorkspaceComponent implements OnInit {
     this.workspace = workspace;
     this.license = new License(workspace.license);
     this.isSsoGranted = this.license.isGranted(LicenseFeatureEnum.Sso);
+
+    this.canUpdateGeneralSettings = this.permissionsService.isGranted(generalResourceRNPattern.workspace, permissionActions.UpdateWorkspaceGeneralSettings);
+    this.canUpdateLicense = this.permissionsService.isGranted(generalResourceRNPattern.workspace, permissionActions.UpdateWorkspaceLicense);
+    this.canUpdateSSOSettings = this.permissionsService.isGranted(generalResourceRNPattern.workspace, permissionActions.UpdateWorkspaceSSOSettings);
+
     this.initForm();
     this.isLoading = false;
   }

--- a/modules/front-end/src/app/shared/policy.ts
+++ b/modules/front-end/src/app/shared/policy.ts
@@ -107,7 +107,7 @@ export const ResourceTypeAll: ResourceType = {
 
 export const ResourceTypeWorkspace: ResourceType = {
   type: ResourceTypeEnum.workspace,
-  pattern: generalResourceRNPattern.organization,
+  pattern: generalResourceRNPattern.workspace,
   displayName: $localize`:@@iam.rsc-type.workspace:Workspace`
 };
 

--- a/modules/front-end/src/app/shared/policy.ts
+++ b/modules/front-end/src/app/shared/policy.ts
@@ -51,6 +51,7 @@ export interface IamPolicyAction {
 
 export enum ResourceTypeEnum {
   All = '*',
+  workspace = 'workspace',
   organization = 'organization',
   IAM = 'iam',
   AccessToken = 'access-token',
@@ -85,6 +86,7 @@ export interface RNViewModel {
 
 export const generalResourceRNPattern = {
   all: '*',
+  workspace: 'workspace/*',
   organization: 'organization/*',
   iam: 'iam/*',
   accessToken: 'access-token/*',
@@ -101,6 +103,12 @@ export const ResourceTypeAll: ResourceType = {
   type: ResourceTypeEnum.All,
   pattern: generalResourceRNPattern.all,
   displayName: $localize`:@@iam.rsc-type.all:All`
+};
+
+export const ResourceTypeWorkspace: ResourceType = {
+  type: ResourceTypeEnum.workspace,
+  pattern: generalResourceRNPattern.organization,
+  displayName: $localize`:@@iam.rsc-type.workspace:Workspace`
 };
 
 export const ResourceTypeOrganization: ResourceType = {
@@ -153,6 +161,7 @@ export const ResourceTypeSegment = {
 
 export const resourcesTypes: ResourceType[] = [
   ResourceTypeAll,
+  ResourceTypeWorkspace,
   ResourceTypeOrganization,
   ResourceTypeIAM,
   ResourceTypeAccessToken,
@@ -173,6 +182,7 @@ export interface ResourceParamViewModel {
 
 export const rscParamsDict: { [key in ResourceTypeEnum]: ResourceParamViewModel[] } = {
   [ResourceTypeEnum.All]: [],
+  [ResourceTypeEnum.workspace]: [],
   [ResourceTypeEnum.organization]: [],
   [ResourceTypeEnum.IAM]: [],
   [ResourceTypeEnum.AccessToken]: [],
@@ -347,6 +357,35 @@ export const permissionActions: { [key: string]: IamPolicyAction } = {
     isSpecificApplicable: false
   },
 
+  // workspace
+  UpdateWorkspaceGeneralSettings: {
+    id: uuidv4(),
+    name: 'UpdateWorkspaceGeneralSettings',
+    resourceType: ResourceTypeEnum.workspace,
+    displayName: $localize`:@@iam.action.update-ws-general:Update workspace general settings`,
+    description: $localize`:@@iam.action.update-ws-general:Update workspace general settings`,
+    isOpenAPIApplicable: false,
+    isSpecificApplicable: false
+  },
+  UpdateWorkspaceLicense: {
+    id: uuidv4(),
+    name: 'UpdateWorkspaceLicense',
+    resourceType: ResourceTypeEnum.workspace,
+    displayName: $localize`:@@iam.action.update-ws-license:Update workspace license`,
+    description: $localize`:@@iam.action.update-ws-license:Update workspace license`,
+    isOpenAPIApplicable: false,
+    isSpecificApplicable: false
+  },
+  UpdateWorkspaceSSOSettings: {
+    id: uuidv4(),
+    name: 'UpdateWorkspaceSSOSettings',
+    resourceType: ResourceTypeEnum.workspace,
+    displayName: $localize`:@@iam.action.update-ws-sso:Update workspace SSO settings`,
+    description: $localize`:@@iam.action.update-ws-sso:Update workspace SSO settings`,
+    isOpenAPIApplicable: false,
+    isSpecificApplicable: false
+  },
+
   // org
   UpdateOrgName: {
     id: uuidv4(),
@@ -357,7 +396,6 @@ export const permissionActions: { [key: string]: IamPolicyAction } = {
     isOpenAPIApplicable: false,
     isSpecificApplicable: false
   },
-
   UpdateOrgDefaultUserPermissions: {
     id: uuidv4(),
     name: 'UpdateOrgDefaultUserPermissions',
@@ -433,7 +471,7 @@ export const permissionActions: { [key: string]: IamPolicyAction } = {
 // if returns false, that means the actions which cannot be applied to a specific resource should be hidden
 // ex: CreateProject should not be available for a specific project: project/abc
 export function isResourceGeneral(type: ResourceTypeEnum, rn: string): boolean {
-  const generalResourceTypes = [ResourceTypeEnum.All, ResourceTypeEnum.organization, ResourceTypeEnum.IAM, ResourceTypeEnum.AccessToken, ResourceTypeEnum.RelayProxy];
+  const generalResourceTypes = [ResourceTypeEnum.All, ResourceTypeEnum.workspace, ResourceTypeEnum.organization, ResourceTypeEnum.IAM, ResourceTypeEnum.AccessToken, ResourceTypeEnum.RelayProxy];
   if (generalResourceTypes.includes(type)) {
     return true;
   }

--- a/modules/front-end/src/locale/messages.xlf
+++ b/modules/front-end/src/locale/messages.xlf
@@ -831,11 +831,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.ts</context>
-          <context context-type="linenumber">111</context>
+          <context context-type="linenumber">123</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.ts</context>
-          <context context-type="linenumber">138</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.operation-failed-try-again" datatype="html">
@@ -1004,7 +1004,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.ts</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="auditlogs.operation-create" datatype="html">
@@ -4721,7 +4721,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">498</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.agents" datatype="html">
@@ -7875,7 +7875,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.policies.details.resource-type" datatype="html">
@@ -8897,7 +8897,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">466</context>
+          <context context-type="linenumber">504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="segment.permanent-remove-msg" datatype="html">
@@ -9052,7 +9052,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="org.org.orgDefaultPermissionsUpdateSuccess" datatype="html">
@@ -9322,197 +9322,197 @@
         <source>License settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.id" datatype="html">
         <source>Id</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.workspace-id-copy-hint" datatype="html">
         <source>You will need to provide this Id to generate the license, please contact us to get a license.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.license" datatype="html">
         <source>License</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">48</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">61</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.license-mandatory" datatype="html">
         <source>License is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">64</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.updateLicense" datatype="html">
         <source>Update</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.sso-settings" datatype="html">
         <source>SSO (OIDC) settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.client-id" datatype="html">
         <source>Client Id</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">86</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">88</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.client-id-mandatory" datatype="html">
         <source>Client Id is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.client-secret" datatype="html">
         <source>Client secret</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">92</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">92</context>
+          <context context-type="linenumber">94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.client-secret-mandatory" datatype="html">
         <source>Client secret is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.token-endpoint" datatype="html">
         <source>Token endpoint</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">98</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.token-endpoint-mandatory" datatype="html">
         <source>Token endpoint is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">97</context>
+          <context context-type="linenumber">99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.client-authentication-method" datatype="html">
         <source>Client authentication method</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">104</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">104</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.client-authentication-method-mandatory" datatype="html">
         <source>Client authentication method is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.authorization-endpoint" datatype="html">
         <source>Authorization endpoint</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">108</context>
+          <context context-type="linenumber">110</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.authorization-endpoint-mandatory" datatype="html">
         <source>Authorization endpoint is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.scope" datatype="html">
         <source>Scope</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">114</context>
+          <context context-type="linenumber">116</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">118</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.scope-mandatory" datatype="html">
         <source>Scope is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.user-email-claim" datatype="html">
         <source>User email claim</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">122</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.workspace.user-email-claim-mandatory" datatype="html">
         <source>User email claim is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="org.org.license-update-success" datatype="html">
         <source>License updated!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.ts</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="org.org.invalid-license" datatype="html">
         <source>Invalid license, please contact FeatBit team to get a license!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.ts</context>
-          <context context-type="linenumber">168</context>
+          <context context-type="linenumber">180</context>
         </context-group>
       </trans-unit>
       <trans-unit id="workspace.routing.org" datatype="html">
@@ -9586,250 +9586,246 @@
         <source>All</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">105</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="iam.rsc-type.workspace" datatype="html">
+        <source>Workspace</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.rsc-type.organization" datatype="html">
         <source>Organization</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.rsc-type.iam" datatype="html">
         <source>IAM</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.rsc-type.access-token" datatype="html">
         <source>Access token</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.rsc-type.relay-proxy" datatype="html">
         <source>Relay proxy</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">135</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.rsc-type.project" datatype="html">
         <source>Project</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.rsc-type.env" datatype="html">
         <source>Environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">139</context>
+          <context context-type="linenumber">147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.rsc-type.feature-flag" datatype="html">
         <source>Feature flag</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.rsc-type.segment" datatype="html">
         <source>Segment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">151</context>
+          <context context-type="linenumber">159</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.policy.project" datatype="html">
         <source>Project</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">196</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.policy.environment" datatype="html">
         <source>Environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.all" datatype="html">
         <source>All</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">223</context>
+          <context context-type="linenumber">233</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">224</context>
+          <context context-type="linenumber">234</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.can-access-project" datatype="html">
         <source>Can access project</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">232</context>
+          <context context-type="linenumber">242</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">233</context>
+          <context context-type="linenumber">243</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.create-projects" datatype="html">
         <source>Create projects</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">241</context>
+          <context context-type="linenumber">251</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">242</context>
+          <context context-type="linenumber">252</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.delete-projects" datatype="html">
         <source>Delete projects</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">250</context>
+          <context context-type="linenumber">260</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">251</context>
+          <context context-type="linenumber">261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.update-project-settings" datatype="html">
         <source>Update project settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">259</context>
+          <context context-type="linenumber">269</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">260</context>
+          <context context-type="linenumber">270</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.create-env" datatype="html">
         <source>Create environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">268</context>
+          <context context-type="linenumber">278</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">269</context>
+          <context context-type="linenumber">279</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.can-access-env" datatype="html">
         <source>Can access environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">277</context>
+          <context context-type="linenumber">287</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">278</context>
+          <context context-type="linenumber">288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.delete-envs" datatype="html">
         <source>Delete environments</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">286</context>
+          <context context-type="linenumber">296</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">287</context>
+          <context context-type="linenumber">297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.update-env-settings" datatype="html">
         <source>Update environment settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">295</context>
+          <context context-type="linenumber">305</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">296</context>
+          <context context-type="linenumber">306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.delete-env-secret" datatype="html">
         <source>Delete environment secret</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">304</context>
+          <context context-type="linenumber">314</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">305</context>
+          <context context-type="linenumber">315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.create-env-secret" datatype="html">
         <source>Create environment secret</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">313</context>
+          <context context-type="linenumber">323</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">314</context>
+          <context context-type="linenumber">324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.update-env-secret" datatype="html">
         <source>Update environment secret</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">322</context>
+          <context context-type="linenumber">332</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">323</context>
+          <context context-type="linenumber">333</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.manage-feature-flag" datatype="html">
         <source>Manage feature flag</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">333</context>
+          <context context-type="linenumber">343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">334</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.manage-segment" datatype="html">
         <source>Manage segment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">344</context>
+          <context context-type="linenumber">354</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">345</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="iam.action.update-org-name" datatype="html">
-        <source>Update org name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
           <context context-type="linenumber">355</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">356</context>
-        </context-group>
       </trans-unit>
-      <trans-unit id="iam.action.update-org-default-user-permissions" datatype="html">
-        <source>Update org default user permissions</source>
+      <trans-unit id="iam.action.update-ws-general" datatype="html">
+        <source>Update workspace general settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
           <context context-type="linenumber">365</context>
@@ -9839,63 +9835,63 @@
           <context context-type="linenumber">366</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="iam.action.update-ws-license" datatype="html">
+        <source>Update workspace license</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">374</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">375</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="iam.action.update-ws-sso" datatype="html">
+        <source>Update workspace SSO settings</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">383</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">384</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="iam.action.update-org-name" datatype="html">
+        <source>Update org name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">394</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">395</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="iam.action.update-org-default-user-permissions" datatype="html">
+        <source>Update org default user permissions</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">403</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">404</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="iam.action.iam" datatype="html">
         <source>IAM</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">376</context>
+          <context context-type="linenumber">414</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">377</context>
+          <context context-type="linenumber">415</context>
         </context-group>
       </trans-unit>
       <trans-unit id="iam.action.list-access-tokens" datatype="html">
         <source>List access tokens</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">387</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">388</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="iam.action.manage-service-access-tokens" datatype="html">
-        <source>Manage service access tokens</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">396</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">397</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="iam.action.manage-personal-access-tokens" datatype="html">
-        <source>Manage personal access tokens</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">405</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">406</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="iam.action.list-relay-proxies" datatype="html">
-        <source>List relay proxies</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">416</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">417</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="iam.action.manage-relay-proxies" datatype="html">
-        <source>Manage relay proxies</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
           <context context-type="linenumber">425</context>
@@ -9905,25 +9901,69 @@
           <context context-type="linenumber">426</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="iam.action.manage-service-access-tokens" datatype="html">
+        <source>Manage service access tokens</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">434</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">435</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="iam.action.manage-personal-access-tokens" datatype="html">
+        <source>Manage personal access tokens</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">443</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">444</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="iam.action.list-relay-proxies" datatype="html">
+        <source>List relay proxies</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">454</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">455</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="iam.action.manage-relay-proxies" datatype="html">
+        <source>Manage relay proxies</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">463</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">464</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="common.organization" datatype="html">
         <source>Organization</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">458</context>
+          <context context-type="linenumber">496</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.environment" datatype="html">
         <source>Environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">462</context>
+          <context context-type="linenumber">500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.flag" datatype="html">
         <source>Flag</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">464</context>
+          <context context-type="linenumber">502</context>
         </context-group>
       </trans-unit>
     </body>

--- a/modules/front-end/src/locale/messages.zh.xlf
+++ b/modules/front-end/src/locale/messages.zh.xlf
@@ -846,11 +846,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.ts</context>
-          <context context-type="linenumber">111</context>
+          <context context-type="linenumber">123</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.ts</context>
-          <context context-type="linenumber">138</context>
+          <context context-type="linenumber">150</context>
         </context-group>
         <target>操作成功</target>
       </trans-unit>
@@ -1022,7 +1022,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.ts</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">101</context>
         </context-group>
         <target>复制成功</target>
       </trans-unit>
@@ -5066,7 +5066,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">498</context>
         </context-group>
         <target>项目</target>
       </trans-unit>
@@ -8579,7 +8579,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">56</context>
         </context-group>
         <target>复制</target>
       </trans-unit>
@@ -9735,7 +9735,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">466</context>
+          <context context-type="linenumber">504</context>
         </context-group>
         <target>用户组</target>
       </trans-unit>
@@ -9911,7 +9911,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">129</context>
         </context-group>
         <target>更新</target>
       </trans-unit>
@@ -10219,7 +10219,7 @@
         <source>License settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">39</context>
         </context-group>
         <target>License 设置</target>
       </trans-unit>
@@ -10227,7 +10227,7 @@
         <source>Id</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">42</context>
         </context-group>
         <target>Id</target>
       </trans-unit>
@@ -10235,7 +10235,7 @@
         <source>You will need to provide this Id to generate the license, please contact us to get a license.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
         <target>颁发 License 时需要提供 Workspace Id, 请联系我们获取 License</target>
       </trans-unit>
@@ -10243,15 +10243,15 @@
         <source>License</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">48</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">61</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">66</context>
         </context-group>
         <target>License</target>
       </trans-unit>
@@ -10259,7 +10259,7 @@
         <source>License is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">64</context>
         </context-group>
         <target>License 不可为空</target>
       </trans-unit>
@@ -10267,7 +10267,7 @@
         <source>Update</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">75</context>
         </context-group>
         <target>更新</target>
       </trans-unit>
@@ -10275,7 +10275,7 @@
         <source>SSO (OIDC) settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">83</context>
         </context-group>
         <target>SSO (OIDC) 设置</target>
       </trans-unit>
@@ -10283,11 +10283,11 @@
         <source>Client Id</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">86</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">86</context>
+          <context context-type="linenumber">88</context>
         </context-group>
         <target>Client Id</target>
       </trans-unit>
@@ -10295,7 +10295,7 @@
         <source>Client Id is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">87</context>
         </context-group>
         <target>Client Id 不可为空</target>
       </trans-unit>
@@ -10303,11 +10303,11 @@
         <source>Client secret</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">92</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">92</context>
+          <context context-type="linenumber">94</context>
         </context-group>
         <target>Client secret</target>
       </trans-unit>
@@ -10315,7 +10315,7 @@
         <source>Client secret is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">93</context>
         </context-group>
         <target>Client secret 不可为空</target>
       </trans-unit>
@@ -10323,11 +10323,11 @@
         <source>Token endpoint</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">98</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">100</context>
         </context-group>
         <target>Token endpoint</target>
       </trans-unit>
@@ -10335,7 +10335,7 @@
         <source>Token endpoint is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">97</context>
+          <context context-type="linenumber">99</context>
         </context-group>
         <target>Token endpoint 不可为空</target>
       </trans-unit>
@@ -10343,11 +10343,11 @@
         <source>Client authentication method</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">104</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">104</context>
+          <context context-type="linenumber">106</context>
         </context-group>
         <target>Client authentication method</target>
       </trans-unit>
@@ -10355,7 +10355,7 @@
         <source>Client authentication method is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">105</context>
         </context-group>
         <target>Client authentication method 不可为空</target>
       </trans-unit>
@@ -10363,11 +10363,11 @@
         <source>Authorization endpoint</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">108</context>
+          <context context-type="linenumber">110</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">110</context>
+          <context context-type="linenumber">112</context>
         </context-group>
         <target>Authorization endpoint</target>
       </trans-unit>
@@ -10375,7 +10375,7 @@
         <source>Authorization endpoint is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">111</context>
         </context-group>
         <target>Authorization endpoint 不可为空</target>
       </trans-unit>
@@ -10383,11 +10383,11 @@
         <source>Scope</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">114</context>
+          <context context-type="linenumber">116</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">118</context>
         </context-group>
         <target>Scope</target>
       </trans-unit>
@@ -10395,7 +10395,7 @@
         <source>Scope is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">117</context>
         </context-group>
         <target>Scope 不可为空</target>
       </trans-unit>
@@ -10403,11 +10403,11 @@
         <source>User email claim</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">122</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">124</context>
         </context-group>
         <target>User email claim</target>
       </trans-unit>
@@ -10415,7 +10415,7 @@
         <source>User email claim is mandatory!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.html</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">123</context>
         </context-group>
         <target>User email claim 不可为空</target>
       </trans-unit>
@@ -10423,7 +10423,7 @@
         <source>License updated!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.ts</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">174</context>
         </context-group>
         <target>License 更新成功</target>
       </trans-unit>
@@ -10431,7 +10431,7 @@
         <source>Invalid license, please contact FeatBit team to get a license!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/workspaces/workspace/workspace.component.ts</context>
-          <context context-type="linenumber">168</context>
+          <context context-type="linenumber">180</context>
         </context-group>
         <target>无效 License, 请联系 FeatBit 团队获取 License。</target>
       </trans-unit>
@@ -10515,15 +10515,23 @@
         <source>All</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">105</context>
         </context-group>
         <target>全部</target>
+      </trans-unit>
+      <trans-unit id="iam.rsc-type.workspace" datatype="html">
+        <source>Workspace</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
+        <target>Workspace</target>
       </trans-unit>
       <trans-unit id="iam.rsc-type.organization" datatype="html">
         <source>Organization</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">117</context>
         </context-group>
         <target>机构</target>
       </trans-unit>
@@ -10531,7 +10539,7 @@
         <source>IAM</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">115</context>
+          <context context-type="linenumber">123</context>
         </context-group>
         <target>权限管理</target>
       </trans-unit>
@@ -10539,7 +10547,7 @@
         <source>Access token</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">129</context>
         </context-group>
         <target>访问策略</target>
       </trans-unit>
@@ -10547,7 +10555,7 @@
         <source>Relay proxy</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">127</context>
+          <context context-type="linenumber">135</context>
         </context-group>
         <target>中继代理</target>
       </trans-unit>
@@ -10555,7 +10563,7 @@
         <source>Project</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">141</context>
         </context-group>
         <target>项目</target>
       </trans-unit>
@@ -10563,7 +10571,7 @@
         <source>Environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">139</context>
+          <context context-type="linenumber">147</context>
         </context-group>
         <target>环境</target>
       </trans-unit>
@@ -10571,7 +10579,7 @@
         <source>Feature flag</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">153</context>
         </context-group>
         <target>开关</target>
       </trans-unit>
@@ -10579,7 +10587,7 @@
         <source>Segment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">151</context>
+          <context context-type="linenumber">159</context>
         </context-group>
         <target>用户组</target>
       </trans-unit>
@@ -10587,11 +10595,11 @@
         <source>Project</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">196</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">208</context>
         </context-group>
         <target>项目</target>
       </trans-unit>
@@ -10599,7 +10607,7 @@
         <source>Environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">218</context>
         </context-group>
         <target>环境</target>
       </trans-unit>
@@ -10607,11 +10615,11 @@
         <source>All</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">223</context>
+          <context context-type="linenumber">233</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">224</context>
+          <context context-type="linenumber">234</context>
         </context-group>
         <target>全部操作</target>
       </trans-unit>
@@ -10619,11 +10627,11 @@
         <source>Can access project</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">232</context>
+          <context context-type="linenumber">242</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">233</context>
+          <context context-type="linenumber">243</context>
         </context-group>
         <target>访问项目</target>
       </trans-unit>
@@ -10631,11 +10639,11 @@
         <source>Create projects</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">241</context>
+          <context context-type="linenumber">251</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">242</context>
+          <context context-type="linenumber">252</context>
         </context-group>
         <target>创建项目</target>
       </trans-unit>
@@ -10643,11 +10651,11 @@
         <source>Delete projects</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">250</context>
+          <context context-type="linenumber">260</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">251</context>
+          <context context-type="linenumber">261</context>
         </context-group>
         <target>删除项目</target>
       </trans-unit>
@@ -10655,11 +10663,11 @@
         <source>Update project settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">259</context>
+          <context context-type="linenumber">269</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">260</context>
+          <context context-type="linenumber">270</context>
         </context-group>
         <target>修改项目设置</target>
       </trans-unit>
@@ -10667,11 +10675,11 @@
         <source>Create environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">268</context>
+          <context context-type="linenumber">278</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">269</context>
+          <context context-type="linenumber">279</context>
         </context-group>
         <target>创建环境</target>
       </trans-unit>
@@ -10679,11 +10687,11 @@
         <source>Can access environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">277</context>
+          <context context-type="linenumber">287</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">278</context>
+          <context context-type="linenumber">288</context>
         </context-group>
         <target>访问环境</target>
       </trans-unit>
@@ -10691,11 +10699,11 @@
         <source>Delete environments</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">286</context>
+          <context context-type="linenumber">296</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">287</context>
+          <context context-type="linenumber">297</context>
         </context-group>
         <target>删除环境</target>
       </trans-unit>
@@ -10703,11 +10711,11 @@
         <source>Update environment settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">295</context>
+          <context context-type="linenumber">305</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">296</context>
+          <context context-type="linenumber">306</context>
         </context-group>
         <target>修改环境设置</target>
       </trans-unit>
@@ -10715,11 +10723,11 @@
         <source>Delete environment secret</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">304</context>
+          <context context-type="linenumber">314</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">305</context>
+          <context context-type="linenumber">315</context>
         </context-group>
         <target>删除环境秘钥</target>
       </trans-unit>
@@ -10727,11 +10735,11 @@
         <source>Create environment secret</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">313</context>
+          <context context-type="linenumber">323</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">314</context>
+          <context context-type="linenumber">324</context>
         </context-group>
         <target>创建环境秘钥</target>
       </trans-unit>
@@ -10739,11 +10747,11 @@
         <source>Update environment secret</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">322</context>
+          <context context-type="linenumber">332</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">323</context>
+          <context context-type="linenumber">333</context>
         </context-group>
         <target>修改环境秘钥</target>
       </trans-unit>
@@ -10751,11 +10759,11 @@
         <source>Manage feature flag</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">333</context>
+          <context context-type="linenumber">343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">334</context>
+          <context context-type="linenumber">344</context>
         </context-group>
         <target>管理开关</target>
       </trans-unit>
@@ -10763,28 +10771,16 @@
         <source>Manage segment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">344</context>
+          <context context-type="linenumber">354</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">345</context>
-        </context-group>
-        <target>管理用户组</target>
-      </trans-unit>
-      <trans-unit id="iam.action.update-org-name" datatype="html">
-        <source>Update org name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
           <context context-type="linenumber">355</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">356</context>
-        </context-group>
-        <target>修改机构名称</target>
+        <target>管理用户组</target>
       </trans-unit>
-      <trans-unit id="iam.action.update-org-default-user-permissions" datatype="html">
-        <source>Update org default user permissions</source>
+      <trans-unit id="iam.action.update-ws-general" datatype="html">
+        <source>Update workspace general settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
           <context context-type="linenumber">365</context>
@@ -10793,70 +10789,70 @@
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
           <context context-type="linenumber">366</context>
         </context-group>
+        <target>修改 workspace 通用设置</target>
+      </trans-unit>
+      <trans-unit id="iam.action.update-ws-license" datatype="html">
+        <source>Update workspace license</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">374</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">375</context>
+        </context-group>
+        <target>更新 License</target>
+      </trans-unit>
+      <trans-unit id="iam.action.update-ws-sso" datatype="html">
+        <source>Update workspace SSO settings</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">383</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">384</context>
+        </context-group>
+        <target>更新 SSO 设置</target>
+      </trans-unit>
+      <trans-unit id="iam.action.update-org-name" datatype="html">
+        <source>Update org name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">394</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">395</context>
+        </context-group>
+        <target>修改机构名称</target>
+      </trans-unit>
+      <trans-unit id="iam.action.update-org-default-user-permissions" datatype="html">
+        <source>Update org default user permissions</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">403</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">404</context>
+        </context-group>
         <target>修改机构默认用户权限</target>
       </trans-unit>
       <trans-unit id="iam.action.iam" datatype="html">
         <source>IAM</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">376</context>
+          <context context-type="linenumber">414</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">377</context>
+          <context context-type="linenumber">415</context>
         </context-group>
         <target>权限管理</target>
       </trans-unit>
       <trans-unit id="iam.action.list-access-tokens" datatype="html">
         <source>List access tokens</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">387</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">388</context>
-        </context-group>
-        <target>查看访问策略列表</target>
-      </trans-unit>
-      <trans-unit id="iam.action.manage-service-access-tokens" datatype="html">
-        <source>Manage service access tokens</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">396</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">397</context>
-        </context-group>
-        <target>管理 Service 访问策略</target>
-      </trans-unit>
-      <trans-unit id="iam.action.manage-personal-access-tokens" datatype="html">
-        <source>Manage personal access tokens</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">405</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">406</context>
-        </context-group>
-        <target>管理 Personal 访问策略</target>
-      </trans-unit>
-      <trans-unit id="iam.action.list-relay-proxies" datatype="html">
-        <source>List relay proxies</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">416</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">417</context>
-        </context-group>
-        <target>查看中继代理列表</target>
-      </trans-unit>
-      <trans-unit id="iam.action.manage-relay-proxies" datatype="html">
-        <source>Manage relay proxies</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
           <context context-type="linenumber">425</context>
@@ -10865,13 +10861,61 @@
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
           <context context-type="linenumber">426</context>
         </context-group>
+        <target>查看访问策略列表</target>
+      </trans-unit>
+      <trans-unit id="iam.action.manage-service-access-tokens" datatype="html">
+        <source>Manage service access tokens</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">434</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">435</context>
+        </context-group>
+        <target>管理 Service 访问策略</target>
+      </trans-unit>
+      <trans-unit id="iam.action.manage-personal-access-tokens" datatype="html">
+        <source>Manage personal access tokens</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">443</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">444</context>
+        </context-group>
+        <target>管理 Personal 访问策略</target>
+      </trans-unit>
+      <trans-unit id="iam.action.list-relay-proxies" datatype="html">
+        <source>List relay proxies</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">454</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">455</context>
+        </context-group>
+        <target>查看中继代理列表</target>
+      </trans-unit>
+      <trans-unit id="iam.action.manage-relay-proxies" datatype="html">
+        <source>Manage relay proxies</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">463</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/policy.ts</context>
+          <context context-type="linenumber">464</context>
+        </context-group>
         <target>管理中继代理</target>
       </trans-unit>
       <trans-unit id="common.organization" datatype="html">
         <source>Organization</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">458</context>
+          <context context-type="linenumber">496</context>
         </context-group>
         <target>组织机构</target>
       </trans-unit>
@@ -10879,7 +10923,7 @@
         <source>Environment</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">462</context>
+          <context context-type="linenumber">500</context>
         </context-group>
         <target>环境</target>
       </trans-unit>
@@ -10887,7 +10931,7 @@
         <source>Flag</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/policy.ts</context>
-          <context context-type="linenumber">464</context>
+          <context context-type="linenumber">502</context>
         </context-group>
         <target>开关</target>
       </trans-unit>


### PR DESCRIPTION
Previously everyone with access to FeatBit can modify the workspace settings, which is dangerous for the system. For example if someone with little knowledge with the SSO resets the SSO with invalid values, the SSO would stop to work. 

Current PR protect the modification of workspace settings with IAM policy, including:
- General settings
- License settings
- SSO settings

The PR added a new Resource Type: `Workspace` and three new actions: `UpdateWorkspaceGeneralSettings`, `UpdateWorkspaceLicense` and `UpdateWorkspaceSSOSettings` 

To let current Administrator policy(the built in policy) has these permission, you need to run the following script against your database:

- MongoDB
```js
db.Policies.updateOne(
  {
    _id: UUID("3e961f0f-6fd4-4cf4-910f-52d356f8cc08"),
    "statements.resourceType": { $ne: "workspace" }
  },
  {
    $push: {
      statements: {
        _id: "7a910fbd-9463-4563-af72-fa977d34fdb2",
        resourceType: "workspace",
        effect: "allow",
        actions: [
          "UpdateWorkspaceGeneralSettings",
          "UpdateWorkspaceLicense",
          "UpdateWorkspaceSSOSettings"
        ],
        resources: ["workspace/*"]
      }
    }
  }
);
```
- Postgres
```sql
UPDATE policies
SET statements = statements || jsonb_build_object(
  '_id', gen_random_uuid(),
  'resourceType', 'workspace',
  'effect', 'allow',
  'actions', '["UpdateWorkspaceGeneralSettings", "UpdateWorkspaceLicense", "UpdateWorkspaceSSOSettings"]'::jsonb,
  'resources', '["workspace/*"]'::jsonb
)
WHERE id = '3e961f0f-6fd4-4cf4-910f-52d356f8cc08'
  AND NOT EXISTS (
    SELECT 1 FROM jsonb_array_elements(statements) AS stmt
    WHERE stmt ->> 'resourceType' = 'workspace'
  );
```