### PR TITLE
🏗 infra: migrate to bitnami legacy images

### DIFF
--- a/docker-compose-mongodb.yml
+++ b/docker-compose-mongodb.yml
@@ -80,7 +80,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     container_name: redis
     restart: on-failure
     environment:

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -86,7 +86,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     restart: on-failure
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
@@ -98,7 +98,7 @@ services:
       - redis:/data
 
   kafka:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     restart: on-failure
     ports:
       - '9092:9092'
@@ -119,7 +119,7 @@ services:
       - kafka:/bitnami/kafka
   
   init-kafka-topics:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     depends_on:
       kafka:
         condition: service_started

--- a/docker-compose-standard.yml
+++ b/docker-compose-standard.yml
@@ -81,7 +81,7 @@ services:
       - featbit-network
   
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     container_name: redis
     restart: on-failure
     environment:

--- a/docker/composes/docker-compose-dev-postgres-clickhouse.yml
+++ b/docker/composes/docker-compose-dev-postgres-clickhouse.yml
@@ -86,7 +86,7 @@ services:
       CHECK_DB_LIVNESS: true
 
   kafka:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     restart: on-failure
     ports:
       - '9092:9092'
@@ -121,7 +121,7 @@ services:
       - featbit-network
   
   init-kafka-topics:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     depends_on:
       kafka:
         condition: service_started
@@ -176,7 +176,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     container_name: redis
     restart: on-failure
     environment:

--- a/docker/composes/docker-compose-dev-postgres.yml
+++ b/docker/composes/docker-compose-dev-postgres.yml
@@ -96,7 +96,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     container_name: redis
     restart: on-failure
     environment:

--- a/docker/composes/docker-compose-dev.yml
+++ b/docker/composes/docker-compose-dev.yml
@@ -96,7 +96,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     container_name: redis
     restart: on-failure
     environment:

--- a/docker/composes/docker-compose-infra.yml
+++ b/docker/composes/docker-compose-infra.yml
@@ -16,7 +16,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     restart: on-failure
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
@@ -28,7 +28,7 @@ services:
       - redis:/data
 
   kafka:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     restart: on-failure
     ports:
       - '9092:9092'
@@ -49,7 +49,7 @@ services:
       - kafka:/bitnami/kafka
 
   init-kafka-topics:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     depends_on:
       kafka:
         condition: service_started

--- a/docker/composes/docker-compose-kafka-3-brokers-clickhouse-3-shards.yml
+++ b/docker/composes/docker-compose-kafka-3-brokers-clickhouse-3-shards.yml
@@ -250,7 +250,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     container_name: redis
     restart: on-failure
     environment:
@@ -263,7 +263,7 @@ services:
       - redis:/bitnami/redis/data
 
   kafka-0:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     container_name: kafka-0
     restart: on-failure
     ports:
@@ -296,7 +296,7 @@ services:
       - kafka_0_data:/bitnami/kafka
   
   kafka-1:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     container_name: kafka-1
     restart: on-failure
     ports:
@@ -328,7 +328,7 @@ services:
       - kafka_1_data:/bitnami/kafka
   
   kafka-2:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     container_name: kafka-2
     restart: on-failure
     ports:
@@ -361,7 +361,7 @@ services:
   
   
   init-kafka-topics:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     depends_on:
       - kafka-0
       - kafka-1

--- a/docker/composes/docker-compose-otel.yml
+++ b/docker/composes/docker-compose-otel.yml
@@ -101,7 +101,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     container_name: redis
     restart: on-failure
     environment:

--- a/docker/composes/docker-compose-pro-dev-HA-kafka.yml
+++ b/docker/composes/docker-compose-pro-dev-HA-kafka.yml
@@ -104,7 +104,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     container_name: redis
     restart: on-failure
     environment:
@@ -117,7 +117,7 @@ services:
       - redis:/bitnami/redis/data
 
   kafka:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     container_name: kafka
     restart: on-failure
     ports:
@@ -139,7 +139,7 @@ services:
       - kafka:/bitnami/kafka
 
   kafka-consumer:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     container_name: kafka-consumer
     restart: on-failure
     ports:
@@ -177,7 +177,7 @@ services:
       - featbit-network
   
   init-kafka-topics:
-    image: bitnami/kafka:3.5
+    image: bitnamilegacy/kafka:3.5
     depends_on:
       kafka:
         condition: service_started

--- a/docker/https/docker-compose-dev.yml
+++ b/docker/https/docker-compose-dev.yml
@@ -98,7 +98,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     container_name: redis
     environment:
       - ALLOW_EMPTY_PASSWORD=yes

--- a/docker/ui-api-bundle/docker-compose-dev.yml
+++ b/docker/ui-api-bundle/docker-compose-dev.yml
@@ -72,7 +72,7 @@ services:
       - featbit-network
 
   redis:
-    image: bitnami/redis:6.2.10
+    image: bitnamilegacy/redis:6.2.10
     container_name: redis
     restart: on-failure
     environment:

--- a/kubernetes/pro/infrastructure/kafka-pod.yaml
+++ b/kubernetes/pro/infrastructure/kafka-pod.yaml
@@ -11,7 +11,7 @@ spec:
     fsGroup: 1001
   initContainers:
     - name: volume-permissions
-      image: bitnami/kafka:3.5
+      image: bitnamilegacy/kafka:3.5
       command:
         - /bin/bash
       args:
@@ -38,7 +38,7 @@ spec:
           mountPath: /bitnami/kafka
   containers:
     - name: kafka
-      image: bitnami/kafka:3.5
+      image: bitnamilegacy/kafka:3.5
       ports:
         - containerPort: 9092
         - containerPort: 29092

--- a/kubernetes/pro/infrastructure/redis-pod.yaml
+++ b/kubernetes/pro/infrastructure/redis-pod.yaml
@@ -9,7 +9,7 @@ spec:
     - env:
         - name: ALLOW_EMPTY_PASSWORD
           value: "yes"
-      image: bitnami/redis:6.2.10
+      image: bitnamilegacy/redis:6.2.10
       name: redis
       ports:
         - containerPort: 6379

--- a/kubernetes/standard/infrastructure/redis-pod.yaml
+++ b/kubernetes/standard/infrastructure/redis-pod.yaml
@@ -9,7 +9,7 @@ spec:
     - env:
         - name: ALLOW_EMPTY_PASSWORD
           value: "yes"
-      image: bitnami/redis:6.2.10
+      image: bitnamilegacy/redis:6.2.10
       name: redis
       ports:
         - containerPort: 6379


### PR DESCRIPTION
This is a stopgap measure. The long-term goal is to move away from Bitnami entirely.

ref: https://github.com/bitnami/containers/issues/83267