### PR TITLE
🐛 fix: populate cache from postgres fails

### DIFF
--- a/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/SegmentService.cs
+++ b/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/SegmentService.cs
@@ -155,8 +155,11 @@ public class SegmentService(AppDbContext dbContext, ILogger<SegmentService> logg
                 .Distinct()
                 .ToArray();
 
-            var translateScopeTasks = scopesToTranslate.Select(x => TranslateScopeAsync(x));
-            var scopes = await Task.WhenAll(translateScopeTasks);
+            var scopes = new List<(string scope, ICollection<Guid> envIds)>();
+            foreach (var scopeToTranslate in scopesToTranslate)
+            {
+                scopes.Add(await TranslateScopeAsync(scopeToTranslate));
+            }
 
             foreach (var sharedSegment in sharedSegments)
             {


### PR DESCRIPTION
We cannot run query in paraller on the same `DbContext`

reference: https://learn.microsoft.com/en-us/ef/core/dbcontext-configuration/#avoiding-dbcontext-threading-issues