### PR TITLE
🐛 fix: guard message.data in websocket handler

### DIFF
--- a/benchmark/k6-scripts/data-sync.js
+++ b/benchmark/k6-scripts/data-sync.js
@@ -94,7 +94,11 @@ export default function () {
   ws.onmessage = (e) => {
     const message = JSON.parse(e.data);
 
-    if (message.messageType === 'data-sync' && message.data.eventType === "full" && message.data.userKeyId === keyId) {
+    if (
+      message.messageType === 'data-sync' &&
+      message.data.eventType === "full" &&
+      message.data.userKeyId === keyId
+    ) {
       const latency = Date.now() - dataSyncSendTime;
       LATENCY.add(latency);
 


### PR DESCRIPTION
Prevent potential runtime error when websocket messages do not include the data field.