### PR TITLE
🐛 fix: docker compose broken link in guide component

### DIFF
--- a/modules/front-end/src/app/core/components/guide/guide.component.html
+++ b/modules/front-end/src/app/core/components/guide/guide.component.html
@@ -19,7 +19,7 @@
 
     <p nz-typography>
       <span i18n="@@guide.deploy-with">Deploy with</span>&nbsp;
-      <a target="_blank" href="https://docs.featbit.co/installation/full-installation">Docker Compose</a>&nbsp;
+      <a target="_blank" href="https://docs.featbit.co/installation/docker-compose">Docker Compose</a>&nbsp;
     </p>
 
     <p nz-typography>


### PR DESCRIPTION
Updated the Docker Compose link in the guide component. The old link returned a 404.

<img width="270" height="500" alt="image" src="https://github.com/user-attachments/assets/f9eabb1f-868c-4f25-96e8-589f71238bc7" />