### PR TITLE
🏗 infra: upgrade actions and .NET versions in CI workflows

### DIFF
--- a/.github/workflows/build-and-test-api.yml
+++ b/.github/workflows/build-and-test-api.yml
@@ -23,12 +23,12 @@ jobs:
         working-directory: modules/back-end
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore Packages
         run: dotnet restore

--- a/.github/workflows/build-and-test-els.yml
+++ b/.github/workflows/build-and-test-els.yml
@@ -23,12 +23,12 @@ jobs:
         working-directory: modules/evaluation-server
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore Packages
         run: dotnet restore

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -55,19 +55,19 @@ jobs:
         run: echo "debug and build-latest is true"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and push - ${{ matrix.app }} (${{ env.VERSION_TAG }})
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: "{{defaultContext}}:${{ matrix.build-dir }}"
           file: ${{ matrix.file }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build and push - ${{ matrix.app }} (${{ env.LATEST_TAG }})
         if: ${{ github.event.inputs.build-latest == 'true' }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: "{{defaultContext}}:${{ matrix.build-dir }}"
           file: ${{ matrix.file }}

--- a/.github/workflows/ui-change-validations.yml
+++ b/.github/workflows/ui-change-validations.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'npm'


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use the latest versions of key actions and dependencies. The main goal is to keep our CI/CD pipelines up-to-date and compatible with the latest language runtimes and action features.

**Workflow action and dependency upgrades:**

* **.NET version and action updates:**
  - Upgraded `actions/checkout` from v4 to v6, and `actions/setup-dotnet` from v4 to v5 in both `build-and-test-api.yml` and `build-and-test-els.yml` workflows. Also updated the .NET version from 8.0.x to 10.0.x. [[1]](diffhunk://#diff-f5cfc0b74e8b483cdf6071e3c8ed1bdb0a46a6681c20cb31ea28e6f8745d013cL26-R31) [[2]](diffhunk://#diff-1090c3dabf7d231244625179cba068ca00a6496c1ab1abdf1a3bf6cc7999f2afL26-R31)

* **Docker-related action updates:**
  - Updated the following Docker actions in `publish-docker-images.yml` to their latest major versions: `docker/setup-qemu-action` (v3 → v4), `docker/setup-buildx-action` (v3 → v4), `docker/login-action` (v3 → v4), and `docker/build-push-action` (v5 → v7). [[1]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L58-R70) [[2]](diffhunk://#diff-a0415f8a50178b93757cf4588a327a98574ff12b2ffd19bf4e70c748e3e2f612L82-R82)

* **Node.js workflow updates:**
  - Upgraded `actions/checkout` from v5 to v6, and `actions/setup-node` from v5 to v6 in `ui-change-validations.yml`.