### PR TITLE
🖍 style: segment flag reference tip

### DIFF
--- a/modules/front-end/src/app/features/safe/segments/details/details.module.ts
+++ b/modules/front-end/src/app/features/safe/segments/details/details.module.ts
@@ -21,7 +21,6 @@ import { NzTypographyModule } from 'ng-zorro-antd/typography';
 import { NzDividerModule } from 'ng-zorro-antd/divider';
 import { NzModalModule  } from 'ng-zorro-antd/modal';
 import { NzCollapseModule } from "ng-zorro-antd/collapse";
-import { NzDropDownModule } from "ng-zorro-antd/dropdown";
 import { DragDropModule } from "@angular/cdk/drag-drop";
 import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions';
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
@@ -29,6 +28,7 @@ import { SettingComponent } from './setting/setting.component';
 import {CoreModule} from "@core/core.module";
 import {AuditLogsComponent} from "@features/safe/segments/details/audit-logs/audit-logs.component";
 import {NzFormModule} from "ng-zorro-antd/form";
+import { FlagReferencesModalComponent } from "@features/safe/segments/index/flag-references-modal";
 
 @NgModule({
   declarations: [
@@ -58,13 +58,13 @@ import {NzFormModule} from "ng-zorro-antd/form";
     NzModalModule,
     DetailsRoutingModule,
     NzCollapseModule,
-    NzDropDownModule,
     NzSkeletonModule,
     DragDropModule,
     NzToolTipModule,
     NzDescriptionsModule,
     CoreModule,
-    NzFormModule
+    NzFormModule,
+    FlagReferencesModalComponent
   ],
   providers: [
   ]

--- a/modules/front-end/src/app/features/safe/segments/details/details.module.ts
+++ b/modules/front-end/src/app/features/safe/segments/details/details.module.ts
@@ -28,7 +28,7 @@ import { SettingComponent } from './setting/setting.component';
 import {CoreModule} from "@core/core.module";
 import {AuditLogsComponent} from "@features/safe/segments/details/audit-logs/audit-logs.component";
 import {NzFormModule} from "ng-zorro-antd/form";
-import { FlagReferencesModalComponent } from "@features/safe/segments/index/flag-references-modal";
+import { FlagReferencesModalComponent } from "../flag-references-modal";
 
 @NgModule({
   declarations: [

--- a/modules/front-end/src/app/features/safe/segments/details/targeting/targeting.component.html
+++ b/modules/front-end/src/app/features/safe/segments/details/targeting/targeting.component.html
@@ -2,31 +2,20 @@
   <div class="detail-body">
     @if (!isLoading) {
       <div class="banner">
-        @if (flagReferences.length === 0) {
-          <div class="references" i18n="@@segment.details.segment-not-used">This segment is not used by any feature flag</div>
-        }
         @if (flagReferences.length > 0) {
-          <div class="references" nz-dropdown [nzDropdownMenu]="menu">
-            <a>
-              <ng-container i18n="@@segment.details.this-segment">This segment is used by</ng-container>
-              <span class="reference-count"> {{flagReferences.length}} </span>
-              <ng-container i18n="@@segment.details.num-ff">feature flag(s)</ng-container>
-              <i nz-icon nzType="down"></i>
-            </a>
-          </div>
+          <span
+            class="flag-references-tip"
+            nz-tooltip
+            nzTooltipTitle="Click to view details"
+            i18n-nzTooltipTitle="@@segment.details.flag-references-tooltip"
+            (click)="flagReferencesModalVisible = true">
+            <span i18n="@@segment.details.referenced-by">Referenced by</span>
+            <span>{{ flagReferences.length }}</span>
+            <span i18n="@@segment.details.num-ff">feature flag(s)</span>
+          </span>
+        } @else {
+          <span class="flag-references-tip no-reference" i18n="@@segment.details.no-flag-references">No flag references</span>
         }
-        <nz-dropdown-menu #menu="nzDropdownMenu">
-          <ul nz-menu>
-            @for (flag of flagReferences; track flag.id) {
-              <li [nzDisabled]="flag.envId !== currentEnvId" nz-menu-item (click)="openFlagPage(flag)">
-                {{ flag.name }}
-                @if (flag.envId !== currentEnvId) {
-                  <span i18n="@@segment.details.in-other-environment">(in other environment)</span>
-                }
-              </li>
-            }
-          </ul>
-        </nz-dropdown-menu>
         <button nz-button nzType="primary" (click)="onReviewChanges()">
           <i nz-icon nzType="icons:icon-save"></i>
           <ng-container i18n="@@common.save">Save</ng-container>
@@ -132,6 +121,16 @@
     (onCancel)="onCloseReviewModal()"
     >
   </change-review>
+
+  <flag-references-modal
+    [visible]="flagReferencesModalVisible"
+    [references]="flagReferences"
+    title="Feature flag references"
+    i18n-title="@@segment.details.flag-references-modal-title"
+    description="This segment is referenced by the following feature flags."
+    i18n-description="@@segment.details.flag-references-modal-description"
+    (onClose)="flagReferencesModalVisible = false">
+  </flag-references-modal>
 }
 
 

--- a/modules/front-end/src/app/features/safe/segments/details/targeting/targeting.component.less
+++ b/modules/front-end/src/app/features/safe/segments/details/targeting/targeting.component.less
@@ -26,28 +26,26 @@
       flex-direction: row;
       justify-content: space-between;
       align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
       margin-bottom: 16px;
 
-      .references {
-        height: 35px;
-        padding: 0 24px;
-        text-align: center;
-        border: 1px solid @grey20-color;
-        line-height: 35px;
-        border-radius: 18px;
+      .flag-references-tip {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        border: 1px solid #EAECEE;
+        border-radius: 8px;
+        color: @grey50-color;
+        font-size: 13px;
+        padding: 5px 10px;
+        cursor: pointer;
+        transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
 
-        a {
-          color: @grey50-color;
-
-          .reference-count {
-            font-weight: 800;
-            display: inline-block;
-            margin: 0 3px;
-          }
-
-          .anticon-down {
-            margin-left: 4px;
-          }
+        &:hover {
+          border-color: @grey30-color;
+          background: @grey10-color;
+          color: @grey70-color;
         }
       }
 

--- a/modules/front-end/src/app/features/safe/segments/details/targeting/targeting.component.less
+++ b/modules/front-end/src/app/features/safe/segments/details/targeting/targeting.component.less
@@ -26,8 +26,6 @@
       flex-direction: row;
       justify-content: space-between;
       align-items: center;
-      gap: 12px;
-      flex-wrap: wrap;
       margin-bottom: 16px;
 
       .flag-references-tip {

--- a/modules/front-end/src/app/features/safe/segments/details/targeting/targeting.component.less
+++ b/modules/front-end/src/app/features/safe/segments/details/targeting/targeting.component.less
@@ -39,6 +39,7 @@
         padding: 5px 10px;
         cursor: pointer;
         transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+        &.no-reference { cursor: default; pointer-events: none; }
 
         &:hover {
           border-color: @grey30-color;

--- a/modules/front-end/src/app/features/safe/segments/details/targeting/targeting.component.ts
+++ b/modules/front-end/src/app/features/safe/segments/details/targeting/targeting.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { NzMessageService } from 'ng-zorro-antd/message';
 import { EnvUserService } from '@services/env-user.service';
 import { SegmentService } from '@services/segment.service';
@@ -10,7 +10,6 @@ import { CdkDragDrop, moveItemInArray } from "@angular/cdk/drag-drop";
 import { EnvUserPropService } from "@services/env-user-prop.service";
 import { EnvUserFilter } from "@features/safe/end-users/types/featureflag-user";
 import { ICondition, IRule } from "@shared/rules";
-import { getPathPrefix } from "@utils/index";
 import { RefTypeEnum } from "@core/components/audit-log/types";
 import { getCurrentProjectEnv } from "@utils/project-env";
 import { finalize } from 'rxjs';
@@ -33,6 +32,7 @@ export class TargetingComponent implements OnInit {
   public id: string;
   public targetUsersActive = true;
   public flagReferences: ISegmentFlagReference[] = [];
+  flagReferencesModalVisible: boolean = false;
 
   reviewModalVisible: boolean = false;
   reviewModalData: ChangeReviewModalData;
@@ -64,7 +64,6 @@ export class TargetingComponent implements OnInit {
   currentEnvId: string = '';
 
   constructor(
-    private router: Router,
     private route: ActivatedRoute,
     private segmentService: SegmentService,
     private envUserService: EnvUserService,
@@ -113,18 +112,6 @@ export class TargetingComponent implements OnInit {
         error: () => this.msg.error($localize`:@@common.load-data-failed:Failed to load data, please refresh the page.`)
       });
     });
-  }
-
-  public openFlagPage(flag: ISegmentFlagReference) {
-    if (flag.envId !== this.currentEnvId) {
-      return;
-    }
-
-    const url = this.router.serializeUrl(
-      this.router.createUrlTree([`/${getPathPrefix()}feature-flags/${flag.key}/targeting`])
-    );
-
-    window.open(url, '_blank');
   }
 
   private loadSegment(segment: ISegment) {

--- a/modules/front-end/src/app/features/safe/segments/flag-references-modal.ts
+++ b/modules/front-end/src/app/features/safe/segments/flag-references-modal.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, inject, Input, OnInit, Output } from "@angular/core";
-import { ISegmentFlagReference } from "../types/segments";
+import { ISegmentFlagReference } from "./types/segments";
 import { NzModalComponent, NzModalContentDirective, NzModalFooterDirective } from "ng-zorro-antd/modal";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { getPathPrefix } from "@utils/index";

--- a/modules/front-end/src/app/features/safe/segments/index/flag-references-modal.ts
+++ b/modules/front-end/src/app/features/safe/segments/index/flag-references-modal.ts
@@ -143,9 +143,9 @@ export class FlagReferencesModalComponent implements OnInit {
   @Output()
   onClose = new EventEmitter<void>();
 
-  currentEnvId: string;
+  currentEnvId: string = '';
   ngOnInit(): void {
-    this.currentEnvId = getCurrentProjectEnv().envId;
+    this.currentEnvId = getCurrentProjectEnv()?.envId ?? '';
   }
 
   close() {

--- a/modules/front-end/src/app/features/safe/segments/index/flag-references-modal.ts
+++ b/modules/front-end/src/app/features/safe/segments/index/flag-references-modal.ts
@@ -1,9 +1,10 @@
-import { Component, EventEmitter, inject, Input, Output } from "@angular/core";
+import { Component, EventEmitter, inject, Input, OnInit, Output } from "@angular/core";
 import { ISegmentFlagReference } from "../types/segments";
 import { NzModalComponent, NzModalContentDirective, NzModalFooterDirective } from "ng-zorro-antd/modal";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { getPathPrefix } from "@utils/index";
 import { Router } from "@angular/router";
+import { getCurrentProjectEnv } from "@utils/project-env";
 
 @Component({
   selector: 'flag-references-modal',
@@ -13,22 +14,29 @@ import { Router } from "@angular/router";
       [(nzVisible)]="visible"
       nzCentered
       nzWidth="450px"
-      nzTitle="Can't archive segment"
-      i18n-nzTitle="@@segment.index.flag-references-modal-title"
+      [nzTitle]="title"
       (nzOnCancel)="close()">
       <ng-container *nzModalContent>
         @if (references.length > 0) {
-          <p class="description" i18n="@@segment.index.flag-references-modal-description">We cannot archive this segment because it is being referenced by the following feature flags.</p>
+          @if (description) {
+            <p class="description">{{ description }}</p>
+          }
           <div class="reference-list">
-            @for (reference of references; track $index) {
-              <div class="reference-item" (click)="openFlagPage(reference.key)">
+            @for (reference of references; track reference.id) {
+              <div class="reference-item"
+                   [class.reference-item-disabled]="!canOpenReference(reference)"
+                   (click)="openFlagPage(reference)">
                 <span class="reference-name">{{ reference.name }}</span>
                 <span class="reference-key">{{ reference.key }}</span>
+                @if (!canOpenReference(reference)) {
+                  <span class="reference-env" i18n="@@segment.details.not-in-this-environment">(not in this environment)</span>
+                }
               </div>
             }
           </div>
         } @else {
-          <p class="description" i18n="@@segment.index.flag-references-modal-empty">No feature flags are referencing this segment.</p>
+          <p class="description" i18n="@@segment.index.flag-references-modal-empty">No feature flags are referencing
+            this segment.</p>
         }
       </ng-container>
       <ng-container *nzModalFooter>
@@ -69,6 +77,15 @@ import { Router } from "@angular/router";
       }
     }
 
+    .reference-item-disabled {
+      cursor: default;
+      opacity: 0.7;
+
+      &:hover {
+        background-color: transparent;
+      }
+    }
+
     .reference-name {
       flex: 1;
       font-weight: 500;
@@ -88,6 +105,12 @@ import { Router } from "@angular/router";
       flex-shrink: 0;
     }
 
+    .reference-env {
+      font-size: 12px;
+      color: #717D8A;
+      flex-shrink: 0;
+    }
+
     .actions {
       button {
         height: unset;
@@ -102,7 +125,7 @@ import { Router } from "@angular/router";
     NzButtonComponent
   ]
 })
-export class FlagReferencesModalComponent {
+export class FlagReferencesModalComponent implements OnInit {
   router = inject(Router);
 
   @Input()
@@ -111,16 +134,39 @@ export class FlagReferencesModalComponent {
   @Input()
   references: ISegmentFlagReference[] = [];
 
+  @Input()
+  title: string;
+
+  @Input()
+  description: string;
+
   @Output()
   onClose = new EventEmitter<void>();
+
+  currentEnvId: string;
+  ngOnInit(): void {
+    this.currentEnvId = getCurrentProjectEnv().envId;
+  }
 
   close() {
     this.onClose.emit();
   }
 
-  openFlagPage(flagKey: string) {
+  canOpenReference(reference: ISegmentFlagReference): boolean {
+    if (!this.currentEnvId || !reference.envId) {
+      return true;
+    }
+
+    return reference.envId === this.currentEnvId;
+  }
+
+  openFlagPage(reference: ISegmentFlagReference) {
+    if (!this.canOpenReference(reference)) {
+      return;
+    }
+
     const url = this.router.serializeUrl(
-      this.router.createUrlTree([`/${getPathPrefix()}feature-flags/${flagKey}/targeting`])
+      this.router.createUrlTree([ `/${getPathPrefix()}feature-flags/${reference.key}/targeting` ])
     );
 
     window.open(url, '_blank');

--- a/modules/front-end/src/app/features/safe/segments/index/index.component.html
+++ b/modules/front-end/src/app/features/safe/segments/index/index.component.html
@@ -155,5 +155,9 @@
 <flag-references-modal
   [visible]="flagReferencesModalVisible"
   [references]="flagReferences"
+  title="Can't archive segment"
+  i18n-title="@@segment.index.flag-references-modal-title"
+  description="We cannot archive this segment because it is being referenced by the following feature flags."
+  i18n-description="@@segment.index.flag-references-modal-description"
   (onClose)="flagReferencesModalVisible = false">
 </flag-references-modal>

--- a/modules/front-end/src/app/features/safe/segments/index/index.module.ts
+++ b/modules/front-end/src/app/features/safe/segments/index/index.module.ts
@@ -22,7 +22,7 @@ import { NzDividerModule } from "ng-zorro-antd/divider";
 import {CoreModule} from "@core/core.module";
 import {NzPopconfirmModule} from "ng-zorro-antd/popconfirm";
 import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
-import { FlagReferencesModalComponent } from "@features/safe/segments/index/flag-references-modal";
+import { FlagReferencesModalComponent } from "../flag-references-modal";
 
 @NgModule({
   declarations: [IndexComponent],

--- a/modules/front-end/src/locale/messages.xlf
+++ b/modules/front-end/src/locale/messages.xlf
@@ -536,7 +536,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">32,33</context>
+          <context context-type="linenumber">21,22</context>
         </context-group>
       </trans-unit>
       <trans-unit id="integrations.access-tokens.access-token-created" datatype="html">
@@ -573,7 +573,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
-          <context context-type="linenumber">36,37</context>
+          <context context-type="linenumber">44,45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="integrations.access-token.access-token-drawer.view-title" datatype="html">
@@ -613,7 +613,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">124,127</context>
+          <context context-type="linenumber">113,116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.operation-success" datatype="html">
@@ -888,7 +888,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">170</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/index.component.ts</context>
@@ -1557,7 +1557,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">93,94</context>
+          <context context-type="linenumber">82,83</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.variations" datatype="html">
@@ -1806,7 +1806,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">73,74</context>
+          <context context-type="linenumber">62,63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.including-users" datatype="html">
@@ -1817,7 +1817,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">61,62</context>
+          <context context-type="linenumber">50,51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.add-users" datatype="html">
@@ -2841,7 +2841,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.ts</context>
-          <context context-type="linenumber">185</context>
+          <context context-type="linenumber">172</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/index.component.ts</context>
@@ -10116,67 +10116,74 @@
           <context context-type="linenumber">99,100</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="segment.details.segment-not-used" datatype="html">
-        <source>This segment is not used by any feature flag</source>
+      <trans-unit id="segment.details.flag-references-tooltip" datatype="html">
+        <source>Click to view details</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">6,8</context>
+          <context context-type="linenumber">9,10</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="segment.details.this-segment" datatype="html">
-        <source>This segment is used by</source>
+      <trans-unit id="segment.details.referenced-by" datatype="html">
+        <source>Referenced by</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">11,12</context>
+          <context context-type="linenumber">12,13</context>
         </context-group>
       </trans-unit>
       <trans-unit id="segment.details.num-ff" datatype="html">
         <source>feature flag(s)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">13,14</context>
+          <context context-type="linenumber">14,16</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="segment.details.in-other-environment" datatype="html">
-        <source>(in other environment)</source>
+      <trans-unit id="segment.details.no-flag-references" datatype="html">
+        <source>No flag references</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">24,27</context>
+          <context context-type="linenumber">17,19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.targeting-users" datatype="html">
         <source>Targeting users</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">45,46</context>
+          <context context-type="linenumber">34,35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="segment.details.flag-references-modal-title" datatype="html">
+        <source>Feature flag references</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
+          <context context-type="linenumber">128,129</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="segment.details.flag-references-modal-description" datatype="html">
+        <source>This segment is referenced by the following feature flags.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
+          <context context-type="linenumber">130,131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.load-data-failed" datatype="html">
         <source>Failed to load data, please refresh the page.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.ts</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">112</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="segment.index.flag-references-modal-title" datatype="html">
-        <source>Can&apos;t archive segment</source>
+      <trans-unit id="segment.details.not-in-this-environment" datatype="html">
+        <source>(not in this environment)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
-          <context context-type="linenumber">16,17</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="segment.index.flag-references-modal-description" datatype="html">
-        <source>We cannot archive this segment because it is being referenced by the following feature flags.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
-          <context context-type="linenumber">21,23</context>
+          <context context-type="linenumber">32,35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="segment.index.flag-references-modal-empty" datatype="html">
         <source>No feature flags are referencing this segment.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
-          <context context-type="linenumber">31,34</context>
+          <context context-type="linenumber">38,42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="segment.index.current-segment-tooltip" datatype="html">
@@ -10191,6 +10198,20 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/index.component.html</context>
           <context context-type="linenumber">119,120</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="segment.index.flag-references-modal-title" datatype="html">
+        <source>Can&apos;t archive segment</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/safe/segments/index/index.component.html</context>
+          <context context-type="linenumber">158,159</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="segment.index.flag-references-modal-description" datatype="html">
+        <source>We cannot archive this segment because it is being referenced by the following feature flags.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/safe/segments/index/index.component.html</context>
+          <context context-type="linenumber">160,161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="segments.archive-confirm-message" datatype="html">

--- a/modules/front-end/src/locale/messages.xlf
+++ b/modules/front-end/src/locale/messages.xlf
@@ -572,7 +572,7 @@
           <context context-type="linenumber">86,87</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
+          <context context-type="sourcefile">src/app/features/safe/segments/flag-references-modal.ts</context>
           <context context-type="linenumber">44,45</context>
         </context-group>
       </trans-unit>
@@ -10175,14 +10175,14 @@
       <trans-unit id="segment.details.not-in-this-environment" datatype="html">
         <source>(not in this environment)</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
+          <context context-type="sourcefile">src/app/features/safe/segments/flag-references-modal.ts</context>
           <context context-type="linenumber">32,35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="segment.index.flag-references-modal-empty" datatype="html">
         <source>No feature flags are referencing this segment.</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
+          <context context-type="sourcefile">src/app/features/safe/segments/flag-references-modal.ts</context>
           <context context-type="linenumber">38,42</context>
         </context-group>
       </trans-unit>

--- a/modules/front-end/src/locale/messages.zh.xlf
+++ b/modules/front-end/src/locale/messages.zh.xlf
@@ -546,7 +546,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">32,33</context>
+          <context context-type="linenumber">21,22</context>
         </context-group>
         <target>保存</target>
       </trans-unit>
@@ -586,7 +586,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
-          <context context-type="linenumber">36,37</context>
+          <context context-type="linenumber">44,45</context>
         </context-group>
         <target>确认</target>
       </trans-unit>
@@ -630,7 +630,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">124,127</context>
+          <context context-type="linenumber">113,116</context>
         </context-group>
         <target>您未被授权进行该操作, 请联系账户管理员添加相关权限</target>
       </trans-unit>
@@ -906,7 +906,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">170</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/index.component.ts</context>
@@ -1614,7 +1614,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">93,94</context>
+          <context context-type="linenumber">82,83</context>
         </context-group>
         <target>规则</target>
       </trans-unit>
@@ -1890,7 +1890,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">73,74</context>
+          <context context-type="linenumber">62,63</context>
         </context-group>
         <target>不包含用户</target>
       </trans-unit>
@@ -1902,7 +1902,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">61,62</context>
+          <context context-type="linenumber">50,51</context>
         </context-group>
         <target>包含用户</target>
       </trans-unit>
@@ -2979,7 +2979,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.ts</context>
-          <context context-type="linenumber">185</context>
+          <context context-type="linenumber">172</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/index.component.ts</context>
@@ -11051,75 +11051,83 @@
         </context-group>
         <target>共享范围</target>
       </trans-unit>
-      <trans-unit id="segment.details.segment-not-used" datatype="html">
-        <source>This segment is not used by any feature flag</source>
+      <trans-unit id="segment.details.flag-references-tooltip" datatype="html">
+        <source>Click to view details</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">6,8</context>
+          <context context-type="linenumber">9,10</context>
         </context-group>
-        <target>该用户组没有被任何开关引用</target>
+        <target>点击查看详情</target>
       </trans-unit>
-      <trans-unit id="segment.details.this-segment" datatype="html">
-        <source>This segment is used by</source>
+      <trans-unit id="segment.details.referenced-by" datatype="html">
+        <source>Referenced by</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">11,12</context>
+          <context context-type="linenumber">12,13</context>
         </context-group>
-        <target>该用户组在</target>
+        <target>被</target>
       </trans-unit>
       <trans-unit id="segment.details.num-ff" datatype="html">
         <source>feature flag(s)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">13,14</context>
+          <context context-type="linenumber">14,16</context>
         </context-group>
-        <target>个开关中被引用</target>
+        <target>个开关引用</target>
       </trans-unit>
-      <trans-unit id="segment.details.in-other-environment" datatype="html">
-        <source>(in other environment)</source>
+      <trans-unit id="segment.details.no-flag-references" datatype="html">
+        <source>No flag references</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">24,27</context>
+          <context context-type="linenumber">17,19</context>
         </context-group>
-        <target>(在其他环境中)</target>
+        <target>没有开关引用</target>
       </trans-unit>
       <trans-unit id="common.targeting-users" datatype="html">
         <source>Targeting users</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
-          <context context-type="linenumber">45,46</context>
+          <context context-type="linenumber">34,35</context>
         </context-group>
         <target>目标用户</target>
+      </trans-unit>
+      <trans-unit id="segment.details.flag-references-modal-title" datatype="html">
+        <source>Feature flag references</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
+          <context context-type="linenumber">128,129</context>
+        </context-group>
+        <target>开关引用</target>
+      </trans-unit>
+      <trans-unit id="segment.details.flag-references-modal-description" datatype="html">
+        <source>This segment is referenced by the following feature flags.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.html</context>
+          <context context-type="linenumber">130,131</context>
+        </context-group>
+        <target>此用户组正在被以下开关引用</target>
       </trans-unit>
       <trans-unit id="common.load-data-failed" datatype="html">
         <source>Failed to load data, please refresh the page.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/details/targeting/targeting.component.ts</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">112</context>
         </context-group>
         <target>加载数据失败，请刷新页面重试。</target>
       </trans-unit>
-      <trans-unit id="segment.index.flag-references-modal-title" datatype="html">
-        <source>Can&apos;t archive segment</source>
+      <trans-unit id="segment.details.not-in-this-environment" datatype="html">
+        <source>(not in this environment)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
-          <context context-type="linenumber">16,17</context>
+          <context context-type="linenumber">32,35</context>
         </context-group>
-        <target>无法存档用户组</target>
-      </trans-unit>
-      <trans-unit id="segment.index.flag-references-modal-description" datatype="html">
-        <source>We cannot archive this segment because it is being referenced by the following feature flags.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
-          <context context-type="linenumber">21,23</context>
-        </context-group>
-        <target>我们无法存档该用户组，因为它正在被以下开关引用。</target>
+        <target>（不在当前环境）</target>
       </trans-unit>
       <trans-unit id="segment.index.flag-references-modal-empty" datatype="html">
         <source>No feature flags are referencing this segment.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
-          <context context-type="linenumber">31,34</context>
+          <context context-type="linenumber">38,42</context>
         </context-group>
         <target>没有开关引用此用户组。</target>
       </trans-unit>
@@ -11138,6 +11146,22 @@
           <context context-type="linenumber">119,120</context>
         </context-group>
         <target>确定要恢复该用户组吗？</target>
+      </trans-unit>
+      <trans-unit id="segment.index.flag-references-modal-title" datatype="html">
+        <source>Can&apos;t archive segment</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/safe/segments/index/index.component.html</context>
+          <context context-type="linenumber">158,159</context>
+        </context-group>
+        <target>无法存档用户组</target>
+      </trans-unit>
+      <trans-unit id="segment.index.flag-references-modal-description" datatype="html">
+        <source>We cannot archive this segment because it is being referenced by the following feature flags.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/safe/segments/index/index.component.html</context>
+          <context context-type="linenumber">160,161</context>
+        </context-group>
+        <target>我们无法存档该用户组，因为它正在被以下开关引用。</target>
       </trans-unit>
       <trans-unit id="segments.archive-confirm-message" datatype="html">
         <source>Are you sure to archive segment</source>

--- a/modules/front-end/src/locale/messages.zh.xlf
+++ b/modules/front-end/src/locale/messages.zh.xlf
@@ -585,7 +585,7 @@
           <context context-type="linenumber">86,87</context>
         </context-group>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
+          <context context-type="sourcefile">src/app/features/safe/segments/flag-references-modal.ts</context>
           <context context-type="linenumber">44,45</context>
         </context-group>
         <target>确认</target>
@@ -11118,7 +11118,7 @@
       <trans-unit id="segment.details.not-in-this-environment" datatype="html">
         <source>(not in this environment)</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
+          <context context-type="sourcefile">src/app/features/safe/segments/flag-references-modal.ts</context>
           <context context-type="linenumber">32,35</context>
         </context-group>
         <target>（不在当前环境）</target>
@@ -11126,7 +11126,7 @@
       <trans-unit id="segment.index.flag-references-modal-empty" datatype="html">
         <source>No feature flags are referencing this segment.</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/safe/segments/index/flag-references-modal.ts</context>
+          <context context-type="sourcefile">src/app/features/safe/segments/flag-references-modal.ts</context>
           <context context-type="linenumber">38,42</context>
         </context-group>
         <target>没有开关引用此用户组。</target>


### PR DESCRIPTION
Redesign the flag reference tip in segment targeting page

**Basic**
<img width="365" height="176" alt="image" src="https://github.com/user-attachments/assets/fa723244-9275-4ed0-8d50-78c3631e55c1" />

**Hover**

<img width="387" height="180" alt="image" src="https://github.com/user-attachments/assets/ef661620-4ffe-4f20-9f9f-8f1c129e0dff" />
