### PR TITLE
🏗 infra: missing indexes to mongo database migrations

### DIFF
--- a/infra/mongodb/docker-entrypoint-initdb.d/v0.0.0.js
+++ b/infra/mongodb/docker-entrypoint-initdb.d/v0.0.0.js
@@ -261,6 +261,8 @@ db.EndUsers.createIndex({updatedAt: 1});
 
 db.ExperimentMetrics.createIndex({updatedAt: 1});
 db.FeatureFlags.createIndex({updatedAt: 1});
+db.FeatureFlags.createIndex({createdAt: 1});
+db.FeatureFlags.createIndex({key: 1});
 db.Segments.createIndex({updatedAt: 1});
 db.AccessTokens.createIndex({createdAt: 1});
 db.Policies.createIndex({createdAt: 1});
@@ -268,4 +270,5 @@ db.Projects.createIndex({createdAt: 1});
 db.RelayProxies.createIndex({createdAt: 1});
 db.Webhooks.createIndex({createdAt: 1});
 db.Webhooks.createIndex({startedAt: 1});
+db.WebhookDeliveries.createIndex({startedAt: 1});
 print('indexes added')

--- a/kubernetes/pro/infrastructure/mongodb-init-configMap.yaml
+++ b/kubernetes/pro/infrastructure/mongodb-init-configMap.yaml
@@ -251,9 +251,12 @@ data:
     // add indexes
     print('add indexes...')
     db.AuditLogs.createIndex({ createdAt: 1 });
+    db.EndUsers.createIndex({ envId: 1, keyId: 1 });
     db.EndUsers.createIndex({ updatedAt: 1 });
     db.ExperimentMetrics.createIndex({ updatedAt: 1 });
     db.FeatureFlags.createIndex({ updatedAt: 1 });
+    db.FeatureFlags.createIndex({ createdAt: 1 });
+    db.FeatureFlags.createIndex({ key: 1 });
     db.Segments.createIndex({ updatedAt: 1 });
     db.AccessTokens.createIndex({ createdAt: 1 });
     db.Policies.createIndex({ createdAt: 1 });
@@ -261,4 +264,5 @@ data:
     db.RelayProxies.createIndex({ createdAt: 1 });
     db.Webhooks.createIndex({ createdAt: 1 });
     db.Webhooks.createIndex({ startedAt: 1 });
+    db.WebhookDeliveries.createIndex({ startedAt: 1 });
     print('indexes added')

--- a/kubernetes/standard/infrastructure/mongodb-init-configMap.yaml
+++ b/kubernetes/standard/infrastructure/mongodb-init-configMap.yaml
@@ -251,9 +251,12 @@ data:
     // add indexes
     print('add indexes...')
     db.AuditLogs.createIndex({ createdAt: 1 });
+    db.EndUsers.createIndex({ envId: 1, keyId: 1 });
     db.EndUsers.createIndex({ updatedAt: 1 });
     db.ExperimentMetrics.createIndex({ updatedAt: 1 });
     db.FeatureFlags.createIndex({ updatedAt: 1 });
+    db.FeatureFlags.createIndex({ createdAt: 1 });
+    db.FeatureFlags.createIndex({ key: 1 });
     db.Segments.createIndex({ updatedAt: 1 });
     db.AccessTokens.createIndex({ createdAt: 1 });
     db.Policies.createIndex({ createdAt: 1 });
@@ -261,4 +264,5 @@ data:
     db.RelayProxies.createIndex({ createdAt: 1 });
     db.Webhooks.createIndex({ createdAt: 1 });
     db.Webhooks.createIndex({ startedAt: 1 });
+    db.WebhookDeliveries.createIndex({ startedAt: 1 });
     print('indexes added')


### PR DESCRIPTION
Added indexes introduced by newer versions of FeatBit to the mongodb migration script.

This is particularly important if running a Mongo backend like Azure Cosmos DB that requires all sorted queries to have indexes.

Fixes https://github.com/featbit/featbit/issues/861