### PR TITLE
✨ feat: allow user creation if keyId unique

### DIFF
--- a/modules/front-end/src/app/core/components/target-user/target-user.component.ts
+++ b/modules/front-end/src/app/core/components/target-user/target-user.component.ts
@@ -44,7 +44,11 @@ export class TargetUserComponent implements OnInit {
       return;
     }
 
-    const searchValue = this.selectNode['searchValue'];
+    const searchValue = this.selectNode?.searchValue;
+    if (!searchValue) {
+      this.userList = [...data];
+      return;
+    }
     const hasExactMatch = data.some(u => u.keyId === searchValue) || this.selectedUserDetailList?.some(u => u.keyId === searchValue);
     if (!hasExactMatch) {
       this.userList = [{

--- a/modules/front-end/src/app/core/components/target-user/target-user.component.ts
+++ b/modules/front-end/src/app/core/components/target-user/target-user.component.ts
@@ -44,11 +44,12 @@ export class TargetUserComponent implements OnInit {
       return;
     }
 
-    const searchValue = this.selectNode?.searchValue;
+    const searchValue = this.selectNode?.['searchValue'];
     if (!searchValue) {
       this.userList = [...data];
       return;
     }
+
     const hasExactMatch = data.some(u => u.keyId === searchValue) || this.selectedUserDetailList?.some(u => u.keyId === searchValue);
     if (!hasExactMatch) {
       this.userList = [{

--- a/modules/front-end/src/app/core/components/target-user/target-user.component.ts
+++ b/modules/front-end/src/app/core/components/target-user/target-user.component.ts
@@ -39,12 +39,18 @@ export class TargetUserComponent implements OnInit {
   @Input("userList")
   set list(data: IUserType[]) {
     this.isLoadingUsers = false;
-    if (!this.disableCreation && this.selectNode['searchValue'] && data.length === 0) {
-      this.userList = [{
-        keyId: this.selectNode['searchValue'],
-        name: this.selectNode['searchValue'],
-        isNew: true
-      } as IUserType];
+    const searchValue = this.selectNode['searchValue'];
+    if (!this.disableCreation && searchValue) {
+      const hasExactMatch = data.some(u => u.keyId === searchValue);
+      if (!hasExactMatch) {
+        this.userList = [{
+          keyId: searchValue,
+          name: searchValue,
+          isNew: true
+        } as IUserType, ...data];
+      } else {
+        this.userList = [...data];
+      }
     } else {
       this.userList = [...data];
     }

--- a/modules/front-end/src/app/core/components/target-user/target-user.component.ts
+++ b/modules/front-end/src/app/core/components/target-user/target-user.component.ts
@@ -39,18 +39,19 @@ export class TargetUserComponent implements OnInit {
   @Input("userList")
   set list(data: IUserType[]) {
     this.isLoadingUsers = false;
+    if (this.disableCreation) {
+      this.userList = [...data];
+      return;
+    }
+
     const searchValue = this.selectNode['searchValue'];
-    if (!this.disableCreation && searchValue) {
-      const hasExactMatch = data.some(u => u.keyId === searchValue) || this.selectedUserDetailList?.some(u => u.keyId === searchValue);
-      if (!hasExactMatch) {
-        this.userList = [{
-          keyId: searchValue,
-          name: searchValue,
-          isNew: true
-        } as IUserType, ...data];
-      } else {
-        this.userList = [...data];
-      }
+    const hasExactMatch = data.some(u => u.keyId === searchValue) || this.selectedUserDetailList?.some(u => u.keyId === searchValue);
+    if (!hasExactMatch) {
+      this.userList = [{
+        keyId: searchValue,
+        name: searchValue,
+        isNew: true
+      } as IUserType, ...data];
     } else {
       this.userList = [...data];
     }

--- a/modules/front-end/src/app/core/components/target-user/target-user.component.ts
+++ b/modules/front-end/src/app/core/components/target-user/target-user.component.ts
@@ -41,7 +41,7 @@ export class TargetUserComponent implements OnInit {
     this.isLoadingUsers = false;
     const searchValue = this.selectNode['searchValue'];
     if (!this.disableCreation && searchValue) {
-      const hasExactMatch = data.some(u => u.keyId === searchValue);
+      const hasExactMatch = data.some(u => u.keyId === searchValue) || this.selectedUserDetailList?.some(u => u.keyId === searchValue);
       if (!hasExactMatch) {
         this.userList = [{
           keyId: searchValue,

--- a/modules/front-end/src/locale/messages.xlf
+++ b/modules/front-end/src/locale/messages.xlf
@@ -943,11 +943,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/target-user/target-user.component.ts</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">145</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/target-user/target-user.component.ts</context>
-          <context context-type="linenumber">176</context>
+          <context context-type="linenumber">188</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/test-webhook-modal/test-webhook-modal.component.ts</context>
@@ -6226,7 +6226,7 @@
         <source>Saved Successfully</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/target-user/target-user.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="integrations.webhooks.send-test-event" datatype="html">
@@ -7077,7 +7077,7 @@
         <source>Failed to load data</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/end-users/index/index.component.ts</context>
-          <context context-type="linenumber">152</context>
+          <context context-type="linenumber">153</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/feature-flags/details/setting/setting.component.ts</context>

--- a/modules/front-end/src/locale/messages.zh.xlf
+++ b/modules/front-end/src/locale/messages.zh.xlf
@@ -962,11 +962,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/target-user/target-user.component.ts</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">145</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/target-user/target-user.component.ts</context>
-          <context context-type="linenumber">176</context>
+          <context context-type="linenumber">188</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/test-webhook-modal/test-webhook-modal.component.ts</context>
@@ -6702,7 +6702,7 @@
         <source>Saved Successfully</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/target-user/target-user.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">186</context>
         </context-group>
         <target>保存与更新成功</target>
       </trans-unit>
@@ -7646,7 +7646,7 @@
         <source>Failed to load data</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/end-users/index/index.component.ts</context>
-          <context context-type="linenumber">152</context>
+          <context context-type="linenumber">153</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/safe/feature-flags/details/setting/setting.component.ts</context>


### PR DESCRIPTION
## Description

End users cannot be created if partial matches are returned when selecting individual flag targets. Changes allow for the _Create_ option to be selected as long as the input is not a direct match with an existing end user.

## Testing Instructions
- Run cd modules/front-end && npm start
- Create an end user 'Tester' via the feature flag individual targeting section. Save flag configuration.
- Upon refresh, enter 'Test' in the feature flag individual targeting section. _Create_ option should be present alongside the search dropdown of any existing end users partial matches.

## Screenshots

### Before
<img width="1015" height="278" alt="image" src="https://github.com/user-attachments/assets/7255ed25-e7af-414f-8b89-dad8e5f4526e" />


### After
<img width="1020" height="351" alt="image" src="https://github.com/user-attachments/assets/562e8b1a-fc5b-4427-a0e1-b9f70d3ac74f" />


## Related
https://github.com/featbit/featbit/issues/929