### PR TITLE
🐛 fix: use SameSite.Lax for cross-origin cookie sharing

### DIFF
--- a/modules/back-end/src/Api/HttpResponseExtensions.cs
+++ b/modules/back-end/src/Api/HttpResponseExtensions.cs
@@ -13,7 +13,7 @@ public static class HttpResponseExtensions
         // can be configured through environment variables, for now we set it to false to make it works in any environment
         Secure = false,
 
-        // we need to allow cookies are sent on cross-domain XHR/fetch with withCredentials
+        // we need to allow cookies are sent on cross-origin XHR/fetch with withCredentials
         SameSite = SameSiteMode.Lax,
 
         MaxAge = RefreshTokenConsts.CookieMaxAge,


### PR DESCRIPTION
We should use `SameSite.Lax` by default