### PR TITLE
🐛 fix: can access an env without the canAccessProject permission

### DIFF
--- a/modules/front-end/src/app/core/services/permissions.service.ts
+++ b/modules/front-end/src/app/core/services/permissions.service.ts
@@ -136,14 +136,4 @@ export class PermissionsService {
 
     return matchedPermissions.every(s => s.effect === EffectEnum.Allow);
   }
-
-  isDenied(rn: string, action: IamPolicyAction): boolean {
-    const matchedPermissions = this.getMatchedPermissions(rn, action);
-
-    if (matchedPermissions.length === 0) {
-      return false;
-    }
-
-    return matchedPermissions.some(s => s.effect === EffectEnum.Deny);
-  }
 }

--- a/modules/front-end/src/app/core/services/project.service.ts
+++ b/modules/front-end/src/app/core/services/project.service.ts
@@ -30,7 +30,7 @@ export class ProjectService {
     }).map((project) => {
       project.environments = project.environments.filter((env) => {
         const envRN = this.permissionsService.getEnvRN(project, env);
-        return !this.permissionsService.isDenied(envRN, permissionActions.CanAccessEnv);
+        return this.permissionsService.isGranted(envRN, permissionActions.CanAccessEnv);
       });
 
       return project;
@@ -45,7 +45,7 @@ export class ProjectService {
       map(project => {
         project.environments = project.environments.filter((env) => {
           const envRN = this.permissionsService.getEnvRN(project, env);
-          return !this.permissionsService.isDenied(envRN, permissionActions.CanAccessEnv);
+          return this.permissionsService.isGranted(envRN, permissionActions.CanAccessEnv);
         });
 
         return project;


### PR DESCRIPTION
A user with only the permission canAccessProject can access all envs of that project which is not normal. A user would need canAccessEnv permission to access any env

<!--
# Instructions

1. Pick a meaningful and result oriented title for your pull request. (Use sentence case, don't include any words indicating the way you achived this result, we just want the result. Keep it short < 70 characters)
  - Prefix the title with an emoji to categorize what is being done. (Copy-paste the emoji from the list below.)
  - Assign the appropriate label(s) to the pull request. (Use one of the labels from the list below.)
  
2. Enter a succinct description that says why the PR is necessary, and what it does.
  - Implement aspect X
  - Leave out feature Y because of A
  - Improve performance by B
  - Improve accessibility by C

3. Provide clear testing instructions that include any pertinent information, i.e. seat, roles, etc.
4. Include screenshots of your changes if they impact the UI (Before & After).
5. Update the preview link with your pull request number.
6. Include any JIRA tickets, design documents, GitHub issues, or other related items to the bottom of the PR.

# Available labels
UI
API
Evaluation Server
OLAP

# Emojis for categorizing pull requests

✨ New feature or functionality
🐛 Bugfix
🔥 P0 fix
✅ Tests
🚀 Performance improvements
🖍 CSS / Styling
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
↩️ Reverting a previous change
🧹 Refactoring / Housekeeping
🔧 Package Upgrades / Maintenance
🗑️ Deleting code

-->
