### PR TITLE
🏗 fix: correct developer_policy_id in postgres migration scripts

### DIFF
--- a/infra/postgresql/docker-entrypoint-initdb.d/v0.0.0.sql
+++ b/infra/postgresql/docker-entrypoint-initdb.d/v0.0.0.sql
@@ -532,7 +532,7 @@ $$
         -- Built-in policies
         owner_policy_id         UUID := '98881f6a-5c6c-4277-bcf7-fda94c538785';
         administrator_policy_id UUID := '3e961f0f-6fd4-4cf4-910f-52d356f8cc08';
-        developer_policy_id     UUID := '66f3687f-939f-4257-bd3f-c3553d39e1b6';
+        developer_policy_id     UUID := '66f3687f-939d-4257-bd3f-c3553d39e1b6';
     BEGIN
         -- truncate tables
         TRUNCATE TABLE workspaces CASCADE;


### PR DESCRIPTION
When using `Postgres`, creating new  `Organization` can cause issues. When we create a new `Organization`, we will set the default permission to `new OrganizationPermissions()` which will use the "wrong" developer policy id.

https://github.com/featbit/featbit/blob/b5cffdee9c78875b878e8db74f192e3fdd9c5671/modules/back-end/src/Domain/Organizations/Organization.cs#L24-L33

https://github.com/featbit/featbit/blob/b5cffdee9c78875b878e8db74f192e3fdd9c5671/modules/back-end/src/Domain/Organizations/OrganizationPermissions.cs#L7

https://github.com/featbit/featbit/blob/b5cffdee9c78875b878e8db74f192e3fdd9c5671/modules/back-end/src/Domain/Policies/BuiltInPolicy.cs#L10

To migrate existing data

```sql
-- fix incorrect developer_policy_id

DO
$$
    DECLARE
        old_developer_policy_id UUID := '66f3687f-939f-4257-bd3f-c3553d39e1b6';
        new_developer_policy_id UUID := '66f3687f-939d-4257-bd3f-c3553d39e1b6';
    BEGIN
        -- 1. Update the id of the built-in developer policy
        UPDATE policies
        SET id = new_developer_policy_id
        WHERE id = old_developer_policy_id
          AND type = 'SysManaged'
          AND name = 'Developer';

        -- 2. Update organizations table - fix default_permissions jsonb
        UPDATE organizations
        SET default_permissions = jsonb_set(
                default_permissions,
                '{policyIds}',
                (
                    SELECT jsonb_agg(
                                   CASE
                                       WHEN elem::text = concat('"', old_developer_policy_id::text, '"')
                                           THEN to_jsonb(new_developer_policy_id::text)
                                       ELSE elem
                                       END
                           )
                    FROM jsonb_array_elements(default_permissions -> 'policyIds') AS elem
                )
            )
        WHERE default_permissions -> 'policyIds' @> to_jsonb(old_developer_policy_id::text);

        -- 3. Update member_policies table
        UPDATE member_policies
        SET policy_id = new_developer_policy_id
        WHERE policy_id = old_developer_policy_id;

        -- 4. Update group_policies table
        UPDATE group_policies
        SET policy_id = new_developer_policy_id
        WHERE policy_id = old_developer_policy_id;

    END
$$;
```