### PR TITLE
🐛 fix: load workspace usage error

### DIFF
--- a/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/WorkspaceService.cs
+++ b/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/WorkspaceService.cs
@@ -246,14 +246,14 @@ public class WorkspaceService(AppDbContext dbContext)
         // 5. Daily new users
         var dailyNewUsers = (await multi.ReadAsync())
             .ToDictionary(
-                x => DateOnly.FromDateTime((DateTime)x.date),
+                x => (DateOnly)x.date,
                 x => (int)x.new_users
             );
 
         // 6. Daily events
         var dailyEvents = (await multi.ReadAsync())
             .ToDictionary(
-                x => DateOnly.FromDateTime((DateTime)x.date),
+                x => (DateOnly)x.date,
                 x => ((long)x.flag_evaluations, (long)x.custom_metrics)
             );
 


### PR DESCRIPTION
Bug introduced in #838, [FeatBit v5.3.6](https://github.com/featbit/featbit/releases/tag/5.3.6).

Npgsql 10 did a breaking change to read PostgreSQL `date` as .NET `DateOnly` instead of `DateTime`, for reference: https://www.npgsql.org/doc/release-notes/10.0.html#date-and-time-are-now-mapped-to-dateonly-and-timeonly