### PR TITLE
🐛 fix: kafka health checks use full config

### DIFF
--- a/modules/back-end/src/Infrastructure/MQ/Kafka/KafkaHealthCheckBuilderExtensions.cs
+++ b/modules/back-end/src/Infrastructure/MQ/Kafka/KafkaHealthCheckBuilderExtensions.cs
@@ -16,24 +16,19 @@ public static class KafkaHealthCheckBuilderExtensions
         string[] tags,
         TimeSpan timeout)
     {
-        var producerServer = configuration.GetValue<string>("Kafka:Producer:bootstrap.servers");
-        var consumerServer = configuration.GetValue<string>("Kafka:Consumer:bootstrap.servers");
-
-        if (string.IsNullOrEmpty(producerServer) || string.IsNullOrEmpty(consumerServer))
-        {
-            throw new InvalidOperationException("Kafka producer and consumer servers must be configured.");
-        }
+        var producerConfig = BuildHealthCheckProducerConfig(configuration.GetSection("Kafka:Producer"));
+        var consumerConfig = BuildHealthCheckProducerConfig(configuration.GetSection("Kafka:Consumer"));
 
         builder
             .AddKafka(
                 "Kafka Producer Cluster",
-                producerServer,
+                producerConfig,
                 tags,
                 timeout
             )
             .AddKafka(
                 "Kafka Consumer Cluster",
-                consumerServer,
+                consumerConfig,
                 tags,
                 timeout
             );
@@ -44,15 +39,10 @@ public static class KafkaHealthCheckBuilderExtensions
     private static IHealthChecksBuilder AddKafka(
         this IHealthChecksBuilder builder,
         string name,
-        string bootstrapServers,
+        ProducerConfig producerConfig,
         IEnumerable<string> tags,
         TimeSpan timeout)
     {
-        var producerConfig = new ProducerConfig
-        {
-            BootstrapServers = bootstrapServers
-        };
-
         var kafkaConfig = new KafkaHealthCheckOptions
         {
             Configuration = producerConfig,
@@ -69,5 +59,18 @@ public static class KafkaHealthCheckBuilderExtensions
         );
 
         return builder.Add(registration);
+    }
+
+    private static ProducerConfig BuildHealthCheckProducerConfig(IConfigurationSection section)
+    {
+        var configDictionary = new Dictionary<string, string>();
+        section.Bind(configDictionary);
+
+        if (!configDictionary.ContainsKey("bootstrap.servers"))
+        {
+            throw new InvalidOperationException($"{section.Path}:bootstrap.servers must be configured.");
+        }
+
+        return new ProducerConfig(configDictionary);
     }
 }


### PR DESCRIPTION
The Kafka health checks in the API and ELS were not binding all of the configuration like we see in the actual Kafka startup code: https://github.com/featbit/featbit/blob/ffc0a0919cea8fef6d3e4d98ee7bb3ff59953009/modules/back-end/src/Infrastructure/MQ/MqServiceCollectionExtensions.cs#L52-L66

It was only setting the bootstrap.server so any kind of authentication or SSL configuration just failed and caused errors such as:

```
{"@t":"2026-02-23T20:20:09.9339553Z","@mt":"Health check {HealthCheckName} with status {HealthStatus} completed after {ElapsedMilliseconds}ms with message '{HealthCheckDescription}'","@l":"Error","@x":"System.Threading.Tasks.TaskCanceledException: A task was canceled.
 at Confluent.Kafka.Producer2.ProduceAsync(TopicPartition topicPartition, Message2 message, CancellationToken cancellationToken)
%6|1771878018.739|FAIL|rdkafka#producer-2| [thrd:<redacted>.servicebus.windows.net:9093/bootstrap]: <redacted>.servicebus.windows.net:9093/bootstrap: Disconnected while requesting ApiVersion: might be caused by incorrect security.protocol configuration (connecting to a SSL listener?) or broker version is < 0.10 (see api.version.request) (after 2ms in state APIVERSION_QUERY, 5 identical error(s) suppressed)
```

We now bind the health check configuration in the same way the rest of the configuration is bound, with an extra check to ensure the bootstrap.servers is set as it did originally

This was causing complete failure on our instance, and after applying this patch it now works correctly