### PR TITLE
✨ feat: make streaming token expiry configurable

### DIFF
--- a/modules/evaluation-server/README.md
+++ b/modules/evaluation-server/README.md
@@ -80,3 +80,4 @@ and [consumer configs](https://kafka.apache.org/documentation/#consumerconfigs) 
 | Name                             | Description                                                  | Default Value |
 |----------------------------------|--------------------------------------------------------------|---------------|
 | `Streaming__TrackClientHostName` | Whether to resolve client's IP hostname for detailed logging | `true`        |
+| `Streaming__TokenExpirySeconds`  | Streaming token expiry time in seconds                       | `30`          |

--- a/modules/evaluation-server/src/Api/appsettings.Development.json
+++ b/modules/evaluation-server/src/Api/appsettings.Development.json
@@ -49,7 +49,8 @@
     "Password": ""
   },
   "Streaming": {
-    "TrackClientHostName": true
+    "TrackClientHostName": true,
+    "TokenExpirySeconds": 30
   },
   "AllowedHosts": "*",
   "PublicKey": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvXd47Say6D+c0hYr85jL\n5GF3mjxjZ/Tz2+P/9HDjVsdyXAXs38RmYSR7zFNnlw3iplQXQpEi/NcJoQET+e4K\nmlEILjOujNTJp6VpFYgTsYSncywbFVQielFXozMcco1PJCBPsl8nnGrY6FuIxugT\nxtsr32zILvmqvoB2xE9hRL4uxalY0HI2EInd38PJcmKLBwB8hcIif6Ts5X67mupw\nVwJLYv9xL6GSlenH4fXfx9HpEVeVU8yPbIF8N7pkIC3cHXvKnG0833HouKUi2YgW\n18GR6kn3Co2kmUDeJBABbPCSEzLGJRXeyBa5kVmneOWMv8mWdZRZ5nxIA0WKH/En\nkDXaMYpM8Zyi3OvlS2z93Ow2Ep/Vgm717FkZl3YHEFfcTdKwww428BgHKHzC00vk\nTkdGoexxtzEGuJoOkOYSXjA5yFAH/C5EOFFJyqEjbcAifLr7O3d/TWndBQjEFrFf\nO4syOcd8DRXImYDyARqVLWsaD1JodAxDLeDf4jfTlxhiY6iySgDHpuZeqNAbx4p9\n7pBzL0Nh5DToq4H4t2xN1eYTW+/UPMykaQuQetzecldM/RLWfu6yZM4xmJ7buPDy\n1AqCRZAOiEXSPlVPopmtA2Z6g79k9IbdiDS9skNBPF+v2eJZ58m1xxdTaxen+5pA\nFnnL39/JL0JYG7FOC+VAX0cCAwEAAQ==\n-----END PUBLIC KEY-----"

--- a/modules/evaluation-server/src/Api/appsettings.json
+++ b/modules/evaluation-server/src/Api/appsettings.json
@@ -48,7 +48,8 @@
     "Password": ""
   },
   "Streaming": {
-    "TrackClientHostName": true
+    "TrackClientHostName": true,
+    "TokenExpirySeconds": 30
   },
   "AllowedHosts": "*",
   "PublicKey": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvXd47Say6D+c0hYr85jL\n5GF3mjxjZ/Tz2+P/9HDjVsdyXAXs38RmYSR7zFNnlw3iplQXQpEi/NcJoQET+e4K\nmlEILjOujNTJp6VpFYgTsYSncywbFVQielFXozMcco1PJCBPsl8nnGrY6FuIxugT\nxtsr32zILvmqvoB2xE9hRL4uxalY0HI2EInd38PJcmKLBwB8hcIif6Ts5X67mupw\nVwJLYv9xL6GSlenH4fXfx9HpEVeVU8yPbIF8N7pkIC3cHXvKnG0833HouKUi2YgW\n18GR6kn3Co2kmUDeJBABbPCSEzLGJRXeyBa5kVmneOWMv8mWdZRZ5nxIA0WKH/En\nkDXaMYpM8Zyi3OvlS2z93Ow2Ep/Vgm717FkZl3YHEFfcTdKwww428BgHKHzC00vk\nTkdGoexxtzEGuJoOkOYSXjA5yFAH/C5EOFFJyqEjbcAifLr7O3d/TWndBQjEFrFf\nO4syOcd8DRXImYDyARqVLWsaD1JodAxDLeDf4jfTlxhiY6iySgDHpuZeqNAbx4p9\n7pBzL0Nh5DToq4H4t2xN1eYTW+/UPMykaQuQetzecldM/RLWfu6yZM4xmJ7buPDy\n1AqCRZAOiEXSPlVPopmtA2Z6g79k9IbdiDS9skNBPF+v2eJZ58m1xxdTaxen+5pA\nFnnL39/JL0JYG7FOC+VAX0cCAwEAAQ==\n-----END PUBLIC KEY-----"

--- a/modules/evaluation-server/src/Streaming/Connections/RequestValidator.cs
+++ b/modules/evaluation-server/src/Streaming/Connections/RequestValidator.cs
@@ -14,8 +14,6 @@ public sealed class RequestValidator(
     ILogger<RequestValidator> logger)
     : IRequestValidator
 {
-    private const long TokenTimeoutMs = 30 * 1000;
-
     public async Task<ValidationResult> ValidateAsync(ConnectionContext context)
     {
         try
@@ -74,7 +72,7 @@ public sealed class RequestValidator(
                 return ValidationResult.Failed($"Invalid token: {tokenString}");
             }
 
-            if (Math.Abs(current - token.Timestamp) > TokenTimeoutMs)
+            if (Math.Abs(current - token.Timestamp) > options.TokenExpirySeconds * 1000)
             {
                 return ValidationResult.Failed($"Token is expired: {tokenString}");
             }

--- a/modules/evaluation-server/src/Streaming/StreamingOptions.cs
+++ b/modules/evaluation-server/src/Streaming/StreamingOptions.cs
@@ -14,4 +14,6 @@ public class StreamingOptions
     public IRelayProxyService? CustomRpService { get; set; } = null;
 
     public bool TrackClientHostName { get; set; } = true;
+
+    public int TokenExpirySeconds { get; set; } = 30;
 }

--- a/modules/evaluation-server/tests/Application.IntegrationTests/Configuration/DefaultTests.cs
+++ b/modules/evaluation-server/tests/Application.IntegrationTests/Configuration/DefaultTests.cs
@@ -36,5 +36,6 @@ public class DefaultTests
         Assert.Equal(ConnectionType.All, options.SupportedTypes);
         Assert.Null(options.CustomRpService);
         Assert.True(options.TrackClientHostName);
+        Assert.Equal(30, options.TokenExpirySeconds);
     }
 }


### PR DESCRIPTION
now the streaming token expiration time is configurable and defaults to 30 seconds (the same as previous)