### PR TITLE
✨ feat: ignore null variation insight

### DIFF
--- a/modules/evaluation-server/src/Domain/Insights/Insight.cs
+++ b/modules/evaluation-server/src/Domain/Insights/Insight.cs
@@ -24,16 +24,22 @@ public class Insight
     public ICollection<InsightMessage> InsightMessages(Guid envId)
     {
         var messages = new List<InsightMessage>();
+        var envIdString = $"{envId}";
 
         // flag messages
         foreach (var variation in Variations)
         {
+            if (variation.Variation == null)
+            {
+                continue;
+            }
+
             var flagId = $"{envId}-{variation.FeatureFlagKey}";
             var properties = new
             {
                 route = "/Variation/GetMultiOptionVariation",
                 flagId = flagId,
-                envId = envId.ToString(),
+                envId = envIdString,
                 accountId = string.Empty,
                 projectId = string.Empty,
                 featureFlagKey = variation.FeatureFlagKey,
@@ -51,7 +57,7 @@ public class Insight
             {
                 Uuid = Guid.NewGuid().ToString(),
                 DistinctId = flagId,
-                EnvId = envId.ToString(),
+                EnvId = envIdString,
                 Event = "FlagValue",
                 Properties = JsonSerializer.Serialize(properties),
                 Timestamp = variation.Timestamp * 1000 // milliseconds to microseconds
@@ -72,10 +78,10 @@ public class Insight
                 user = new { keyId = User!.KeyId, name = User!.Name },
                 applicationType = metric.AppType,
                 projectId = string.Empty,
-                envId = envId.ToString(),
+                envId = envIdString,
                 accountId = string.Empty,
                 tag_0 = User!.KeyId,
-                tag_1 = metric.NumericValue.ToString(),
+                tag_1 = $"{metric.NumericValue}",
                 tag_2 = User!.Name
             };
 
@@ -83,7 +89,7 @@ public class Insight
             {
                 Uuid = Guid.NewGuid().ToString(),
                 DistinctId = metric.EventName,
-                EnvId = envId.ToString(),
+                EnvId = envIdString,
                 Event = metric.Type,
                 Properties = JsonSerializer.Serialize(properties),
                 Timestamp = metric.Timestamp * 1000 // milliseconds to microseconds

--- a/modules/evaluation-server/src/Streaming/StreamingLoggingExtensions.cs
+++ b/modules/evaluation-server/src/Streaming/StreamingLoggingExtensions.cs
@@ -8,7 +8,7 @@ internal static partial class StreamingLoggingExtensions
         EventName = "RequestRejected")]
     public static partial void RequestRejected(this ILogger logger, string? request, string reason);
 
-    [LoggerMessage(2, LogLevel.Error, "Failed to resolve host for IP address: {IpAddress}.",
+    [LoggerMessage(2, LogLevel.Warning, "Failed to resolve host for IP address: {IpAddress}.",
         EventName = "FailedToResolveHost")]
     public static partial void FailedToResolveHost(this ILogger logger, string ipAddress, Exception ex);
 


### PR DESCRIPTION
Due to #922 , older versions of the client SDKs may send insights data with `null` variation.

Addtionally, change the log level for `FailedToResolveHost` from error to warning