### PR TITLE
✨ feat: track workspace usage

### DIFF
--- a/modules/back-end/README.md
+++ b/modules/back-end/README.md
@@ -111,3 +111,10 @@ and [consumer configs](https://kafka.apache.org/documentation/#consumerconfigs) 
 | Name                | Description                       | Default Value        |
 |---------------------|-----------------------------------|----------------------|
 | `OLAP__ServiceHost` | URI for the data analytics server | `"http://da-server"` |
+
+### UsageTracking
+
+| Name                             | Description                                            | Default Value |
+|----------------------------------|--------------------------------------------------------|---------------|
+| `UsageTracking__FlushIntervalMs` | Interval in milliseconds between usage data flushes    | `5000`        |
+| `UsageTracking__ChannelCapacity` | Maximum number of usage events buffered in the channel | `10000`       |

--- a/modules/back-end/src/Api/appsettings.Development.json
+++ b/modules/back-end/src/Api/appsettings.Development.json
@@ -59,7 +59,7 @@
     "Password": ""
   },
   "UsageTracking": {
-    "FlushInterval": 5000,
+    "FlushIntervalMs": 5000,
     "ChannelCapacity": 10000
   },
   "AllowedHosts": "*",

--- a/modules/back-end/src/Api/appsettings.Development.json
+++ b/modules/back-end/src/Api/appsettings.Development.json
@@ -58,6 +58,10 @@
     "ConnectionString": "localhost:6379",
     "Password": ""
   },
+  "UsageTracking": {
+    "FlushInterval": 5000,
+    "ChannelCapacity": 10000
+  },
   "AllowedHosts": "*",
   "SSOEnabled": false,
   "PublicKey": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvXd47Say6D+c0hYr85jL\n5GF3mjxjZ/Tz2+P/9HDjVsdyXAXs38RmYSR7zFNnlw3iplQXQpEi/NcJoQET+e4K\nmlEILjOujNTJp6VpFYgTsYSncywbFVQielFXozMcco1PJCBPsl8nnGrY6FuIxugT\nxtsr32zILvmqvoB2xE9hRL4uxalY0HI2EInd38PJcmKLBwB8hcIif6Ts5X67mupw\nVwJLYv9xL6GSlenH4fXfx9HpEVeVU8yPbIF8N7pkIC3cHXvKnG0833HouKUi2YgW\n18GR6kn3Co2kmUDeJBABbPCSEzLGJRXeyBa5kVmneOWMv8mWdZRZ5nxIA0WKH/En\nkDXaMYpM8Zyi3OvlS2z93Ow2Ep/Vgm717FkZl3YHEFfcTdKwww428BgHKHzC00vk\nTkdGoexxtzEGuJoOkOYSXjA5yFAH/C5EOFFJyqEjbcAifLr7O3d/TWndBQjEFrFf\nO4syOcd8DRXImYDyARqVLWsaD1JodAxDLeDf4jfTlxhiY6iySgDHpuZeqNAbx4p9\n7pBzL0Nh5DToq4H4t2xN1eYTW+/UPMykaQuQetzecldM/RLWfu6yZM4xmJ7buPDy\n1AqCRZAOiEXSPlVPopmtA2Z6g79k9IbdiDS9skNBPF+v2eJZ58m1xxdTaxen+5pA\nFnnL39/JL0JYG7FOC+VAX0cCAwEAAQ==\n-----END PUBLIC KEY-----"

--- a/modules/back-end/src/Api/appsettings.json
+++ b/modules/back-end/src/Api/appsettings.json
@@ -58,7 +58,7 @@
     "Password": ""
   },
   "UsageTracking": {
-    "FlushInterval": 5000,
+    "FlushIntervalMs": 5000,
     "ChannelCapacity": 10000
   },
   "AllowedHosts": "*",

--- a/modules/back-end/src/Api/appsettings.json
+++ b/modules/back-end/src/Api/appsettings.json
@@ -57,6 +57,10 @@
     "ConnectionString": "redis:6379",
     "Password": ""
   },
+  "UsageTracking": {
+    "FlushInterval": 5000,
+    "ChannelCapacity": 10000
+  },
   "AllowedHosts": "*",
   "PublicKey": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvXd47Say6D+c0hYr85jL\n5GF3mjxjZ/Tz2+P/9HDjVsdyXAXs38RmYSR7zFNnlw3iplQXQpEi/NcJoQET+e4K\nmlEILjOujNTJp6VpFYgTsYSncywbFVQielFXozMcco1PJCBPsl8nnGrY6FuIxugT\nxtsr32zILvmqvoB2xE9hRL4uxalY0HI2EInd38PJcmKLBwB8hcIif6Ts5X67mupw\nVwJLYv9xL6GSlenH4fXfx9HpEVeVU8yPbIF8N7pkIC3cHXvKnG0833HouKUi2YgW\n18GR6kn3Co2kmUDeJBABbPCSEzLGJRXeyBa5kVmneOWMv8mWdZRZ5nxIA0WKH/En\nkDXaMYpM8Zyi3OvlS2z93Ow2Ep/Vgm717FkZl3YHEFfcTdKwww428BgHKHzC00vk\nTkdGoexxtzEGuJoOkOYSXjA5yFAH/C5EOFFJyqEjbcAifLr7O3d/TWndBQjEFrFf\nO4syOcd8DRXImYDyARqVLWsaD1JodAxDLeDf4jfTlxhiY6iySgDHpuZeqNAbx4p9\n7pBzL0Nh5DToq4H4t2xN1eYTW+/UPMykaQuQetzecldM/RLWfu6yZM4xmJ7buPDy\n1AqCRZAOiEXSPlVPopmtA2Z6g79k9IbdiDS9skNBPF+v2eJZ58m1xxdTaxen+5pA\nFnnL39/JL0JYG7FOC+VAX0cCAwEAAQ==\n-----END PUBLIC KEY-----"
 }

--- a/modules/back-end/src/Application/Services/IUsageAppService.cs
+++ b/modules/back-end/src/Application/Services/IUsageAppService.cs
@@ -1,0 +1,10 @@
+namespace Application.Services;
+
+public interface IUsageAppService
+{
+    Task SaveRecordsAsync(
+        Dictionary<Guid, HashSet<string>> endUsers,
+        Dictionary<Guid, (int flagEvaluations, int customMetrics)> insights,
+        CancellationToken cancellationToken
+    );
+}

--- a/modules/back-end/src/Application/Services/IUsageAppService.cs
+++ b/modules/back-end/src/Application/Services/IUsageAppService.cs
@@ -1,9 +1,8 @@
+using Application.Usages;
+
 namespace Application.Services;
 
 public interface IUsageAppService
 {
-    Task SaveRecordsAsync(
-        Dictionary<Guid, HashSet<string>> endUsers,
-        Dictionary<Guid, (int flagEvaluations, int customMetrics)> insights
-    );
+    Task SaveRecordsAsync(AggregatedUsageRecords records);
 }

--- a/modules/back-end/src/Application/Services/IUsageAppService.cs
+++ b/modules/back-end/src/Application/Services/IUsageAppService.cs
@@ -4,7 +4,6 @@ public interface IUsageAppService
 {
     Task SaveRecordsAsync(
         Dictionary<Guid, HashSet<string>> endUsers,
-        Dictionary<Guid, (int flagEvaluations, int customMetrics)> insights,
-        CancellationToken cancellationToken
+        Dictionary<Guid, (int flagEvaluations, int customMetrics)> insights
     );
 }

--- a/modules/back-end/src/Application/Usages/UsageRecord.cs
+++ b/modules/back-end/src/Application/Usages/UsageRecord.cs
@@ -1,0 +1,6 @@
+namespace Application.Usages;
+
+public abstract record UsageRecord(Guid EnvId);
+
+public record InsightsUsageRecord(Guid EnvId, string[] EndUsers, int FlagEvaluations, int CustomMetrics)
+    : UsageRecord(EnvId);

--- a/modules/back-end/src/Application/Usages/UsageRecord.cs
+++ b/modules/back-end/src/Application/Usages/UsageRecord.cs
@@ -1,6 +1,10 @@
 namespace Application.Usages;
 
-public abstract record UsageRecord(Guid EnvId);
+public abstract record UsageRecord(Guid EnvId, DateOnly RecordedAt);
 
-public record InsightsUsageRecord(Guid EnvId, string[] EndUsers, int FlagEvaluations, int CustomMetrics)
-    : UsageRecord(EnvId);
+public record InsightsUsageRecord(
+    Guid EnvId,
+    DateOnly RecordedAt,
+    string[] EndUsers,
+    int FlagEvaluations,
+    int CustomMetrics) : UsageRecord(EnvId, RecordedAt);

--- a/modules/back-end/src/Application/Usages/UsageRecordsAggregator.cs
+++ b/modules/back-end/src/Application/Usages/UsageRecordsAggregator.cs
@@ -1,0 +1,67 @@
+namespace Application.Usages;
+
+public record AggregatedUsageRecords(
+    DateOnly RecordedAt,
+    Dictionary<Guid, HashSet<string>> EndUsers,
+    Dictionary<Guid, (int FlagEvaluations, int CustomMetrics)> Events
+);
+
+public static class UsageRecordsAggregator
+{
+    public static AggregatedUsageRecords[] Aggregate(List<UsageRecord> records)
+    {
+        var groupByRecordedAt = records.GroupBy(x => x.RecordedAt).ToArray();
+        if (groupByRecordedAt.Length == 1)
+        {
+            // this is the most common case
+            return [AggregateCore(groupByRecordedAt[0])];
+        }
+
+        var aggregationResults = new AggregatedUsageRecords[groupByRecordedAt.Length];
+
+        for (int i = 0; i < groupByRecordedAt.Length; i++)
+        {
+            var group = groupByRecordedAt[i];
+            aggregationResults[i] = AggregateCore(group);
+        }
+
+        return aggregationResults;
+
+        AggregatedUsageRecords AggregateCore(IGrouping<DateOnly, UsageRecord> group)
+        {
+            var recordedAt = group.Key;
+
+            var endUserRecords = new Dictionary<Guid, HashSet<string>>();
+            var eventRecords = new Dictionary<Guid, (int flagEvals, int customMetrics)>();
+
+            foreach (var record in group)
+            {
+                switch (record)
+                {
+                    case InsightsUsageRecord iur:
+                        if (!endUserRecords.TryGetValue(iur.EnvId, out var endUsers))
+                        {
+                            endUsers = [];
+                            endUserRecords[iur.EnvId] = endUsers;
+                        }
+
+                        // for end users, we only care about unique count
+                        foreach (var endUser in iur.EndUsers)
+                        {
+                            endUsers.Add(endUser);
+                        }
+
+                        // for flag evaluations and custom metrics, we sum them up
+                        var existing = eventRecords.GetValueOrDefault(iur.EnvId, (flagEvals: 0, customMetrics: 0));
+                        eventRecords[iur.EnvId] = (
+                            existing.flagEvals + iur.FlagEvaluations,
+                            existing.customMetrics + iur.CustomMetrics
+                        );
+                        break;
+                }
+            }
+
+            return new AggregatedUsageRecords(recordedAt, endUserRecords, eventRecords);
+        }
+    }
+}

--- a/modules/back-end/src/Application/Usages/UsageTracker.cs
+++ b/modules/back-end/src/Application/Usages/UsageTracker.cs
@@ -14,9 +14,9 @@ public class UsageTracker(IOptions<UsageTrackingOptions> options)
         }
     );
 
-    public void RecordInsights(Guid envId, string[] endUsers, int flagEvaluations, int customMetrics)
+    public void RecordInsights(Guid envId, DateOnly recordedAt, string[] endUsers, int flagEvaluations, int customMetrics)
     {
-        var record = new InsightsUsageRecord(envId, endUsers, flagEvaluations, customMetrics);
+        var record = new InsightsUsageRecord(envId, recordedAt, endUsers, flagEvaluations, customMetrics);
         _recordsChannel.Writer.TryWrite(record);
     }
 

--- a/modules/back-end/src/Application/Usages/UsageTracker.cs
+++ b/modules/back-end/src/Application/Usages/UsageTracker.cs
@@ -1,0 +1,24 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Options;
+
+namespace Application.Usages;
+
+public class UsageTracker(IOptions<UsageTrackingOptions> options)
+{
+    private readonly Channel<UsageRecord> _recordsChannel = Channel.CreateBounded<UsageRecord>(
+        new BoundedChannelOptions(options.Value.ChannelCapacity)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleWriter = false,
+            SingleReader = true
+        }
+    );
+
+    public void RecordInsights(Guid envId, string[] endUsers, int flagEvaluations, int customMetrics)
+    {
+        var record = new InsightsUsageRecord(envId, endUsers, flagEvaluations, customMetrics);
+        _recordsChannel.Writer.TryWrite(record);
+    }
+
+    public ChannelReader<UsageRecord> Reader => _recordsChannel.Reader;
+}

--- a/modules/back-end/src/Application/Usages/UsageTrackingOptions.cs
+++ b/modules/back-end/src/Application/Usages/UsageTrackingOptions.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Application.Usages;
+
+public class UsageTrackingOptions
+{
+    public const string UsageTracking = nameof(UsageTracking);
+
+    [Range(1000, 30_000, ErrorMessage = "Flush interval must be between 1,000 ms and 30,000 ms.")]
+    public int FlushInterval { get; set; } = 5000;
+
+    [Range(1000, 100_000, ErrorMessage = "Channel capacity must be between 1,000 and 100,000.")]
+    public int ChannelCapacity { get; set; } = 10_000;
+}

--- a/modules/back-end/src/Application/Usages/UsageTrackingOptions.cs
+++ b/modules/back-end/src/Application/Usages/UsageTrackingOptions.cs
@@ -7,7 +7,7 @@ public class UsageTrackingOptions
     public const string UsageTracking = nameof(UsageTracking);
 
     [Range(1000, 30_000, ErrorMessage = "Flush interval must be between 1,000 ms and 30,000 ms.")]
-    public int FlushInterval { get; set; } = 5000;
+    public int FlushIntervalMs { get; set; } = 5000;
 
     [Range(1000, 100_000, ErrorMessage = "Channel capacity must be between 1,000 and 100,000.")]
     public int ChannelCapacity { get; set; } = 10_000;

--- a/modules/back-end/src/Application/Webhooks/SendWebhook.cs
+++ b/modules/back-end/src/Application/Webhooks/SendWebhook.cs
@@ -28,7 +28,7 @@ public class SendWebhookValidator : AbstractValidator<SendWebhook>
             {
                 try
                 {
-                    JsonDocument.Parse(x);
+                    using var _ = JsonDocument.Parse(x);
                     return true;
                 }
                 catch (JsonException)
@@ -50,7 +50,7 @@ public class SendWebhookHandler : IRequestHandler<SendWebhook, WebhookDelivery>
 
     public async Task<WebhookDelivery> Handle(SendWebhook request, CancellationToken cancellationToken)
     {
-        var json = JsonDocument.Parse(request.Payload);
+        using var json = JsonDocument.Parse(request.Payload);
         if (request.PreventEmptyPayloads && json.RootElement.IsEmptyObject())
         {
             return WebhookDelivery.Ignored("Not allowed to send an empty JSON object", request.Url, request.Payload);

--- a/modules/back-end/src/Domain/Messages/Topics.cs
+++ b/modules/back-end/src/Domain/Messages/Topics.cs
@@ -10,6 +10,8 @@ public static class Topics
 
     public const string Insights = "featbit-insights";
 
+    public const string Usage = "featbit-usage";
+
     public static string ToChannel(string topic) => topic switch
     {
         FeatureFlagChange => "featbit_feature_flag_change_channel",

--- a/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
+++ b/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
@@ -1,0 +1,170 @@
+using Dapper;
+using Infrastructure.Persistence;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Npgsql;
+
+namespace Infrastructure.AppService;
+
+public class UsageAppService(IConfiguration configuration, IServiceProvider serviceProvider) : IUsageAppService
+{
+    public async Task SaveRecordsAsync(
+        Dictionary<Guid, HashSet<string>> endUsers,
+        Dictionary<Guid, (int flagEvaluations, int customMetrics)> insights,
+        CancellationToken cancellationToken)
+    {
+        var dbProvider = configuration.GetDbProvider();
+
+        var task = dbProvider.Name switch
+        {
+            DbProvider.Postgres => PostgresSaveAsync(),
+            DbProvider.MongoDb => MongoDbSaveAsync(),
+            _ => Task.CompletedTask
+        };
+
+        await task;
+
+        return;
+
+        async Task PostgresSaveAsync()
+        {
+            var dataSource = serviceProvider.GetRequiredService<NpgsqlDataSource>();
+            await using var connection = await dataSource.OpenConnectionAsync();
+
+            var now = DateTime.UtcNow;
+
+            // Record each unique user once per month (DO NOTHING on conflict preserves first_seen_at).
+            if (endUsers.Count > 0)
+            {
+                List<Guid> mauEnvIds = [];
+                List<string> mauUserKeys = [];
+                foreach (var endUser in endUsers)
+                {
+                    var (key, value) = endUser;
+
+                    foreach (var userKey in value)
+                    {
+                        mauEnvIds.Add(key);
+                        mauUserKeys.Add(userKey);
+                    }
+                }
+
+                await connection.ExecuteAsync(
+                    """
+                    INSERT INTO usage_end_user_stats (env_id, year_month, user_key, first_seen_at)
+                    SELECT env_id, @YearMonth, user_key, @FirstSeenAt
+                    FROM unnest(
+                        @EnvIds::uuid[],
+                        @UserKeys::text[]
+                    ) AS t(env_id, user_key)
+                    ON CONFLICT (env_id, year_month, user_key) DO NOTHING
+                    """,
+                    new
+                    {
+                        EnvIds = mauEnvIds.ToArray(),
+                        YearMonth = now.Year * 100 + now.Month,
+                        UserKeys = mauUserKeys.ToArray(),
+                        FirstSeenAt = DateOnly.FromDateTime(now)
+                    }
+                );
+            }
+
+            // Accumulate daily flag evaluation and custom metric counts.
+            // ON CONFLICT increments so multiple flushes per day are safe.
+            if (insights.Count > 0)
+            {
+                List<Guid> envIds = [];
+                List<int> flagEvaluations = [];
+                List<int> customMetrics = [];
+                foreach (var insight in insights)
+                {
+                    var (key, value) = insight;
+
+                    envIds.Add(key);
+                    flagEvaluations.Add(value.flagEvaluations);
+                    customMetrics.Add(value.customMetrics);
+                }
+
+                await connection.ExecuteAsync(
+                    """
+                    INSERT INTO usage_event_stats (env_id, stats_date, flag_evaluations, custom_metrics)
+                    SELECT env_id, @StatsDate, flag_evaluations, custom_metrics
+                    FROM unnest(
+                        @EnvIds::uuid[],
+                        @FlagEvaluations::int[],
+                        @CustomMetrics::int[]
+                    ) AS t(env_id, flag_evaluations, custom_metrics)
+                    ON CONFLICT (env_id, stats_date) DO UPDATE
+                        SET flag_evaluations = usage_event_stats.flag_evaluations + EXCLUDED.flag_evaluations,
+                            custom_metrics   = usage_event_stats.custom_metrics   + EXCLUDED.custom_metrics
+                    """,
+                    new
+                    {
+                        EnvIds = envIds.ToArray(),
+                        StatsDate = DateOnly.FromDateTime(now),
+                        FlagEvaluations = flagEvaluations.ToArray(),
+                        CustomMetrics = customMetrics.ToArray()
+                    }
+                );
+            }
+        }
+
+        async Task MongoDbSaveAsync()
+        {
+            var mongoClient = serviceProvider.GetRequiredService<MongoDbClient>();
+            var now = DateTime.UtcNow;
+
+            // Record each unique user once per month; $setOnInsert ensures firstSeenAt is never overwritten.
+            if (endUsers.Count > 0)
+            {
+                var yearMonth = now.Year * 100 + now.Month;
+                var today = DateOnly.FromDateTime(now);
+
+                var mauCollection = mongoClient.CollectionOf("UsageEndUserStats");
+                var mauUpdates = endUsers.SelectMany(kvp => kvp.Value.Select(userKey =>
+                    {
+                        var filter = Builders<BsonDocument>.Filter.And(
+                            Builders<BsonDocument>.Filter.Eq("envId", new BsonBinaryData(kvp.Key, GuidRepresentation.Standard)),
+                            Builders<BsonDocument>.Filter.Eq("yearMonth", yearMonth),
+                            Builders<BsonDocument>.Filter.Eq("userKey", userKey)
+                        );
+
+                        var update = Builders<BsonDocument>.Update
+                            .SetOnInsert("envId", kvp.Key)
+                            .SetOnInsert("yearMonth", yearMonth)
+                            .SetOnInsert("userKey", userKey)
+                            .SetOnInsert("firstSeenAt", today);
+
+                        return new UpdateOneModel<BsonDocument>(filter, update) { IsUpsert = true };
+                    })
+                );
+
+                await mauCollection.BulkWriteAsync(mauUpdates, cancellationToken: cancellationToken);
+            }
+
+            // Accumulate daily flag evaluation and custom metric counts via $inc upsert.
+            if (insights.Count > 0)
+            {
+                var statsCollection = mongoClient.CollectionOf("UsageEventStats");
+
+                var statsUpdates = insights.Select(kvp =>
+                {
+                    var filter = Builders<BsonDocument>.Filter.And(
+                        Builders<BsonDocument>.Filter.Eq("envId", new BsonBinaryData(kvp.Key, GuidRepresentation.Standard)),
+                        Builders<BsonDocument>.Filter.Eq("statsDate", now.Date)
+                    );
+
+                    var update = Builders<BsonDocument>.Update
+                        .Inc("flagEvaluations", kvp.Value.flagEvaluations)
+                        .Inc("customMetrics", kvp.Value.customMetrics);
+
+                    return new UpdateOneModel<BsonDocument>(filter, update) { IsUpsert = true };
+                });
+
+                await statsCollection.BulkWriteAsync(statsUpdates, cancellationToken: cancellationToken);
+            }
+        }
+    }
+}

--- a/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
+++ b/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
@@ -137,9 +137,12 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
 
                         return new UpdateOneModel<BsonDocument>(filter, update) { IsUpsert = true };
                     })
-                );
+                ).ToArray();
 
-                await mauCollection.BulkWriteAsync(mauUpdates);
+                if (mauUpdates.Length > 0)
+                {
+                    await mauCollection.BulkWriteAsync(mauUpdates);
+                }
             }
 
             // Accumulate daily flag evaluation and custom metric counts via $inc upsert.

--- a/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
+++ b/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
@@ -63,7 +63,10 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
                     EnvIds = mauEnvIds.ToArray(),
                     YearMonth = recordedAt.Year * 100 + recordedAt.Month,
                     UserKeys = mauUserKeys.ToArray(),
-                    FirstSeenAt = recordedAt.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)
+                    // The date time must be Unspecified kind, which PG already considered as local, and so timezone conversion wasn't applied when converting to date.
+                    // Check https://github.com/npgsql/npgsql/issues/4471#issuecomment-1134314277 for details.
+                    // https://www.npgsql.org/doc/types/datetime.html#net-types-and-postgresql-types
+                    FirstSeenAt = recordedAt.ToDateTime(TimeOnly.MinValue)
                 }
             );
         }
@@ -100,7 +103,10 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
                 new
                 {
                     EnvIds = envIds.ToArray(),
-                    StatsDate = recordedAt.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+                    // The date time must be Unspecified kind, which PG already considered as local, and so timezone conversion wasn't applied when converting to date.
+                    // Check https://github.com/npgsql/npgsql/issues/4471#issuecomment-1134314277 for details.
+                    // https://www.npgsql.org/doc/types/datetime.html#net-types-and-postgresql-types
+                    StatsDate = recordedAt.ToDateTime(TimeOnly.MinValue),
                     FlagEvaluations = flagEvaluations.ToArray(),
                     CustomMetrics = customMetrics.ToArray()
                 }

--- a/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
+++ b/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
@@ -12,8 +12,7 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
 {
     public async Task SaveRecordsAsync(
         Dictionary<Guid, HashSet<string>> endUsers,
-        Dictionary<Guid, (int flagEvaluations, int customMetrics)> insights,
-        CancellationToken cancellationToken)
+        Dictionary<Guid, (int flagEvaluations, int customMetrics)> insights)
     {
         var dbProvider = configuration.GetDbProvider();
 
@@ -132,7 +131,7 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
                         );
 
                         var update = Builders<BsonDocument>.Update
-                            .SetOnInsert("envId", kvp.Key)
+                            .SetOnInsert("envId", new BsonBinaryData(kvp.Key, GuidRepresentation.Standard))
                             .SetOnInsert("yearMonth", yearMonth)
                             .SetOnInsert("userKey", userKey)
                             .SetOnInsert("firstSeenAt", today);
@@ -141,7 +140,7 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
                     })
                 );
 
-                await mauCollection.BulkWriteAsync(mauUpdates, cancellationToken: cancellationToken);
+                await mauCollection.BulkWriteAsync(mauUpdates);
             }
 
             // Accumulate daily flag evaluation and custom metric counts via $inc upsert.
@@ -163,7 +162,7 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
                     return new UpdateOneModel<BsonDocument>(filter, update) { IsUpsert = true };
                 });
 
-                await statsCollection.BulkWriteAsync(statsUpdates, cancellationToken: cancellationToken);
+                await statsCollection.BulkWriteAsync(statsUpdates);
             }
         }
     }

--- a/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
+++ b/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
@@ -65,7 +65,7 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
                         EnvIds = mauEnvIds.ToArray(),
                         YearMonth = now.Year * 100 + now.Month,
                         UserKeys = mauUserKeys.ToArray(),
-                        FirstSeenAt = DateOnly.FromDateTime(now)
+                        FirstSeenAt = now.Date
                     }
                 );
             }
@@ -102,7 +102,7 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
                     new
                     {
                         EnvIds = envIds.ToArray(),
-                        StatsDate = DateOnly.FromDateTime(now),
+                        StatsDate = now.Date,
                         FlagEvaluations = flagEvaluations.ToArray(),
                         CustomMetrics = customMetrics.ToArray()
                     }
@@ -119,7 +119,6 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
             if (endUsers.Count > 0)
             {
                 var yearMonth = now.Year * 100 + now.Month;
-                var today = DateOnly.FromDateTime(now);
 
                 var mauCollection = mongoClient.CollectionOf("UsageEndUserStats");
                 var mauUpdates = endUsers.SelectMany(kvp => kvp.Value.Select(userKey =>
@@ -134,7 +133,7 @@ public class UsageAppService(IConfiguration configuration, IServiceProvider serv
                             .SetOnInsert("envId", new BsonBinaryData(kvp.Key, GuidRepresentation.Standard))
                             .SetOnInsert("yearMonth", yearMonth)
                             .SetOnInsert("userKey", userKey)
-                            .SetOnInsert("firstSeenAt", today);
+                            .SetOnInsert("firstSeenAt", now.Date);
 
                         return new UpdateOneModel<BsonDocument>(filter, update) { IsUpsert = true };
                     })

--- a/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
+++ b/modules/back-end/src/Infrastructure/AppService/UsageAppService.cs
@@ -1,3 +1,4 @@
+using Application.Usages;
 using Dapper;
 using Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
@@ -10,162 +11,162 @@ namespace Infrastructure.AppService;
 
 public class UsageAppService(IConfiguration configuration, IServiceProvider serviceProvider) : IUsageAppService
 {
-    public async Task SaveRecordsAsync(
-        Dictionary<Guid, HashSet<string>> endUsers,
-        Dictionary<Guid, (int flagEvaluations, int customMetrics)> insights)
+    public async Task SaveRecordsAsync(AggregatedUsageRecords records)
     {
         var dbProvider = configuration.GetDbProvider();
 
         var task = dbProvider.Name switch
         {
-            DbProvider.Postgres => PostgresSaveAsync(),
-            DbProvider.MongoDb => MongoDbSaveAsync(),
+            DbProvider.Postgres => PostgresSaveAsync(records),
+            DbProvider.MongoDb => MongoDbSaveAsync(records),
             _ => Task.CompletedTask
         };
 
         await task;
+    }
 
-        return;
+    private async Task PostgresSaveAsync(AggregatedUsageRecords records)
+    {
+        var (recordedAt, endUsers, events) = records;
 
-        async Task PostgresSaveAsync()
+        var dataSource = serviceProvider.GetRequiredService<NpgsqlDataSource>();
+        await using var connection = await dataSource.OpenConnectionAsync();
+
+        if (endUsers.Count > 0)
         {
-            var dataSource = serviceProvider.GetRequiredService<NpgsqlDataSource>();
-            await using var connection = await dataSource.OpenConnectionAsync();
+            List<Guid> mauEnvIds = [];
+            List<string> mauUserKeys = [];
+            foreach (var endUser in endUsers)
+            {
+                var (key, value) = endUser;
 
-            var now = DateTime.UtcNow;
+                foreach (var userKey in value)
+                {
+                    mauEnvIds.Add(key);
+                    mauUserKeys.Add(userKey);
+                }
+            }
 
             // Record each unique user once per month (DO NOTHING on conflict preserves first_seen_at).
-            if (endUsers.Count > 0)
-            {
-                List<Guid> mauEnvIds = [];
-                List<string> mauUserKeys = [];
-                foreach (var endUser in endUsers)
+            await connection.ExecuteAsync(
+                """
+                INSERT INTO usage_end_user_stats (env_id, year_month, user_key, first_seen_at)
+                SELECT env_id, @YearMonth, user_key, @FirstSeenAt
+                FROM unnest(
+                    @EnvIds::uuid[],
+                    @UserKeys::text[]
+                ) AS t(env_id, user_key)
+                ON CONFLICT (env_id, year_month, user_key) DO NOTHING
+                """,
+                new
                 {
-                    var (key, value) = endUser;
-
-                    foreach (var userKey in value)
-                    {
-                        mauEnvIds.Add(key);
-                        mauUserKeys.Add(userKey);
-                    }
+                    EnvIds = mauEnvIds.ToArray(),
+                    YearMonth = recordedAt.Year * 100 + recordedAt.Month,
+                    UserKeys = mauUserKeys.ToArray(),
+                    FirstSeenAt = recordedAt.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)
                 }
+            );
+        }
 
-                await connection.ExecuteAsync(
-                    """
-                    INSERT INTO usage_end_user_stats (env_id, year_month, user_key, first_seen_at)
-                    SELECT env_id, @YearMonth, user_key, @FirstSeenAt
-                    FROM unnest(
-                        @EnvIds::uuid[],
-                        @UserKeys::text[]
-                    ) AS t(env_id, user_key)
-                    ON CONFLICT (env_id, year_month, user_key) DO NOTHING
-                    """,
-                    new
-                    {
-                        EnvIds = mauEnvIds.ToArray(),
-                        YearMonth = now.Year * 100 + now.Month,
-                        UserKeys = mauUserKeys.ToArray(),
-                        FirstSeenAt = now.Date
-                    }
-                );
+        if (events.Count > 0)
+        {
+            List<Guid> envIds = [];
+            List<int> flagEvaluations = [];
+            List<int> customMetrics = [];
+            foreach (var insight in events)
+            {
+                var (key, value) = insight;
+
+                envIds.Add(key);
+                flagEvaluations.Add(value.FlagEvaluations);
+                customMetrics.Add(value.CustomMetrics);
             }
 
             // Accumulate daily flag evaluation and custom metric counts.
             // ON CONFLICT increments so multiple flushes per day are safe.
-            if (insights.Count > 0)
-            {
-                List<Guid> envIds = [];
-                List<int> flagEvaluations = [];
-                List<int> customMetrics = [];
-                foreach (var insight in insights)
+            await connection.ExecuteAsync(
+                """
+                INSERT INTO usage_event_stats (env_id, stats_date, flag_evaluations, custom_metrics)
+                SELECT env_id, @StatsDate, flag_evaluations, custom_metrics
+                FROM unnest(
+                    @EnvIds::uuid[],
+                    @FlagEvaluations::int[],
+                    @CustomMetrics::int[]
+                ) AS t(env_id, flag_evaluations, custom_metrics)
+                ON CONFLICT (env_id, stats_date) DO UPDATE
+                    SET flag_evaluations = usage_event_stats.flag_evaluations + EXCLUDED.flag_evaluations,
+                        custom_metrics   = usage_event_stats.custom_metrics   + EXCLUDED.custom_metrics
+                """,
+                new
                 {
-                    var (key, value) = insight;
-
-                    envIds.Add(key);
-                    flagEvaluations.Add(value.flagEvaluations);
-                    customMetrics.Add(value.customMetrics);
+                    EnvIds = envIds.ToArray(),
+                    StatsDate = recordedAt.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+                    FlagEvaluations = flagEvaluations.ToArray(),
+                    CustomMetrics = customMetrics.ToArray()
                 }
-
-                await connection.ExecuteAsync(
-                    """
-                    INSERT INTO usage_event_stats (env_id, stats_date, flag_evaluations, custom_metrics)
-                    SELECT env_id, @StatsDate, flag_evaluations, custom_metrics
-                    FROM unnest(
-                        @EnvIds::uuid[],
-                        @FlagEvaluations::int[],
-                        @CustomMetrics::int[]
-                    ) AS t(env_id, flag_evaluations, custom_metrics)
-                    ON CONFLICT (env_id, stats_date) DO UPDATE
-                        SET flag_evaluations = usage_event_stats.flag_evaluations + EXCLUDED.flag_evaluations,
-                            custom_metrics   = usage_event_stats.custom_metrics   + EXCLUDED.custom_metrics
-                    """,
-                    new
-                    {
-                        EnvIds = envIds.ToArray(),
-                        StatsDate = now.Date,
-                        FlagEvaluations = flagEvaluations.ToArray(),
-                        CustomMetrics = customMetrics.ToArray()
-                    }
-                );
-            }
+            );
         }
+    }
 
-        async Task MongoDbSaveAsync()
+    private async Task MongoDbSaveAsync(AggregatedUsageRecords records)
+    {
+        var (recordedAt, endUsers, events) = records;
+        var recordedDateTime = recordedAt.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        var mongoClient = serviceProvider.GetRequiredService<MongoDbClient>();
+
+        // Record each unique user once per month; $setOnInsert ensures firstSeenAt is never overwritten.
+        if (endUsers.Count > 0)
         {
-            var mongoClient = serviceProvider.GetRequiredService<MongoDbClient>();
-            var now = DateTime.UtcNow;
+            var yearMonth = recordedAt.Year * 100 + recordedAt.Month;
 
-            // Record each unique user once per month; $setOnInsert ensures firstSeenAt is never overwritten.
-            if (endUsers.Count > 0)
-            {
-                var yearMonth = now.Year * 100 + now.Month;
-
-                var mauCollection = mongoClient.CollectionOf("UsageEndUserStats");
-                var mauUpdates = endUsers.SelectMany(kvp => kvp.Value.Select(userKey =>
-                    {
-                        var filter = Builders<BsonDocument>.Filter.And(
-                            Builders<BsonDocument>.Filter.Eq("envId", new BsonBinaryData(kvp.Key, GuidRepresentation.Standard)),
-                            Builders<BsonDocument>.Filter.Eq("yearMonth", yearMonth),
-                            Builders<BsonDocument>.Filter.Eq("userKey", userKey)
-                        );
-
-                        var update = Builders<BsonDocument>.Update
-                            .SetOnInsert("envId", new BsonBinaryData(kvp.Key, GuidRepresentation.Standard))
-                            .SetOnInsert("yearMonth", yearMonth)
-                            .SetOnInsert("userKey", userKey)
-                            .SetOnInsert("firstSeenAt", now.Date);
-
-                        return new UpdateOneModel<BsonDocument>(filter, update) { IsUpsert = true };
-                    })
-                ).ToArray();
-
-                if (mauUpdates.Length > 0)
+            var mauCollection = mongoClient.CollectionOf("UsageEndUserStats");
+            var mauUpdates = endUsers.SelectMany(kvp => kvp.Value.Select(userKey =>
                 {
-                    await mauCollection.BulkWriteAsync(mauUpdates);
-                }
-            }
+                    var envId = new BsonBinaryData(kvp.Key, GuidRepresentation.Standard);
 
-            // Accumulate daily flag evaluation and custom metric counts via $inc upsert.
-            if (insights.Count > 0)
-            {
-                var statsCollection = mongoClient.CollectionOf("UsageEventStats");
-
-                var statsUpdates = insights.Select(kvp =>
-                {
                     var filter = Builders<BsonDocument>.Filter.And(
-                        Builders<BsonDocument>.Filter.Eq("envId", new BsonBinaryData(kvp.Key, GuidRepresentation.Standard)),
-                        Builders<BsonDocument>.Filter.Eq("statsDate", now.Date)
+                        Builders<BsonDocument>.Filter.Eq("envId", envId),
+                        Builders<BsonDocument>.Filter.Eq("yearMonth", yearMonth),
+                        Builders<BsonDocument>.Filter.Eq("userKey", userKey)
                     );
 
                     var update = Builders<BsonDocument>.Update
-                        .Inc("flagEvaluations", kvp.Value.flagEvaluations)
-                        .Inc("customMetrics", kvp.Value.customMetrics);
+                        .SetOnInsert("envId", envId)
+                        .SetOnInsert("yearMonth", yearMonth)
+                        .SetOnInsert("userKey", userKey)
+                        .SetOnInsert("firstSeenAt", recordedDateTime);
 
                     return new UpdateOneModel<BsonDocument>(filter, update) { IsUpsert = true };
-                });
+                })
+            ).ToArray();
 
-                await statsCollection.BulkWriteAsync(statsUpdates);
+            if (mauUpdates.Length > 0)
+            {
+                await mauCollection.BulkWriteAsync(mauUpdates);
             }
+        }
+
+        // Accumulate daily flag evaluation and custom metric counts via $inc upsert.
+        if (events.Count > 0)
+        {
+            var statsCollection = mongoClient.CollectionOf("UsageEventStats");
+
+            var statsUpdates = events.Select(kvp =>
+            {
+                var filter = Builders<BsonDocument>.Filter.And(
+                    Builders<BsonDocument>.Filter.Eq("envId", new BsonBinaryData(kvp.Key, GuidRepresentation.Standard)),
+                    Builders<BsonDocument>.Filter.Eq("statsDate", recordedDateTime)
+                );
+
+                var update = Builders<BsonDocument>.Update
+                    .Inc("flagEvaluations", kvp.Value.FlagEvaluations)
+                    .Inc("customMetrics", kvp.Value.CustomMetrics);
+
+                return new UpdateOneModel<BsonDocument>(filter, update) { IsUpsert = true };
+            });
+
+            await statsCollection.BulkWriteAsync(statsUpdates);
         }
     }
 }

--- a/modules/back-end/src/Infrastructure/AppService/UsageFlushWorker.cs
+++ b/modules/back-end/src/Infrastructure/AppService/UsageFlushWorker.cs
@@ -1,0 +1,105 @@
+using Application.Usages;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AppService;
+
+public class UsageFlushWorker(
+    UsageTracker usageTracker,
+    IOptions<UsageTrackingOptions> options,
+    IServiceProvider serviceProvider,
+    ILogger<UsageFlushWorker> logger) : BackgroundService
+{
+    private readonly PeriodicTimer _timer = new(TimeSpan.FromMilliseconds(options.Value.FlushInterval));
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (await _timer.WaitForNextTickAsync(stoppingToken))
+        {
+            var records = new List<UsageRecord>();
+
+            try
+            {
+                // Drain everything currently available
+                while (usageTracker.Reader.TryRead(out var record))
+                {
+                    records.Add(record);
+                }
+
+                if (records.Count == 0)
+                {
+                    continue;
+                }
+
+                await FlushCoreAsync(records, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // ignore cancellation
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Exception occurred while flushing usage records.");
+            }
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _timer.Dispose();
+        await base.StopAsync(cancellationToken);
+
+        // Flush whatever remains in the channel
+        var remaining = new List<UsageRecord>();
+        while (usageTracker.Reader.TryRead(out var record))
+        {
+            remaining.Add(record);
+        }
+
+        if (remaining.Count > 0)
+        {
+            await FlushCoreAsync(remaining, cancellationToken);
+        }
+    }
+
+    private async Task FlushCoreAsync(List<UsageRecord> records, CancellationToken cancellationToken)
+    {
+        var endUserRecords = new Dictionary<Guid, HashSet<string>>();
+        var insightRecords = new Dictionary<Guid, (int flagEvals, int customMetrics)>();
+
+        // aggregate records by envId, so we can batch upserts by envId
+        foreach (var record in records)
+        {
+            switch (record)
+            {
+                case InsightsUsageRecord iur:
+                    if (!endUserRecords.TryGetValue(iur.EnvId, out var endUsers))
+                    {
+                        endUsers = [];
+                        endUserRecords[iur.EnvId] = endUsers;
+                    }
+
+                    // for end users, we only care about unique count
+                    foreach (var endUser in iur.EndUsers)
+                    {
+                        endUsers.Add(endUser);
+                    }
+
+                    // for flag evaluations and custom metrics, we sum them up
+                    var existing = insightRecords.GetValueOrDefault(iur.EnvId, (flagEvals: 0, customMetrics: 0));
+                    insightRecords[iur.EnvId] = (
+                        existing.flagEvals + iur.FlagEvaluations,
+                        existing.customMetrics + iur.CustomMetrics
+                    );
+
+                    break;
+            }
+        }
+
+        using var scope = serviceProvider.CreateScope();
+        var usageAppService = scope.ServiceProvider.GetRequiredService<IUsageAppService>();
+        await usageAppService.SaveRecordsAsync(endUserRecords, insightRecords, cancellationToken);
+    }
+}

--- a/modules/back-end/src/Infrastructure/AppService/UsageFlushWorker.cs
+++ b/modules/back-end/src/Infrastructure/AppService/UsageFlushWorker.cs
@@ -66,40 +66,25 @@ public class UsageFlushWorker(
 
     private async Task FlushCoreAsync(List<UsageRecord> records)
     {
-        var endUserRecords = new Dictionary<Guid, HashSet<string>>();
-        var insightRecords = new Dictionary<Guid, (int flagEvals, int customMetrics)>();
-
-        // aggregate records by envId, so we can batch upserts by envId
-        foreach (var record in records)
-        {
-            switch (record)
-            {
-                case InsightsUsageRecord iur:
-                    if (!endUserRecords.TryGetValue(iur.EnvId, out var endUsers))
-                    {
-                        endUsers = [];
-                        endUserRecords[iur.EnvId] = endUsers;
-                    }
-
-                    // for end users, we only care about unique count
-                    foreach (var endUser in iur.EndUsers)
-                    {
-                        endUsers.Add(endUser);
-                    }
-
-                    // for flag evaluations and custom metrics, we sum them up
-                    var existing = insightRecords.GetValueOrDefault(iur.EnvId, (flagEvals: 0, customMetrics: 0));
-                    insightRecords[iur.EnvId] = (
-                        existing.flagEvals + iur.FlagEvaluations,
-                        existing.customMetrics + iur.CustomMetrics
-                    );
-
-                    break;
-            }
-        }
+        var aggregatedRecords = UsageRecordsAggregator.Aggregate(records);
 
         using var scope = serviceProvider.CreateScope();
         var usageAppService = scope.ServiceProvider.GetRequiredService<IUsageAppService>();
-        await usageAppService.SaveRecordsAsync(endUserRecords, insightRecords);
+
+        if (aggregatedRecords.Length == 1)
+        {
+            // this is the most common case
+            await usageAppService.SaveRecordsAsync(aggregatedRecords[0]);
+        }
+        else
+        {
+            var tasks = new Task[aggregatedRecords.Length];
+            for (var i = 0; i < aggregatedRecords.Length; i++)
+            {
+                tasks[i] = usageAppService.SaveRecordsAsync(aggregatedRecords[i]);
+            }
+
+            await Task.WhenAll(tasks);
+        }
     }
 }

--- a/modules/back-end/src/Infrastructure/AppService/UsageFlushWorker.cs
+++ b/modules/back-end/src/Infrastructure/AppService/UsageFlushWorker.cs
@@ -12,7 +12,7 @@ public class UsageFlushWorker(
     IServiceProvider serviceProvider,
     ILogger<UsageFlushWorker> logger) : BackgroundService
 {
-    private readonly PeriodicTimer _timer = new(TimeSpan.FromMilliseconds(options.Value.FlushInterval));
+    private readonly PeriodicTimer _timer = new(TimeSpan.FromMilliseconds(options.Value.FlushIntervalMs));
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {

--- a/modules/back-end/src/Infrastructure/AppService/UsageFlushWorker.cs
+++ b/modules/back-end/src/Infrastructure/AppService/UsageFlushWorker.cs
@@ -33,11 +33,11 @@ public class UsageFlushWorker(
                     continue;
                 }
 
-                await FlushCoreAsync(records, stoppingToken);
+                await FlushCoreAsync(records);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
-                // ignore cancellation
+                // ignore cancellation from the timer loop itself
             }
             catch (Exception ex)
             {
@@ -60,11 +60,11 @@ public class UsageFlushWorker(
 
         if (remaining.Count > 0)
         {
-            await FlushCoreAsync(remaining, cancellationToken);
+            await FlushCoreAsync(remaining);
         }
     }
 
-    private async Task FlushCoreAsync(List<UsageRecord> records, CancellationToken cancellationToken)
+    private async Task FlushCoreAsync(List<UsageRecord> records)
     {
         var endUserRecords = new Dictionary<Guid, HashSet<string>>();
         var insightRecords = new Dictionary<Guid, (int flagEvals, int customMetrics)>();
@@ -100,6 +100,6 @@ public class UsageFlushWorker(
 
         using var scope = serviceProvider.CreateScope();
         var usageAppService = scope.ServiceProvider.GetRequiredService<IUsageAppService>();
-        await usageAppService.SaveRecordsAsync(endUserRecords, insightRecords, cancellationToken);
+        await usageAppService.SaveRecordsAsync(endUserRecords, insightRecords);
     }
 }

--- a/modules/back-end/src/Infrastructure/ConfigureServices.cs
+++ b/modules/back-end/src/Infrastructure/ConfigureServices.cs
@@ -51,6 +51,7 @@ public static class ConfigureServices
         services.AddDbSpecificServices(configuration);
         services.AddTransient<IEnvironmentAppService, AppServices.EnvironmentAppService>();
         services.AddTransient<IFeatureFlagAppService, AppServices.FeatureFlagAppService>();
+        services.AddTransient<IUsageAppService, AppServices.UsageAppService>();
 
         // InsightsWriter must be a singleton service
         services.AddSingleton(typeof(AppServices.InsightsWriter));

--- a/modules/back-end/src/Infrastructure/ConfigureServices.cs
+++ b/modules/back-end/src/Infrastructure/ConfigureServices.cs
@@ -1,3 +1,4 @@
+using Application.Usages;
 using Domain.Users;
 using Infrastructure.Caches;
 using Infrastructure.MQ;
@@ -22,6 +23,14 @@ public static class ConfigureServices
 
         // flag schedule worker
         services.AddHostedService<AppServices.FlagScheduleWorker>();
+
+        // track usage
+        services.AddOptions<UsageTrackingOptions>()
+            .Bind(configuration.GetSection(UsageTrackingOptions.UsageTracking))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.AddSingleton<UsageTracker>();
+        services.AddHostedService<AppServices.UsageFlushWorker>();
 
         // messaging services
         services.AddMq(configuration);

--- a/modules/back-end/src/Infrastructure/MQ/Kafka/KafkaMessageConsumer.Log.cs
+++ b/modules/back-end/src/Infrastructure/MQ/Kafka/KafkaMessageConsumer.Log.cs
@@ -16,5 +16,8 @@ public partial class KafkaMessageConsumer
 
         [LoggerMessage(3, LogLevel.Error, "Exception occurred when store offset.", EventName = "ErrorStoreOffset")]
         public static partial void ErrorStoreOffset(ILogger logger, Exception ex);
+
+        [LoggerMessage(4, LogLevel.Warning, "No message handler for topic: {Topic}", EventName = "NoHandlerForTopic")]
+        public static partial void NoHandlerForTopic(ILogger logger, string topic);
     }
 }

--- a/modules/back-end/src/Infrastructure/MQ/Kafka/KafkaMessageConsumer.cs
+++ b/modules/back-end/src/Infrastructure/MQ/Kafka/KafkaMessageConsumer.cs
@@ -1,8 +1,5 @@
-using System.Text.Json;
 using Confluent.Kafka;
-using Domain.EndUsers;
 using Domain.Messages;
-using Domain.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -35,8 +32,10 @@ public partial class KafkaMessageConsumer : BackgroundService
 
     private async Task StartConsumerLoop(CancellationToken cancellationToken)
     {
-        _consumer.Subscribe(Topics.EndUser);
-        _logger.LogInformation("Start consuming {Topic} messages...", Topics.EndUser);
+        var topics = new[] { Topics.EndUser, Topics.Usage };
+
+        _consumer.Subscribe(topics);
+        _logger.LogInformation("Start consuming {Topic} messages...", string.Join(',', topics));
 
         ConsumeResult<Null, string>? consumeResult = null;
         var message = string.Empty;
@@ -55,21 +54,17 @@ public partial class KafkaMessageConsumer : BackgroundService
                 {
                     continue;
                 }
+                
+                using var scope = _serviceProvider.CreateScope();
 
-                var endUserMessage =
-                    JsonSerializer.Deserialize<EndUserMessage>(message, ReusableJsonSerializerOptions.Web);
-                if (endUserMessage == null)
+                var handler = scope.ServiceProvider.GetKeyedService<IMessageHandler>(consumeResult.Topic);
+                if (handler == null)
                 {
+                    Log.NoHandlerForTopic(_logger, consumeResult.Topic);
                     continue;
                 }
 
-                using var scope = _serviceProvider.CreateScope();
-                var endUserService = scope.ServiceProvider.GetRequiredService<IEndUserService>();
-
-                // upsert endUser and it's properties
-                var endUser = endUserMessage.AsEndUser();
-                await endUserService.UpsertAsync(endUser);
-                await endUserService.AddNewPropertiesAsync(endUser);
+                await handler.HandleAsync(message);
             }
             catch (ConsumeException ex)
             {

--- a/modules/back-end/src/Infrastructure/MQ/MqServiceCollectionExtensions.cs
+++ b/modules/back-end/src/Infrastructure/MQ/MqServiceCollectionExtensions.cs
@@ -31,6 +31,8 @@ public static class MqServiceCollectionExtensions
                 break;
         }
 
+        AddMessageHandlers();
+
         return;
 
         void AddNone()
@@ -44,9 +46,6 @@ public static class MqServiceCollectionExtensions
 
             services.AddSingleton<IMessageProducer, RedisMessageProducer>();
             services.AddHostedService<RedisMessageConsumer>();
-
-            services.AddKeyedTransient<IMessageHandler, EndUserMessageHandler>(Topics.EndUser);
-            services.AddKeyedTransient<IMessageHandler, InsightMessageHandler>(Topics.Insights);
         }
 
         void AddKafka()
@@ -68,12 +67,16 @@ public static class MqServiceCollectionExtensions
         void AddPostgres()
         {
             services.TryAddPostgres(configuration);
-            
+
             services.AddSingleton<IMessageProducer, PostgresMessageProducer>();
             services.AddHostedService<PostgresMessageConsumer>();
+        }
 
+        void AddMessageHandlers()
+        {
             services.AddKeyedTransient<IMessageHandler, EndUserMessageHandler>(Topics.EndUser);
             services.AddKeyedTransient<IMessageHandler, InsightMessageHandler>(Topics.Insights);
+            services.AddKeyedTransient<IMessageHandler, UsageMessageHandler>(Topics.Usage);
         }
     }
 }

--- a/modules/back-end/src/Infrastructure/MQ/Postgres/PostgresMessageConsumer.cs
+++ b/modules/back-end/src/Infrastructure/MQ/Postgres/PostgresMessageConsumer.cs
@@ -45,7 +45,8 @@ public partial class PostgresMessageConsumer(
         var tasks = new[]
         {
             ProcessAsync(Topics.EndUser, stoppingToken),
-            ProcessAsync(Topics.Insights, stoppingToken)
+            ProcessAsync(Topics.Insights, stoppingToken),
+            ProcessAsync(Topics.Usage, stoppingToken)
         };
 
         return Task.WhenAll(tasks);

--- a/modules/back-end/src/Infrastructure/MQ/Redis/RedisMessageConsumer.cs
+++ b/modules/back-end/src/Infrastructure/MQ/Redis/RedisMessageConsumer.cs
@@ -21,7 +21,8 @@ public partial class RedisMessageConsumer(
         var tasks = new[]
         {
             ConsumeAsync(Topics.EndUser, stoppingToken),
-            ConsumeAsync(Topics.Insights, stoppingToken)
+            ConsumeAsync(Topics.Insights, stoppingToken),
+            ConsumeAsync(Topics.Usage, stoppingToken)
         };
 
         return Task.WhenAll(tasks);

--- a/modules/back-end/src/Infrastructure/MQ/UsageMessageHandler.cs
+++ b/modules/back-end/src/Infrastructure/MQ/UsageMessageHandler.cs
@@ -38,6 +38,10 @@ public class UsageMessageHandler(UsageTracker usageTracker, ILogger<UsageMessage
 
         void RecordInsightUsage()
         {
+            var recordedAt = rootElement.TryGetProperty("recordedAt", out var recordedAtElem)
+                ? DateOnly.Parse(recordedAtElem.GetString()!)
+                : DateOnly.FromDateTime(DateTime.UtcNow);
+
             var endUsers = rootElement.TryGetProperty("endUsers", out var endUsersElem)
                 ? endUsersElem.Deserialize<string[]>()!
                 : [];
@@ -50,7 +54,7 @@ public class UsageMessageHandler(UsageTracker usageTracker, ILogger<UsageMessage
                 ? customMetricsElem.GetInt32()
                 : 0;
 
-            usageTracker.RecordInsights(envId, endUsers, flagEvaluations, customMetrics);
+            usageTracker.RecordInsights(envId, recordedAt, endUsers, flagEvaluations, customMetrics);
         }
     }
 }

--- a/modules/back-end/src/Infrastructure/MQ/UsageMessageHandler.cs
+++ b/modules/back-end/src/Infrastructure/MQ/UsageMessageHandler.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Application.Usages;
 using Domain.Messages;
+using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.MQ;
 
@@ -9,7 +10,7 @@ public static class UsageTypes
     public const string Insight = "insight";
 }
 
-public class UsageMessageHandler(UsageTracker usageTracker) : IMessageHandler
+public class UsageMessageHandler(UsageTracker usageTracker, ILogger<UsageMessageHandler> logger) : IMessageHandler
 {
     public string Topic => Topics.Usage;
 
@@ -23,6 +24,7 @@ public class UsageMessageHandler(UsageTracker usageTracker) : IMessageHandler
             !rootElement.TryGetProperty("envId", out var envIdProp) ||
             !envIdProp.TryGetGuid(out var envId))
         {
+            logger.LogWarning("Received invalid usage message: {Message}", message);
             return Task.CompletedTask;
         }
 

--- a/modules/back-end/src/Infrastructure/MQ/UsageMessageHandler.cs
+++ b/modules/back-end/src/Infrastructure/MQ/UsageMessageHandler.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Application.Usages;
+using Domain.Messages;
+
+namespace Infrastructure.MQ;
+
+public static class UsageTypes
+{
+    public const string Insight = "insight";
+}
+
+public class UsageMessageHandler(UsageTracker usageTracker) : IMessageHandler
+{
+    public string Topic => Topics.Usage;
+
+    public Task HandleAsync(string message)
+    {
+        using var json = JsonDocument.Parse(message);
+        var rootElement = json.RootElement;
+
+        // validate required properties
+        if (!rootElement.TryGetProperty("type", out var usageTypeElem) ||
+            !rootElement.TryGetProperty("envId", out var envIdProp) ||
+            !envIdProp.TryGetGuid(out var envId))
+        {
+            return Task.CompletedTask;
+        }
+
+        var usageType = usageTypeElem.GetString();
+        if (usageType == UsageTypes.Insight)
+        {
+            RecordInsightUsage();
+        }
+
+        return Task.CompletedTask;
+
+        void RecordInsightUsage()
+        {
+            var endUsers = rootElement.TryGetProperty("endUsers", out var endUsersElem)
+                ? endUsersElem.Deserialize<string[]>()!
+                : [];
+
+            var flagEvaluations = rootElement.TryGetProperty("flagEvaluations", out var flagEvaluationsElem)
+                ? flagEvaluationsElem.GetInt32()
+                : 0;
+
+            var customMetrics = rootElement.TryGetProperty("customMetrics", out var customMetricsElem)
+                ? customMetricsElem.GetInt32()
+                : 0;
+
+            usageTracker.RecordInsights(envId, endUsers, flagEvaluations, customMetrics);
+        }
+    }
+}

--- a/modules/back-end/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/modules/back-end/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -7,7 +7,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
-using StackExchange.Redis;
 
 namespace Infrastructure;
 

--- a/modules/back-end/tests/Application.UnitTests/Usages/UsageRecordAggregatorTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/Usages/UsageRecordAggregatorTests.cs
@@ -45,7 +45,7 @@ public class UsageRecordAggregatorTests
         Assert.Single(result);
         var agg = result[0];
         Assert.Equal(Today, agg.RecordedAt);
-        Assert.Equal(["user1", "user2", "user3"], agg.EndUsers[EnvId1]);
+        Assert.Equal(new HashSet<string> { "user1", "user2", "user3" }, agg.EndUsers[EnvId1]);
         Assert.Equal((15, 5), agg.Events[EnvId1]);
     }
 
@@ -64,10 +64,10 @@ public class UsageRecordAggregatorTests
         var todayAgg = result.Single(r => r.RecordedAt == Today);
         var yesterdayAgg = result.Single(r => r.RecordedAt == Yesterday);
 
-        Assert.Equal(["user1"], todayAgg.EndUsers[EnvId1]);
+        Assert.Equal(new HashSet<string> { "user1" }, todayAgg.EndUsers[EnvId1]);
         Assert.Equal((10, 2), todayAgg.Events[EnvId1]);
 
-        Assert.Equal(["user2"], yesterdayAgg.EndUsers[EnvId1]);
+        Assert.Equal(new HashSet<string> { "user2" }, yesterdayAgg.EndUsers[EnvId1]);
         Assert.Equal((4, 1), yesterdayAgg.Events[EnvId1]);
     }
 
@@ -85,10 +85,10 @@ public class UsageRecordAggregatorTests
         Assert.Single(result);
 
         var agg = result[0];
-        Assert.Equal(["user1"], agg.EndUsers[EnvId1]);
+        Assert.Equal(new HashSet<string> { "user1" }, agg.EndUsers[EnvId1]);
         Assert.Equal((10, 1), agg.Events[EnvId1]);
 
-        Assert.Equal(["user2"], agg.EndUsers[EnvId2]);
+        Assert.Equal(new HashSet<string> { "user2" }, agg.EndUsers[EnvId2]);
         Assert.Equal((20, 2), agg.Events[EnvId2]);
     }
 
@@ -104,7 +104,7 @@ public class UsageRecordAggregatorTests
         var result = UsageRecordsAggregator.Aggregate(records);
 
         Assert.Single(result);
-        Assert.Equal(["user1", "user2"], result[0].EndUsers[EnvId1]);
+        Assert.Equal(new HashSet<string> { "user1", "user2" }, result[0].EndUsers[EnvId1]);
     }
 
     [Fact]

--- a/modules/back-end/tests/Application.UnitTests/Usages/UsageRecordAggregatorTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/Usages/UsageRecordAggregatorTests.cs
@@ -1,0 +1,121 @@
+using Application.Usages;
+
+namespace Application.UnitTests.Usages;
+
+public class UsageRecordAggregatorTests
+{
+    private static readonly Guid EnvId1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly Guid EnvId2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
+    private static readonly DateOnly Today = new DateOnly(2026, 4, 14);
+    private static readonly DateOnly Yesterday = new DateOnly(2026, 4, 13);
+
+    [Fact]
+    public void EmptyList()
+    {
+        var result = UsageRecordsAggregator.Aggregate([]);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void SingleRecord()
+    {
+        var record = new InsightsUsageRecord(EnvId1, Today, ["user1", "user2"], 10, 5);
+
+        var result = UsageRecordsAggregator.Aggregate([record]);
+
+        Assert.Single(result);
+        var agg = result[0];
+        Assert.Equal(Today, agg.RecordedAt);
+        Assert.Equal(new HashSet<string> { "user1", "user2" }, agg.EndUsers[EnvId1]);
+        Assert.Equal((10, 5), agg.Events[EnvId1]);
+    }
+
+    [Fact]
+    public void MultipleRecordsSameDate()
+    {
+        var records = new List<UsageRecord>
+        {
+            new InsightsUsageRecord(EnvId1, Today, ["user1", "user2"], 10, 3),
+            new InsightsUsageRecord(EnvId1, Today, ["user2", "user3"], 5, 2),
+        };
+
+        var result = UsageRecordsAggregator.Aggregate(records);
+
+        Assert.Single(result);
+        var agg = result[0];
+        Assert.Equal(Today, agg.RecordedAt);
+        Assert.Equal(["user1", "user2", "user3"], agg.EndUsers[EnvId1]);
+        Assert.Equal((15, 5), agg.Events[EnvId1]);
+    }
+
+    [Fact]
+    public void MultipleRecordsDifferentDates()
+    {
+        var records = new List<UsageRecord>
+        {
+            new InsightsUsageRecord(EnvId1, Today, ["user1"], 10, 2),
+            new InsightsUsageRecord(EnvId1, Yesterday, ["user2"], 4, 1),
+        };
+
+        var result = UsageRecordsAggregator.Aggregate(records);
+
+        Assert.Equal(2, result.Length);
+        var todayAgg = result.Single(r => r.RecordedAt == Today);
+        var yesterdayAgg = result.Single(r => r.RecordedAt == Yesterday);
+
+        Assert.Equal(["user1"], todayAgg.EndUsers[EnvId1]);
+        Assert.Equal((10, 2), todayAgg.Events[EnvId1]);
+
+        Assert.Equal(["user2"], yesterdayAgg.EndUsers[EnvId1]);
+        Assert.Equal((4, 1), yesterdayAgg.Events[EnvId1]);
+    }
+
+    [Fact]
+    public void MultipleEnvsSameDate()
+    {
+        var records = new List<UsageRecord>
+        {
+            new InsightsUsageRecord(EnvId1, Today, ["user1"], 10, 1),
+            new InsightsUsageRecord(EnvId2, Today, ["user2"], 20, 2),
+        };
+
+        var result = UsageRecordsAggregator.Aggregate(records);
+
+        Assert.Single(result);
+
+        var agg = result[0];
+        Assert.Equal(["user1"], agg.EndUsers[EnvId1]);
+        Assert.Equal((10, 1), agg.Events[EnvId1]);
+
+        Assert.Equal(["user2"], agg.EndUsers[EnvId2]);
+        Assert.Equal((20, 2), agg.Events[EnvId2]);
+    }
+
+    [Fact]
+    public void DuplicateEndUsers()
+    {
+        var records = new List<UsageRecord>
+        {
+            new InsightsUsageRecord(EnvId1, Today, ["user1", "user1", "user2"], 5, 0),
+            new InsightsUsageRecord(EnvId1, Today, ["user1"], 3, 0),
+        };
+
+        var result = UsageRecordsAggregator.Aggregate(records);
+
+        Assert.Single(result);
+        Assert.Equal(["user1", "user2"], result[0].EndUsers[EnvId1]);
+    }
+
+    [Fact]
+    public void EnvWithNoEndUsers()
+    {
+        var record = new InsightsUsageRecord(EnvId1, Today, [], 7, 3);
+
+        var result = UsageRecordsAggregator.Aggregate([record]);
+
+        Assert.Single(result);
+        Assert.Empty(result[0].EndUsers[EnvId1]);
+        Assert.Equal((7, 3), result[0].Events[EnvId1]);
+    }
+}

--- a/modules/evaluation-server/src/Api/Public/InsightController.cs
+++ b/modules/evaluation-server/src/Api/Public/InsightController.cs
@@ -54,19 +54,19 @@ public class InsightController : PublicApiControllerBase
             {
                 _cache.Set(key, string.Empty, _cacheEntryOptions);
                 endUserMessages.Add(insight.EndUserMessage(envId));
+                usage.AddUser(insight.User!.KeyId);
             }
 
             insightMessages.AddRange(insight.InsightMessages(envId));
-            usage.AddInsight(insight);
+            usage.AddEvents(insight.Variations.Length, insight.Metrics.Length);
         }
 
-        await Task.WhenAll(
-            endUserMessages.Select(x => _producer.PublishAsync(Topics.EndUser, x))
-        );
-        await Task.WhenAll(
-            insightMessages.Select(x => _producer.PublishAsync(Topics.Insights, x))
-        );
-        await _producer.PublishAsync(Topics.Usage, usage);
+        var tasks = endUserMessages.Select(x => _producer.PublishAsync(Topics.EndUser, x))
+            .Concat(insightMessages.Select(x => _producer.PublishAsync(Topics.Insights, x)))
+            .Append(_producer.PublishAsync(Topics.Usage, usage))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
 
         return Ok();
     }

--- a/modules/evaluation-server/src/Api/Public/InsightController.cs
+++ b/modules/evaluation-server/src/Api/Public/InsightController.cs
@@ -3,6 +3,7 @@ using Api.Setup;
 using Domain.EndUsers;
 using Domain.Insights;
 using Domain.Messages;
+using Domain.Usages;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Caching.Memory;
@@ -45,6 +46,7 @@ public class InsightController : PublicApiControllerBase
 
         var endUserMessages = new List<EndUserMessage>();
         var insightMessages = new List<InsightMessage>();
+        var usage = new InsightUsage(EnvId);
         foreach (var insight in validInsights)
         {
             var key = $"{envId:N}:{insight.User!.KeyId}";
@@ -55,6 +57,7 @@ public class InsightController : PublicApiControllerBase
             }
 
             insightMessages.AddRange(insight.InsightMessages(envId));
+            usage.AddInsight(insight);
         }
 
         await Task.WhenAll(
@@ -63,6 +66,7 @@ public class InsightController : PublicApiControllerBase
         await Task.WhenAll(
             insightMessages.Select(x => _producer.PublishAsync(Topics.Insights, x))
         );
+        await _producer.PublishAsync(Topics.Usage, usage);
 
         return Ok();
     }

--- a/modules/evaluation-server/src/Domain/Insights/Insight.cs
+++ b/modules/evaluation-server/src/Domain/Insights/Insight.cs
@@ -7,9 +7,9 @@ public class Insight
 {
     public EndUser? User { get; set; }
 
-    public IEnumerable<VariationInsight> Variations { get; set; } = Array.Empty<VariationInsight>();
+    public VariationInsight[] Variations { get; set; } = [];
 
-    public IEnumerable<MetricInsight> Metrics { get; set; } = Array.Empty<MetricInsight>();
+    public MetricInsight[] Metrics { get; set; } = [];
 
     public bool IsValid()
     {

--- a/modules/evaluation-server/src/Domain/Messages/Topics.cs
+++ b/modules/evaluation-server/src/Domain/Messages/Topics.cs
@@ -10,6 +10,7 @@ public static class Topics
     public const string SegmentChange = "featbit-segment-change";
 
     public const string Insights = "featbit-insights";
+    public const string Usage = "featbit-usage";
 
     public static string ToChannel(string topic) => topic switch
     {

--- a/modules/evaluation-server/src/Domain/Usages/Usage.cs
+++ b/modules/evaluation-server/src/Domain/Usages/Usage.cs
@@ -21,6 +21,8 @@ public class InsightUsage : Usage
 {
     public override string Type => UsageTypes.Insight;
 
+    public DateOnly RecordedAt { get; set; }
+
     public HashSet<string> EndUsers { get; set; }
 
     public int FlagEvaluations { get; set; }
@@ -29,6 +31,7 @@ public class InsightUsage : Usage
 
     public InsightUsage(Guid envId) : base(envId)
     {
+        RecordedAt = DateOnly.FromDateTime(DateTime.UtcNow.Date);
         EndUsers = [];
         FlagEvaluations = 0;
         CustomMetrics = 0;

--- a/modules/evaluation-server/src/Domain/Usages/Usage.cs
+++ b/modules/evaluation-server/src/Domain/Usages/Usage.cs
@@ -1,5 +1,3 @@
-using Domain.Insights;
-
 namespace Domain.Usages;
 
 public class UsageTypes
@@ -23,7 +21,7 @@ public class InsightUsage : Usage
 {
     public override string Type => UsageTypes.Insight;
 
-    public List<string> EndUsers { get; set; }
+    public HashSet<string> EndUsers { get; set; }
 
     public int FlagEvaluations { get; set; }
 
@@ -36,14 +34,11 @@ public class InsightUsage : Usage
         CustomMetrics = 0;
     }
 
-    public void AddInsight(Insight insight)
-    {
-        if (insight.User != null)
-        {
-            EndUsers.Add(insight.User.KeyId);
-        }
+    public void AddUser(string userKeyId) => EndUsers.Add(userKeyId);
 
-        FlagEvaluations += insight.Variations.Length;
-        CustomMetrics += insight.Metrics.Length;
+    public void AddEvents(int flagEvaluations, int customMetrics)
+    {
+        FlagEvaluations += flagEvaluations;
+        CustomMetrics += customMetrics;
     }
 }

--- a/modules/evaluation-server/src/Domain/Usages/Usage.cs
+++ b/modules/evaluation-server/src/Domain/Usages/Usage.cs
@@ -1,0 +1,49 @@
+using Domain.Insights;
+
+namespace Domain.Usages;
+
+public class UsageTypes
+{
+    public const string Insight = "insight";
+}
+
+public abstract class Usage
+{
+    public Guid EnvId { get; }
+
+    public abstract string Type { get; }
+
+    public Usage(Guid envId)
+    {
+        EnvId = envId;
+    }
+}
+
+public class InsightUsage : Usage
+{
+    public override string Type => UsageTypes.Insight;
+
+    public List<string> EndUsers { get; set; }
+
+    public int FlagEvaluations { get; set; }
+
+    public int CustomMetrics { get; set; }
+
+    public InsightUsage(Guid envId) : base(envId)
+    {
+        EndUsers = [];
+        FlagEvaluations = 0;
+        CustomMetrics = 0;
+    }
+
+    public void AddInsight(Insight insight)
+    {
+        if (insight.User != null)
+        {
+            EndUsers.Add(insight.User.KeyId);
+        }
+
+        FlagEvaluations += insight.Variations.Length;
+        CustomMetrics += insight.Metrics.Length;
+    }
+}

--- a/modules/evaluation-server/src/Infrastructure/Caches/Redis/RedisKeys.cs
+++ b/modules/evaluation-server/src/Infrastructure/Caches/Redis/RedisKeys.cs
@@ -20,6 +20,6 @@ public static class RedisKeys
     public static RedisKey Segment(string id) => new($"{SegmentPrefix}{id}");
 
     public static RedisKey Secret(string secretString) => new($"{SecretPrefix}{secretString}");
-    
+
     public static RedisKey RateLimit(string type, string partitionKey) => new($"{RateLimitPrefix}{type}:{partitionKey}");
 }


### PR DESCRIPTION
1. MAU/DAU
2. Flag Evaluations & Custom Metrics

This PR done the backend (record stats) only

## Database Schemas

### Postgres

```sql
-- Monthly unique end users per environment
-- One row per (env_id, year_month, user_key); first_seen_at is written once on insert and never updated.
-- Equivalent of Redis ZADD NX: only the first occurrence in a month is recorded.
--
-- Queries this enables:
--   MAU / DAU  : SELECT COUNT(*) FROM usage_end_user_stats WHERE env_id = ANY(?) AND first_seen_at BETWEEN ? AND ?
--   Daily trend: ... GROUP BY first_seen_at
--   Per-env    : ... GROUP BY env_id
CREATE TABLE usage_end_user_stats
(
    env_id        uuid                     NOT NULL,
    year_month    integer                  NOT NULL, -- format YYYYMM, e.g. 202604
    user_key      varchar(512)             NOT NULL,
    first_seen_at date                     NOT NULL,
    CONSTRAINT pk_usage_end_user_stats PRIMARY KEY (env_id, year_month, user_key)
);

-- All read queries filter on (env_id, first_seen_at); year_month only appears in the PK for upsert deduplication.
CREATE INDEX ix_usage_end_user_stats_env_date ON usage_end_user_stats (env_id, first_seen_at);

-- Daily aggregated metrics per environment
-- Tracks total flag_evaluations and custom_metrics per day
-- Upsert with increment so multiple writes on the same day accumulate correctly
CREATE TABLE usage_event_stats
(
    env_id           uuid   NOT NULL,
    stats_date       date   NOT NULL,
    flag_evaluations integer NOT NULL DEFAULT 0,
    custom_metrics   integer NOT NULL DEFAULT 0,
    CONSTRAINT pk_usage_event_stats PRIMARY KEY (env_id, stats_date)
);
```

### MongoDb

```js
// Daily aggregated metrics per environment.
// Equivalent of usage_event_stats in PostgreSQL.
// Documents: { envId, statsDate (date-only, no time), flagEvaluations, customMetrics }
// Upsert via $inc so concurrent writes accumulate correctly.
db.UsageEventStats.createIndex({ envId: 1, statsDate: 1 }, { unique: true });

// Monthly unique end users per environment.
// Equivalent of usage_end_user_stats in PostgreSQL.
// Documents: { envId, yearMonth (integer yyyyMM, e.g. 202604), userKey, firstSeenAt (date-only, no time) }
// firstSeenAt is written once on insert ($setOnInsert) and never overwritten.
//
// Queries this enables:
//   MAU / DAU  : db.UsageEndUserStats.countDocuments({ envId: { $in: [...] }, firstSeenAt: { $gte, $lte } })
//   Daily trend: ... $group by firstSeenAt
//   Per-env    : ... $group by envId
// yearMonth only appears here for per-month upsert deduplication, not for reads.
db.UsageEndUserStats.createIndex({ envId: 1, yearMonth: 1, userKey: 1 }, { unique: true });
// All read queries filter on (envId, firstSeenAt); yearMonth is not used in any read path.
db.UsageEndUserStats.createIndex({ envId: 1, firstSeenAt: 1 });
```