### PR TITLE
✨ feat: make the base_href configurable in the UI

### DIFF
--- a/docker-compose-mongodb.yml
+++ b/docker-compose-mongodb.yml
@@ -6,6 +6,7 @@ services:
       - API_URL=http://localhost:5000
       - DEMO_URL=http://localhost:5173
       - EVALUATION_URL=http://localhost:5100
+      - BASE_HREF=/
     depends_on:
       - api-server
       - demo-dino-game-vue

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -6,6 +6,7 @@ services:
       - API_URL=http://localhost:5000
       - DEMO_URL=https://featbit-samples.vercel.app
       - EVALUATION_URL=http://localhost:5100
+      - BASE_HREF=/
     depends_on:
       - api-server
     ports:

--- a/docker-compose-standard.yml
+++ b/docker-compose-standard.yml
@@ -6,6 +6,7 @@ services:
       - API_URL=http://localhost:5000
       - DEMO_URL=https://featbit-samples.vercel.app
       - EVALUATION_URL=http://localhost:5100
+      - BASE_HREF=/
     depends_on:
       - api-server
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - API_URL=http://localhost:5000
       - DEMO_URL=https://featbit-samples.vercel.app
       - EVALUATION_URL=http://localhost:5100
+      - BASE_HREF=/
     depends_on:
       - api-server
     ports:

--- a/docker/composes/docker-compose-dev-postgres-clickhouse.yml
+++ b/docker/composes/docker-compose-dev-postgres-clickhouse.yml
@@ -10,6 +10,7 @@ services:
       - API_URL=http://localhost:5000
       - DEMO_URL=http://localhost:5173
       - EVALUATION_URL=http://localhost:5100
+      - BASE_HREF=/
     depends_on:
       - api-server
       - demo-dino-game-vue

--- a/docker/composes/docker-compose-dev-postgres.yml
+++ b/docker/composes/docker-compose-dev-postgres.yml
@@ -10,6 +10,7 @@ services:
       - API_URL=http://localhost:5000
       - DEMO_URL=http://localhost:5173
       - EVALUATION_URL=http://localhost:5100
+      - BASE_HREF=/
     depends_on:
       - api-server
       - demo-dino-game-vue

--- a/docker/composes/docker-compose-dev.yml
+++ b/docker/composes/docker-compose-dev.yml
@@ -10,6 +10,7 @@ services:
       - API_URL=http://localhost:5000
       - DEMO_URL=http://localhost:5173
       - EVALUATION_URL=http://localhost:5100
+      - BASE_HREF=/
     depends_on:
       - api-server
       - demo-dino-game-vue

--- a/docker/composes/docker-compose-kafka-3-brokers-clickhouse-3-shards.yml
+++ b/docker/composes/docker-compose-kafka-3-brokers-clickhouse-3-shards.yml
@@ -112,6 +112,7 @@ services:
       - API_URL=http://localhost:5000
       - DEMO_URL=http://localhost:5173
       - EVALUATION_URL=http://localhost:5100
+      - BASE_HREF=/
     depends_on:
       - api-server
       - demo-dino-game-vue

--- a/docker/composes/docker-compose-otel.yml
+++ b/docker/composes/docker-compose-otel.yml
@@ -10,6 +10,7 @@ services:
       - API_URL=http://localhost:5000
       - DEMO_URL=http://localhost:5173
       - EVALUATION_URL=http://localhost:5100
+      - BASE_HREF=/
     depends_on:
       - api-server
       - demo-dino-game-vue

--- a/docker/composes/docker-compose-pro-dev-HA-kafka.yml
+++ b/docker/composes/docker-compose-pro-dev-HA-kafka.yml
@@ -10,6 +10,7 @@ services:
       - API_URL=http://localhost:5000
       - DEMO_URL=http://localhost:5173
       - EVALUATION_URL=http://localhost:5100
+      - BASE_HREF=/
     depends_on:
       - api-server
       - demo-dino-game-vue

--- a/modules/front-end/Dockerfile
+++ b/modules/front-end/Dockerfile
@@ -19,7 +19,9 @@ ENV API_URL \
 RUN apt-get update -y && apt-get install gettext-base
 
 COPY --from=build-stage /app/dist/featbit/browser/ /usr/share/nginx/featbit/
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+COPY ./nginx.conf /etc/nginx/conf.d/nginx.default.conf
+COPY ./nginx.base_href.conf /etc/nginx/conf.d/nginx.base_href.conf
+
 COPY docker-entrypoint.sh /scripts/
 WORKDIR /scripts
 RUN chmod +x docker-entrypoint.sh

--- a/modules/front-end/Dockerfile
+++ b/modules/front-end/Dockerfile
@@ -19,7 +19,7 @@ ENV API_URL \
 RUN apt-get update -y && apt-get install gettext-base
 
 COPY --from=build-stage /app/dist/featbit/browser/ /usr/share/nginx/featbit/
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+COPY ./nginx.conf /etc/nginx/conf.d/nginx.default.conf
 COPY ./nginx.base_href.conf /etc/nginx/conf.d/nginx.base_href.conf
 
 COPY docker-entrypoint.sh /scripts/

--- a/modules/front-end/Dockerfile
+++ b/modules/front-end/Dockerfile
@@ -19,7 +19,7 @@ ENV API_URL \
 RUN apt-get update -y && apt-get install gettext-base
 
 COPY --from=build-stage /app/dist/featbit/browser/ /usr/share/nginx/featbit/
-COPY ./nginx.conf /etc/nginx/conf.d/nginx.default.conf
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY ./nginx.base_href.conf /etc/nginx/conf.d/nginx.base_href.conf
 
 COPY docker-entrypoint.sh /scripts/

--- a/modules/front-end/Dockerfile
+++ b/modules/front-end/Dockerfile
@@ -13,7 +13,8 @@ FROM nginx:1.23
 
 ENV API_URL \
     DEMO_URL \
-    EVALUATION_URL
+    EVALUATION_URL \
+    BASE_HREF
 
 RUN apt-get update -y && apt-get install gettext-base
 

--- a/modules/front-end/docker-entrypoint.sh
+++ b/modules/front-end/docker-entrypoint.sh
@@ -7,7 +7,7 @@ set -e
 BASE_HREF="${BASE_HREF%/}"
 
 # Select and process nginx configuration based on BASE_HREF
-if [ -n "$BASE_HREF" ] && [ "$BASE_HREF" != "" ]; then
+if [ -n "$BASE_HREF" ]; then
   echo "Using nginx.base_href.conf with BASE_HREF=$BASE_HREF"
   envsubst '$BASE_HREF' < /etc/nginx/conf.d/nginx.base_href.conf > /etc/nginx/conf.d/default.conf
 else

--- a/modules/front-end/docker-entrypoint.sh
+++ b/modules/front-end/docker-entrypoint.sh
@@ -3,6 +3,24 @@
 # Abort on any error (including if wait-for-it fails).
 set -e
 
-envsubst < /usr/share/nginx/featbit/en/assets/env.template.js > /usr/share/nginx/featbit/en/assets/env.js
-envsubst < /usr/share/nginx/featbit/zh/assets/env.template.js > /usr/share/nginx/featbit/zh/assets/env.js
+# Remove trailing slash if present
+BASE_HREF="${BASE_HREF%/}"
+
+# Process each locale directory
+for locale in /usr/share/nginx/featbit/*; do
+  if [ -d "$locale" ]; then
+    lang=$(basename "$locale")
+
+    # Update <base href="..."> inside index.html
+    if [ -f "$locale/index.html" ]; then
+      sed -i "s|<base href=\"/${lang}/\"|<base href=\"${BASE_HREF}/${lang}/\"|g" "$locale/index.html"
+    fi
+
+   # Generate env.js from env.template.js if available
+    if [ -f "$locale/assets/env.template.js" ]; then
+      envsubst < "$locale/assets/env.template.js" > "$locale/assets/env.js"
+    fi
+  fi
+done
+
 exec nginx -g 'daemon off;'

--- a/modules/front-end/docker-entrypoint.sh
+++ b/modules/front-end/docker-entrypoint.sh
@@ -16,7 +16,7 @@ for locale in /usr/share/nginx/featbit/*; do
       sed -i "s|<base href=\"/${lang}/\"|<base href=\"${BASE_HREF}/${lang}/\"|g" "$locale/index.html"
     fi
 
-   # Generate env.js from env.template.js if available
+    # Generate env.js from env.template.js if available
     if [ -f "$locale/assets/env.template.js" ]; then
       envsubst < "$locale/assets/env.template.js" > "$locale/assets/env.js"
     fi

--- a/modules/front-end/docker-entrypoint.sh
+++ b/modules/front-end/docker-entrypoint.sh
@@ -1,10 +1,22 @@
 #!/bin/sh
 
-# Abort on any error (including if wait-for-it fails).
+# Abort on any error
 set -e
 
 # Remove trailing slash if present
 BASE_HREF="${BASE_HREF%/}"
+
+# Select and process nginx configuration based on BASE_HREF
+if [ -n "$BASE_HREF" ] && [ "$BASE_HREF" != "" ]; then
+  echo "Using nginx.base_href.conf with BASE_HREF=$BASE_HREF"
+  envsubst '$BASE_HREF' < /etc/nginx/conf.d/nginx.base_href.conf > /etc/nginx/conf.d/default.conf
+else
+  echo "Using nginx.conf (default configuration)"
+  cp /etc/nginx/conf.d/nginx.default.conf /etc/nginx/conf.d/default.conf
+fi
+
+# Remove the template files to avoid confusion
+rm -f /etc/nginx/conf.d/nginx.base_href.conf /etc/nginx/conf.d/nginx.default.conf
 
 # Process each locale directory
 for locale in /usr/share/nginx/featbit/*; do

--- a/modules/front-end/nginx.base_href.conf
+++ b/modules/front-end/nginx.base_href.conf
@@ -20,7 +20,7 @@ server {
   root /usr/share/nginx/featbit;
 
   # Redirect base path to Angular application in the preferred language
-  rewrite ^${BASE_HREF}/?$ ${BASE_HREF}/$accept_language permanent;
+  rewrite ^${BASE_HREF}/?$ ${BASE_HREF}/$accept_language/ permanent;
 
   location /health {
     access_log off;

--- a/modules/front-end/nginx.base_href.conf
+++ b/modules/front-end/nginx.base_href.conf
@@ -1,0 +1,65 @@
+# Browser preferred language detection (does NOT require
+# AcceptLanguageModule)
+map $http_accept_language $accept_language {
+  ~*^zh zh;
+  ~*^en en;
+}
+
+server {
+  server_tokens off;
+
+  gzip            on;
+  gzip_static     on;
+  gzip_types      text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_proxied    no-cache no-store private expired auth;
+  gzip_min_length 1000;
+
+  listen 80;
+  server_name  featbit;
+  root /usr/share/nginx/featbit;
+
+  # Fallback to default language if no preference defined by browser
+  if ($accept_language ~ "^$") {
+    set $accept_language "en";
+  }
+
+  # Redirect base path to Angular application in the preferred language
+  rewrite ^${BASE_HREF}/?$ ${BASE_HREF}/$accept_language permanent;
+
+  location /health {
+    access_log off;
+    add_header 'Content-Type' 'text/plain';
+    return 200 "healthy\n";
+  }
+
+  # Media files for base href paths - rewrite to remove base path
+  location ~* ^${BASE_HREF}/(en|zh)/.*\.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+    rewrite ^${BASE_HREF}/(.*)$ /$1 break;
+    root /usr/share/nginx/featbit;
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=2592000";
+  }
+
+  # CSS and Javascript files for base href paths - rewrite to remove base path
+  location ~* ^${BASE_HREF}/(en|zh)/(.*\.(?:css|js))$ {
+    rewrite ^${BASE_HREF}/(.*)$ /$1 break;
+    root /usr/share/nginx/featbit;
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=31449600";
+  }
+
+  # Handle the custom base path with language routing
+  location ~* ^${BASE_HREF}/(en|zh) {
+    try_files $uri$args $uri$args/index.html $uri$args/ /$1/index.html =404;
+    add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+  }
+
+  # Any route containing a file extension (e.g. /devicesfile.js)
+  location ~ ^.+\..+$ {
+    try_files $uri =404;
+  }
+
+  location / {
+    return 404;
+  }
+}

--- a/modules/front-end/nginx.base_href.conf
+++ b/modules/front-end/nginx.base_href.conf
@@ -3,6 +3,7 @@
 map $http_accept_language $accept_language {
   ~*^zh zh;
   ~*^en en;
+  default en;
 }
 
 server {
@@ -17,11 +18,6 @@ server {
   listen 80;
   server_name  featbit;
   root /usr/share/nginx/featbit;
-
-  # Fallback to default language if no preference defined by browser
-  if ($accept_language ~ "^$") {
-    set $accept_language "en";
-  }
 
   # Redirect base path to Angular application in the preferred language
   rewrite ^${BASE_HREF}/?$ ${BASE_HREF}/$accept_language permanent;

--- a/modules/front-end/nginx.conf
+++ b/modules/front-end/nginx.conf
@@ -3,6 +3,7 @@
 map $http_accept_language $accept_language {
   ~*^zh zh;
   ~*^en en;
+  default en;
 }
 
 server {
@@ -17,11 +18,6 @@ server {
   listen 80;
   server_name  featbit;
   root /usr/share/nginx/featbit;
-
-  # Fallback to default language if no preference defined by browser
-  if ($accept_language ~ "^$") {
-    set $accept_language "en";
-  }
 
   # Redirect "/" to Angular application in the preferred language of the browser
   rewrite ^/$ $accept_language permanent;


### PR DESCRIPTION
If you ever need to run UI from a path different that the default value, you can now pass the `BASE_HREF` environment variable to the UI. With this, the navigator could successfully find the assets files.

Ex. You wanna run the UI from:
```https://yourdomain.com/dev/svc-featbit-poc/latest/featbit-ui-server/en```

Then just do
```BASE_HREF=/dev/svc-featbit-poc/latest/featbit-ui-server/```

You can modify the value of the environment variable in the docker compose file you are using

<!--
# Instructions

1. Pick a meaningful and result oriented title for your pull request. (Use sentence case, don't include any words indicating the way you achived this result, we just want the result. Keep it short < 70 characters)
  - Prefix the title with an emoji to categorize what is being done. (Copy-paste the emoji from the list below.)
  - Assign the appropriate label(s) to the pull request. (Use one of the labels from the list below.)
  
2. Enter a succinct description that says why the PR is necessary, and what it does.
  - Implement aspect X
  - Leave out feature Y because of A
  - Improve performance by B
  - Improve accessibility by C

3. Provide clear testing instructions that include any pertinent information, i.e. seat, roles, etc.
4. Include screenshots of your changes if they impact the UI (Before & After).
5. Update the preview link with your pull request number.
6. Include any JIRA tickets, design documents, GitHub issues, or other related items to the bottom of the PR.

# Available labels
UI
API
Evaluation Server
OLAP

# Emojis for categorizing pull requests

✨ New feature or functionality
🐛 Bugfix
🔥 P0 fix
✅ Tests
🚀 Performance improvements
🖍 CSS / Styling
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
↩️ Reverting a previous change
🧹 Refactoring / Housekeeping
🔧 Package Upgrades / Maintenance
🗑️ Deleting code

-->
