### PR TITLE
✨ feat: configure display URL for backend services

### DIFF
--- a/modules/front-end/Dockerfile
+++ b/modules/front-end/Dockerfile
@@ -15,8 +15,8 @@ ENV API_URL \
     DEMO_URL \
     EVALUATION_URL \
     BASE_HREF \
-    FEATBIT_DISPLAY_API_URL \
-    FEATBIT_DISPLAY_EVAL_URL
+    DISPLAY_API_URL \
+    DISPLAY_EVALUATION_URL
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y gettext-base && rm -rf /var/lib/apt/lists/*
 

--- a/modules/front-end/README.md
+++ b/modules/front-end/README.md
@@ -58,8 +58,8 @@ Three variables could be overridden by environment variables when running the co
 - **API_URL**: the url of the API Server, default value is http://localhost:5000, it overrides **url**
 - **DEMO_URL**: set the value if you deploy the [dino-game demo](https://github.com/featbit/featbit-samples/tree/main/samples/dino-game/interactive-demo-vue) on your own server, otherwise it would use our demo deployed on https://featbit-samples.vercel.app. The link doesn't work if you click directly on it, it needs extra parameters. **demoUrl**
 - **EVALUATION_URL**: the url of the evaluation server, this is used by the demo, ignore it if you don't want to run the demo, the default value is http://localhost:5100. It overrides **evaluationUrl**
-- **FEATBIT_DISPLAY_API_URL**: the display url of the API server. This is an optional variable used when you want to override the API URL displayed in the 'Getting Started' UI. 
-- **FEATBIT_DISPLAY_EVAL_URL**: the display url of the Evaluation server. This is an optional variable used when you want to override the Event and Streaming URL displayed in the 'Getting Started' UI.
+- **DISPLAY_API_URL**: the display url of the API server. This is an optional variable used when you want to override the API URL displayed in the 'Getting Started' UI. 
+- **DISPLAY_EVALUATION_URL**: the display url of the Evaluation server. This is an optional variable used when you want to override the Event and Streaming URL displayed in the 'Getting Started' UI.
 
 Bind the port 8081 or any other available port to 80.
 

--- a/modules/front-end/src/app/features/safe/get-started/steps/connect-an-sdk/connect-an-sdk.component.ts
+++ b/modules/front-end/src/app/features/safe/get-started/steps/connect-an-sdk/connect-an-sdk.component.ts
@@ -20,23 +20,14 @@ export class ConnectAnSdkComponent implements OnChanges {
 
   protected readonly SecretTypeEnum = SecretTypeEnum;
 
-  featbitDisplayApiURL: string = environment.featbitDisplayApiUrl;
-  featbitDisplayEvalURL: string = environment.featbitDisplayEvalUrl;
+  displayApiUrl: string = environment.displayApiUrl?.trim();
+  displayEvaluationUrl: string = environment.displayEvaluationUrl?.trim();
 
-  streamingURL: string =
-    this.featbitDisplayEvalURL && this.featbitDisplayEvalURL.trim() !== ''
-      ? this.featbitDisplayEvalURL.replace(/^http/, 'ws')
-      : environment.evaluationUrl?.replace(/^http/, 'ws')
+  streamingURL: string = this.displayEvaluationUrl?.replace(/^http/, 'ws') || environment.evaluationUrl?.replace(/^http/, 'ws');
 
-  eventURL: string =
-    this.featbitDisplayEvalURL && this.featbitDisplayEvalURL.trim() !== ''
-      ? this.featbitDisplayEvalURL
-      : environment.evaluationUrl
+  eventURL: string = this.displayEvaluationUrl || environment.evaluationUrl;
 
-  apiHost: string =
-    this.featbitDisplayApiURL && this.featbitDisplayApiURL.trim() !== ''
-      ? this.featbitDisplayApiURL
-      : environment.url;
+  apiHost: string = this.displayApiUrl || environment.url;
 
   selectedSecret: ISecret;
   get secret(): string {

--- a/modules/front-end/src/assets/env.js
+++ b/modules/front-end/src/assets/env.js
@@ -5,6 +5,6 @@
   window["env"]["apiUrl"] = "";
   window["env"]["demoUrl"] = "";
   window["env"]["evaluationUrl"] = "";
-  window["env"]["featbitDisplayApiUrl"] = "";
-  window["env"]["featbitDisplayEvalUrl"] = "";
+  window["env"]["displayApiUrl"] = "";
+  window["env"]["displayEvaluationUrl"] = "";
 })(this);

--- a/modules/front-end/src/assets/env.template.js
+++ b/modules/front-end/src/assets/env.template.js
@@ -5,6 +5,6 @@
   window["env"]["apiUrl"] = "${API_URL}";
   window["env"]["demoUrl"] = "${DEMO_URL}";
   window["env"]["evaluationUrl"] = "${EVALUATION_URL}";
-  window["env"]["featbitDisplayApiUrl"] = "${FEATBIT_DISPLAY_API_URL}";
-  window["env"]["featbitDisplayEvalUrl"] = "${FEATBIT_DISPLAY_EVAL_URL}";
+  window["env"]["displayApiUrl"] = "${DISPLAY_API_URL}";
+  window["env"]["displayEvaluationUrl"] = "${DISPLAY_EVALUATION_URL}";
 })(this);

--- a/modules/front-end/src/environments/environment.prod.ts
+++ b/modules/front-end/src/environments/environment.prod.ts
@@ -3,6 +3,6 @@ export const environment = {
   url: window['env']['apiUrl'] || location.origin.replace(/\/$/, ''),
   demoUrl: window['env']['demoUrl'] || 'https://featbit-samples.vercel.app',
   evaluationUrl: window['env']['evaluationUrl'] || location.origin.replace(/\/$/, ''),
-  featbitDisplayApiUrl: window['env']['featbitDisplayApiUrl'],
-  featbitDisplayEvalUrl: window['env']['featbitDisplayEvalUrl']
+  displayApiUrl: window['env']['displayApiUrl'],
+  displayEvaluationUrl: window['env']['displayEvaluationUrl']
 };

--- a/modules/front-end/src/environments/environment.ts
+++ b/modules/front-end/src/environments/environment.ts
@@ -3,6 +3,6 @@ export const environment = {
   url: window['env']['apiUrl'] || 'http://localhost:5000',
   demoUrl: window['env']['demoUrl'] || 'https://featbit-samples.vercel.app',
   evaluationUrl: window['env']['evaluationUrl'] || 'http://localhost:5100',
-  featbitDisplayApiUrl: window['env']['featbitDisplayApiUrl'],
-  featbitDisplayEvalUrl: window['env']['featbitDisplayEvalUrl'],
+  displayApiUrl: window['env']['displayApiUrl'],
+  displayEvaluationUrl: window['env']['displayEvaluationUrl'],
 };


### PR DESCRIPTION
<!--
# Instructions

1. Pick a meaningful and result oriented title for your pull request. (Use sentence case, don't include any words indicating the way you achived this result, we just want the result. Keep it short < 70 characters)
  - Prefix the title with an emoji to categorize what is being done. (Copy-paste the emoji from the list below.)
  - Assign the appropriate label(s) to the pull request. (Use one of the labels from the list below.)
  


3. Provide clear testing instructions that include any pertinent information, i.e. seat, roles, etc.
4. Include screenshots of your changes if they impact the UI (Before & After).
5. Update the preview link with your pull request number.
6. Include any JIRA tickets, design documents, GitHub issues, or other related items to the bottom of the PR.

# Available labels
UI
API
Evaluation Server
OLAP

# Emojis for categorizing pull requests

✨ New feature or functionality
🐛 Bugfix
🔥 P0 fix
✅ Tests
🚀 Performance improvements
🖍 CSS / Styling
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
↩️ Reverting a previous change
🧹 Refactoring / Housekeeping
🔧 Package Upgrades / Maintenance
🗑️ Deleting code

-->

**Why this is needed:** 

When maintaining multiple physical environments and multiple availability zones, we need to show the user the URI they should target in their code when using Featbit.  Currently, the URI comes from API_URL and EVALUATION_URL.  Assume you have 3 environments dev, test, and prod and 2 availability zones 1, 2. The get started page would display something like featbit-api.prod-1.example.com or featbit-api.test-2.example.com.  This leads to user confusion because they should be connected to featbit-api.example.com when using the production environment. DNS handles routing to correct environment and availability zone behind the scenes. The application internals still use API_URL and EVALUATION_URL to keep internal traffic within it's environment and availability zones

**Testing Instructions:**

Set the `FEATBIT_DISPLAY_API_URL` and `FEATBIT_DISPLAY_EVAL_URL` environment variables for the UI application and verify on the `Getting Started - Connect An SDK` page in the UI that the values of these variables override the values of `API_URL` and `EVALUATION_URL` for the `Streaming URL`, `Event URL`, and `Open API Endpoint`.
