### PR TITLE
🐛 fix: incorrect path for copying build artifacts

### DIFF
--- a/modules/front-end/Dockerfile
+++ b/modules/front-end/Dockerfile
@@ -17,7 +17,7 @@ ENV API_URL \
 
 RUN apt-get update -y && apt-get install gettext-base
 
-COPY --from=build-stage /app/dist/featbit/ /usr/share/nginx/featbit/
+COPY --from=build-stage /app/dist/featbit/browser /usr/share/nginx/featbit/
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker-entrypoint.sh /scripts/
 WORKDIR /scripts

--- a/modules/front-end/Dockerfile
+++ b/modules/front-end/Dockerfile
@@ -17,7 +17,7 @@ ENV API_URL \
 
 RUN apt-get update -y && apt-get install gettext-base
 
-COPY --from=build-stage /app/dist/featbit/browser /usr/share/nginx/featbit/
+COPY --from=build-stage /app/dist/featbit/browser/ /usr/share/nginx/featbit/
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker-entrypoint.sh /scripts/
 WORKDIR /scripts

--- a/modules/front-end/docker-entrypoint.sh
+++ b/modules/front-end/docker-entrypoint.sh
@@ -3,6 +3,6 @@
 # Abort on any error (including if wait-for-it fails).
 set -e
 
-envsubst < /usr/share/nginx/featbit/en/assets/env.template.js > /usr/share/nginx/featbit/en/assets/env.js
-envsubst < /usr/share/nginx/featbit/zh/assets/env.template.js > /usr/share/nginx/featbit/zh/assets/env.js
+envsubst < /usr/share/nginx/featbit/browser/en/assets/env.template.js > /usr/share/nginx/featbit/browser/en/assets/env.js
+envsubst < /usr/share/nginx/featbit/browser/zh/assets/env.template.js > /usr/share/nginx/featbit/browser/zh/assets/env.js
 exec nginx -g 'daemon off;'

--- a/modules/front-end/docker-entrypoint.sh
+++ b/modules/front-end/docker-entrypoint.sh
@@ -3,6 +3,6 @@
 # Abort on any error (including if wait-for-it fails).
 set -e
 
-envsubst < /usr/share/nginx/featbit/browser/en/assets/env.template.js > /usr/share/nginx/featbit/browser/en/assets/env.js
-envsubst < /usr/share/nginx/featbit/browser/zh/assets/env.template.js > /usr/share/nginx/featbit/browser/zh/assets/env.js
+envsubst < /usr/share/nginx/featbit/en/assets/env.template.js > /usr/share/nginx/featbit/en/assets/env.js
+envsubst < /usr/share/nginx/featbit/zh/assets/env.template.js > /usr/share/nginx/featbit/zh/assets/env.js
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
This pull request makes a small adjustment to the build output path in the Dockerfile, ensuring that the correct frontend assets are copied to the Nginx directory.

* Updated the `COPY` command in `modules/front-end/Dockerfile` to copy from `dist/featbit/browser/` instead of `dist/featbit/`, ensuring the correct build output is used for deployment.