### PR TITLE
🐛 fix: redis populate race and fail fast on populate errors

### DIFF
--- a/modules/back-end/README.md
+++ b/modules/back-end/README.md
@@ -97,10 +97,12 @@ JWT (JSON Web Token) configuration for authentication and authorization.
 
 ### Redis
 
-| Name                      | Description                                                                                  | Default Value  |
-|---------------------------|----------------------------------------------------------------------------------------------|----------------|
-| `Redis__ConnectionString` | Redis Connection String                                                                      | `"redis:6379"` |
-| `Redis__Password`         | Redis Password (Optional). If provided, override the password specified in connection string | `""`           |
+| Name                            | Description                                                                                                                                                                                                               | Default Value  |
+|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|
+| `Redis__ConnectionString`       | Redis Connection String                                                                                                                                                                                                   | `"redis:6379"` |
+| `Redis__Password`               | Redis Password (Optional). If provided, override the password specified in connection string                                                                                                                              | `""`           |
+| `Redis__PopulateLockTtlSeconds` | Lock TTL (seconds) for the startup Redis populate. Must exceed the expected populate duration; if the lock expires mid-populate a second instance can start a concurrent populate. Increase for large datasets.           | `60`           |
+| `Redis__PopulateMaxWaitSeconds` | Maximum seconds an instance will wait for another instance to finish populating Redis before throwing. Should be comfortably larger than `PopulateLockTtlSeconds` so a crashed instance's lock can expire and be retaken. | `90`           |
 
 ### Kafka
 

--- a/modules/back-end/src/Api/appsettings.Development.json
+++ b/modules/back-end/src/Api/appsettings.Development.json
@@ -60,8 +60,8 @@
   "Redis": {
     "ConnectionString": "localhost:6379",
     "Password": "",
-    "PopulateLockTtlSeconds": 5,
-    "PopulateMaxWaitSeconds": 15
+    "PopulateLockTtlSeconds": 60,
+    "PopulateMaxWaitSeconds": 90
   },
   "UsageTracking": {
     "FlushIntervalMs": 5000,

--- a/modules/back-end/src/Api/appsettings.Development.json
+++ b/modules/back-end/src/Api/appsettings.Development.json
@@ -59,7 +59,9 @@
   },
   "Redis": {
     "ConnectionString": "localhost:6379",
-    "Password": ""
+    "Password": "",
+    "PopulateLockTtlSeconds": 5,
+    "PopulateMaxWaitSeconds": 15
   },
   "UsageTracking": {
     "FlushIntervalMs": 5000,

--- a/modules/back-end/src/Api/appsettings.json
+++ b/modules/back-end/src/Api/appsettings.json
@@ -59,8 +59,8 @@
   "Redis": {
     "ConnectionString": "redis:6379",
     "Password": "",
-    "PopulateLockTtlSeconds": 5,
-    "PopulateMaxWaitSeconds": 15
+    "PopulateLockTtlSeconds": 60,
+    "PopulateMaxWaitSeconds": 90
   },
   "UsageTracking": {
     "FlushIntervalMs": 5000,

--- a/modules/back-end/src/Api/appsettings.json
+++ b/modules/back-end/src/Api/appsettings.json
@@ -58,7 +58,9 @@
   },
   "Redis": {
     "ConnectionString": "redis:6379",
-    "Password": ""
+    "Password": "",
+    "PopulateLockTtlSeconds": 5,
+    "PopulateMaxWaitSeconds": 15
   },
   "UsageTracking": {
     "FlushIntervalMs": 5000,

--- a/modules/back-end/src/Application/Caches/CachePopulatingHostedService.cs
+++ b/modules/back-end/src/Application/Caches/CachePopulatingHostedService.cs
@@ -27,7 +27,12 @@ public class CachePopulatingHostedService : IHostedService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Exception occurred when populating cache.");
+            // Re-throw so the host fails to start. Previously we logged-and-swallowed, which
+            // let the API serve traffic against an empty or partially populated cache.
+            // Failing fast surfaces the problem and lets the orchestrator (Kubernetes,
+            // systemd, Docker, etc.) drive recovery via its restart policy.
+            _logger.LogCritical(ex, "Exception occurred when populating cache. Host will not start.");
+            throw;
         }
     }
 

--- a/modules/back-end/src/Application/Caches/CachePopulatingHostedService.cs
+++ b/modules/back-end/src/Application/Caches/CachePopulatingHostedService.cs
@@ -23,13 +23,16 @@ public class CachePopulatingHostedService : IHostedService
         {
             using var scope = _serviceProvider.CreateScope();
             var populatingService = scope.ServiceProvider.GetRequiredService<ICachePopulatingService>();
-            await populatingService.PopulateAsync();
+            await populatingService.PopulateAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The host is shutting down
+            throw;
         }
         catch (Exception ex)
         {
-            // Re-throw so the host fails to start. Previously we logged-and-swallowed, which
-            // let the API serve traffic against an empty or partially populated cache.
-            // Failing fast surfaces the problem and lets the orchestrator (Kubernetes,
+            // Re-throw so the host fails to start and let the orchestrator (Kubernetes,
             // systemd, Docker, etc.) drive recovery via its restart policy.
             _logger.LogCritical(ex, "Exception occurred when populating cache. Host will not start.");
             throw;

--- a/modules/back-end/src/Application/Caches/ICachePopulatingService.cs
+++ b/modules/back-end/src/Application/Caches/ICachePopulatingService.cs
@@ -2,5 +2,5 @@ namespace Application.Caches;
 
 public interface ICachePopulatingService
 {
-    Task PopulateAsync();
+    Task PopulateAsync(CancellationToken stoppingToken);
 }

--- a/modules/back-end/src/Infrastructure/Caches/None/NonePopulatingService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/None/NonePopulatingService.cs
@@ -4,5 +4,5 @@ namespace Infrastructure.Caches.None;
 
 public class NonePopulatingService : ICachePopulatingService
 {
-    public Task PopulateAsync() => Task.CompletedTask;
+    public Task PopulateAsync(CancellationToken stoppingToken) => Task.CompletedTask;
 }

--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisOptions.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisOptions.cs
@@ -14,13 +14,14 @@ public class RedisOptions
     /// <summary>
     /// Lock TTL (seconds) used by <see cref="RedisPopulatingService"/> when taking the
     /// <c>featbit:populate-redis</c> lock at startup. The lock prevents multiple back-end
-    /// instances from running the Redis populate concurrently. Default is 5 seconds for
-    /// backwards compatibility; production deployments with larger data sets should set this
-    /// to a value greater than the expected populate duration to avoid concurrent populates
-    /// from instances that arrive after the lock has expired.
+    /// instances from running the Redis populate concurrently. Must be set to a value greater
+    /// than the expected populate duration; if the lock expires before the populate finishes,
+    /// another instance can acquire the lock and run a concurrent populate. Default is
+    /// 60 seconds, which is sufficient for most deployments. Increase this value
+    /// if your dataset is large enough that populate regularly takes longer than 60 seconds.
     /// </summary>
     [Range(1, 3600, ErrorMessage = "Populate lock TTL must be between 1 and 3600 seconds.")]
-    public int PopulateLockTtlSeconds { get; set; } = 5;
+    public int PopulateLockTtlSeconds { get; set; } = 60;
 
     /// <summary>
     /// Maximum number of seconds an instance will wait for another instance to finish
@@ -28,9 +29,9 @@ public class RedisOptions
     /// poll the populate marker and re-attempt the lock; if the populating instance is stuck
     /// or crashed past this timeout, the waiting instance throws so the host can surface the
     /// failure (and the orchestrator can restart it) rather than serving against a partially
-    /// populated Redis indefinitely. Default is 180 seconds (3 minutes), which is a small
-    /// multiple of the default lock TTL.
+    /// populated Redis indefinitely. Default is 90 seconds (<see cref="PopulateLockTtlSeconds"/>
+    /// plus a 30-second margin for lock expiry and polling overhead).
     /// </summary>
     [Range(1, 3600, ErrorMessage = "Populate max wait must be between 1 and 3600 seconds.")]
-    public int PopulateMaxWaitSeconds { get; set; } = 180;
+    public int PopulateMaxWaitSeconds { get; set; } = 90;
 }

--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisOptions.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisOptions.cs
@@ -10,4 +10,27 @@ public class RedisOptions
     public string ConnectionString { get; set; } = string.Empty;
 
     public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Lock TTL (seconds) used by <see cref="RedisPopulatingService"/> when taking the
+    /// <c>featbit:populate-redis</c> lock at startup. The lock prevents multiple back-end
+    /// instances from running the Redis populate concurrently. Default is 5 seconds for
+    /// backwards compatibility; production deployments with larger data sets should set this
+    /// to a value greater than the expected populate duration to avoid concurrent populates
+    /// from instances that arrive after the lock has expired.
+    /// </summary>
+    [Range(1, 3600, ErrorMessage = "Populate lock TTL must be between 1 and 3600 seconds.")]
+    public int PopulateLockTtlSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// Maximum number of seconds an instance will wait for another instance to finish
+    /// populating Redis before throwing. Instances that arrive while a populate is in progress
+    /// poll the populate marker and re-attempt the lock; if the populating instance is stuck
+    /// or crashed past this timeout, the waiting instance throws so the host can surface the
+    /// failure (and the orchestrator can restart it) rather than serving against a partially
+    /// populated Redis indefinitely. Default is 180 seconds (3 minutes), which is a small
+    /// multiple of the default lock TTL.
+    /// </summary>
+    [Range(1, 3600, ErrorMessage = "Populate max wait must be between 1 and 3600 seconds.")]
+    public int PopulateMaxWaitSeconds { get; set; } = 180;
 }

--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisPopulatingService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisPopulatingService.cs
@@ -52,7 +52,17 @@ public class RedisPopulatingService(
                         return;
                     }
 
-                    await PopulateCoreAsync();
+                    logger.LogInformation("Start to populate redis. Lock TTL: {LockTtl}s.", lockTtl.TotalSeconds);
+
+                    var stopwatch = Stopwatch.StartNew();
+                    await PopulateFlagsAsync();
+                    await PopulateSegmentAsync();
+                    await PopulateSecretsAsync();
+
+                    // mark redis as populated
+                    await redis.StringSetAsync(IsPopulatedKey, "true");
+
+                    logger.LogInformation("Populate redis finished in {Elapsed} ms.", stopwatch.ElapsedMilliseconds);
                 }
                 finally
                 {
@@ -83,31 +93,6 @@ public class RedisPopulatingService(
             );
 
             await Task.Delay(pollInterval, stoppingToken);
-        }
-
-        return;
-
-        async Task PopulateCoreAsync()
-        {
-            logger.LogInformation("Start to populate redis. Lock TTL: {LockTtlSeconds}s.", lockTtl.TotalSeconds);
-
-            var stopwatch = Stopwatch.StartNew();
-            try
-            {
-                await PopulateFlagsAsync();
-                await PopulateSegmentAsync();
-                await PopulateSecretsAsync();
-
-                // mark redis as populated
-                await redis.StringSetAsync(IsPopulatedKey, "true");
-
-                logger.LogInformation("Populate redis finished in {Elapsed} ms.", stopwatch.ElapsedMilliseconds);
-            }
-            catch
-            {
-                logger.LogError("Populate redis failed after {Elapsed} ms.", stopwatch.ElapsedMilliseconds);
-                throw;
-            }
         }
     }
 

--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisPopulatingService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisPopulatingService.cs
@@ -89,7 +89,7 @@ public class RedisPopulatingService(
 
         async Task PopulateCoreAsync()
         {
-            logger.LogWarning("Start to populate redis. Lock TTL: {LockTtlSeconds}s.", lockTtl.TotalSeconds);
+            logger.LogInformation("Start to populate redis. Lock TTL: {LockTtlSeconds}s.", lockTtl.TotalSeconds);
 
             var stopwatch = Stopwatch.StartNew();
             try

--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisPopulatingService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisPopulatingService.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Application.Caches;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Infrastructure.Caches.Redis;
 
@@ -10,6 +11,7 @@ public class RedisPopulatingService(
     IFeatureFlagService flagService,
     ISegmentService segmentService,
     IEnvironmentService envService,
+    IOptions<RedisOptions> redisOptions,
     ILogger<RedisPopulatingService> logger)
     : ICachePopulatingService
 {
@@ -20,36 +22,82 @@ public class RedisPopulatingService(
     {
         var redis = redisClient.GetDatabase();
 
-        var isPopulated = await redis.StringGetAsync(IsPopulatedKey) == "true";
-        if (isPopulated)
-        {
-            logger.LogInformation("Redis has been populated before, ignore run again");
-            return;
-        }
+        var lockTtl = TimeSpan.FromSeconds(redisOptions.Value.PopulateLockTtlSeconds);
+        var pollInterval = TimeSpan.FromSeconds(2);
+        var maxWait = TimeSpan.FromSeconds(redisOptions.Value.PopulateMaxWaitSeconds);
+        var waitStopwatch = Stopwatch.StartNew();
 
-        var lockValue = Guid.NewGuid().ToString();
-        if (await redis.LockTakeAsync(PopulateLockKey, lockValue, TimeSpan.FromSeconds(5)))
+        while (true)
         {
-            logger.LogInformation("Start to populate redis.");
-            var stopWatch = Stopwatch.StartNew();
-            try
+            // Cheap path: marker already set by a prior instance, nothing to do.
+            if (await redis.StringGetAsync(IsPopulatedKey) == "true")
             {
-                await PopulateFlagsAsync();
-                await PopulateSegmentAsync();
-                await PopulateSecretsAsync();
+                logger.LogInformation("Redis has been populated before, ignore run again");
+                return;
+            }
 
-                // mark redis as populated
-                await redis.StringSetAsync(IsPopulatedKey, "true");
-            }
-            catch (Exception ex)
+            var lockValue = Guid.NewGuid().ToString();
+            if (await redis.LockTakeAsync(PopulateLockKey, lockValue, lockTtl))
             {
-                logger.LogError(ex, "Exception occurred while populating redis");
+                try
+                {
+                    // Re-check the marker inside the lock. Closes the race where another
+                    // instance finished writing the marker between our StringGet above and our
+                    // LockTake. Without this we'd run a redundant populate immediately after
+                    // the previous instance just completed one.
+                    if (await redis.StringGetAsync(IsPopulatedKey) == "true")
+                    {
+                        logger.LogInformation(
+                            "Redis populated by another instance while we waited for the lock");
+                        return;
+                    }
+
+                    logger.LogInformation(
+                        "Start to populate redis. Lock TTL: {LockTtlSeconds}s.",
+                        lockTtl.TotalSeconds);
+                    var populateStopwatch = Stopwatch.StartNew();
+                    try
+                    {
+                        await PopulateFlagsAsync();
+                        await PopulateSegmentAsync();
+                        await PopulateSecretsAsync();
+
+                        // mark redis as populated
+                        await redis.StringSetAsync(IsPopulatedKey, "true");
+                    }
+                    finally
+                    {
+                        logger.LogInformation(
+                            "Populate redis finished in {Elapsed} ms.",
+                            populateStopwatch.ElapsedMilliseconds);
+                    }
+                }
+                finally
+                {
+                    await redis.LockReleaseAsync(PopulateLockKey, lockValue);
+                }
+
+                return;
             }
-            finally
+
+            // Another instance holds the lock. Wait and retry both the marker and the lock
+            // take. Instances that arrive while a populate is in progress used to silently
+            // no-op here and start serving against a partially-populated Redis. Looping
+            // prevents that.
+            if (waitStopwatch.Elapsed > maxWait)
             {
-                logger.LogInformation("Populate redis finished in {Elapsed} ms.", stopWatch.ElapsedMilliseconds);
-                await redis.LockReleaseAsync(PopulateLockKey, lockValue);
+                throw new InvalidOperationException(
+                    $"Timed out waiting for another instance to finish populating Redis " +
+                    $"after {maxWait.TotalSeconds} seconds. This instance will not start. " +
+                    $"Investigate whether the populating instance is stuck or crashed.");
             }
+
+            logger.LogInformation(
+                "Another instance is populating Redis. Waiting {PollIntervalSeconds}s before " +
+                "re-checking (elapsed: {ElapsedSeconds:F0}s).",
+                pollInterval.TotalSeconds, waitStopwatch.Elapsed.TotalSeconds);
+
+            await Task.Delay(pollInterval);
         }
     }
 

--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisPopulatingService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisPopulatingService.cs
@@ -18,25 +18,26 @@ public class RedisPopulatingService(
     private const string IsPopulatedKey = "featbit:redis-is-populated";
     private const string PopulateLockKey = "featbit:populate-redis";
 
-    public async Task PopulateAsync()
+    public async Task PopulateAsync(CancellationToken stoppingToken)
     {
-        var redis = redisClient.GetDatabase();
+        logger.LogInformation("Verifying redis population status on startup...");
 
         var lockTtl = TimeSpan.FromSeconds(redisOptions.Value.PopulateLockTtlSeconds);
-        var pollInterval = TimeSpan.FromSeconds(2);
         var maxWait = TimeSpan.FromSeconds(redisOptions.Value.PopulateMaxWaitSeconds);
+        var pollInterval = TimeSpan.FromSeconds(2);
+        var lockValue = Guid.NewGuid().ToString();
+
         var waitStopwatch = Stopwatch.StartNew();
 
-        while (true)
+        var redis = redisClient.GetDatabase();
+        while (!stoppingToken.IsCancellationRequested)
         {
-            // Cheap path: marker already set by a prior instance, nothing to do.
             if (await redis.StringGetAsync(IsPopulatedKey) == "true")
             {
-                logger.LogInformation("Redis has been populated before, ignore run again");
+                logger.LogInformation("Redis has been populated, proceeding with service startup.");
                 return;
             }
 
-            var lockValue = Guid.NewGuid().ToString();
             if (await redis.LockTakeAsync(PopulateLockKey, lockValue, lockTtl))
             {
                 try
@@ -47,30 +48,11 @@ public class RedisPopulatingService(
                     // the previous instance just completed one.
                     if (await redis.StringGetAsync(IsPopulatedKey) == "true")
                     {
-                        logger.LogInformation(
-                            "Redis populated by another instance while we waited for the lock");
+                        logger.LogInformation("Redis populated by another instance, proceeding with service startup.");
                         return;
                     }
 
-                    logger.LogInformation(
-                        "Start to populate redis. Lock TTL: {LockTtlSeconds}s.",
-                        lockTtl.TotalSeconds);
-                    var populateStopwatch = Stopwatch.StartNew();
-                    try
-                    {
-                        await PopulateFlagsAsync();
-                        await PopulateSegmentAsync();
-                        await PopulateSecretsAsync();
-
-                        // mark redis as populated
-                        await redis.StringSetAsync(IsPopulatedKey, "true");
-                    }
-                    finally
-                    {
-                        logger.LogInformation(
-                            "Populate redis finished in {Elapsed} ms.",
-                            populateStopwatch.ElapsedMilliseconds);
-                    }
+                    await PopulateCoreAsync();
                 }
                 finally
                 {
@@ -89,15 +71,43 @@ public class RedisPopulatingService(
                 throw new InvalidOperationException(
                     $"Timed out waiting for another instance to finish populating Redis " +
                     $"after {maxWait.TotalSeconds} seconds. This instance will not start. " +
-                    $"Investigate whether the populating instance is stuck or crashed.");
+                    $"Investigate whether the populating instance is stuck or crashed."
+                );
             }
 
             logger.LogInformation(
                 "Another instance is populating Redis. Waiting {PollIntervalSeconds}s before " +
                 "re-checking (elapsed: {ElapsedSeconds:F0}s).",
-                pollInterval.TotalSeconds, waitStopwatch.Elapsed.TotalSeconds);
+                pollInterval.TotalSeconds,
+                waitStopwatch.Elapsed.TotalSeconds
+            );
 
-            await Task.Delay(pollInterval);
+            await Task.Delay(pollInterval, stoppingToken);
+        }
+
+        return;
+
+        async Task PopulateCoreAsync()
+        {
+            logger.LogWarning("Start to populate redis. Lock TTL: {LockTtlSeconds}s.", lockTtl.TotalSeconds);
+
+            var stopwatch = Stopwatch.StartNew();
+            try
+            {
+                await PopulateFlagsAsync();
+                await PopulateSegmentAsync();
+                await PopulateSecretsAsync();
+
+                // mark redis as populated
+                await redis.StringSetAsync(IsPopulatedKey, "true");
+
+                logger.LogInformation("Populate redis finished in {Elapsed} ms.", stopwatch.ElapsedMilliseconds);
+            }
+            catch
+            {
+                logger.LogError("Populate redis failed after {Elapsed} ms.", stopwatch.ElapsedMilliseconds);
+                throw;
+            }
         }
     }
 
@@ -108,7 +118,7 @@ public class RedisPopulatingService(
 
         await Task.WhenAll(tasks);
 
-        logger.LogInformation("populate flag success, total count: {Total}", flags.Count);
+        logger.LogInformation("Populate flag success, total count: {Total}", flags.Count);
     }
 
     private async Task PopulateSegmentAsync()
@@ -118,7 +128,7 @@ public class RedisPopulatingService(
 
         await Task.WhenAll(tasks);
 
-        logger.LogInformation("populate segment success, total count: {Total}", caches.Count);
+        logger.LogInformation("Populate segment success, total count: {Total}", caches.Count);
     }
 
     private async Task PopulateSecretsAsync()
@@ -128,6 +138,6 @@ public class RedisPopulatingService(
 
         await Task.WhenAll(tasks);
 
-        logger.LogInformation("populate secrets success, total count: {Total}", caches.Count);
+        logger.LogInformation("Populate secrets success, total count: {Total}", caches.Count);
     }
 }


### PR DESCRIPTION
## Summary
 
 Two related startup-safety bugs in the API's Redis cache populate path
 could leave the Evaluation Server serving SDK requests against an empty
 or partially populated cache. The bugs are ordering issues that only
 manifest in multi-instance deployments and on cold caches (fresh deploy,
 `FLUSHDB`, Redis restart).
 
 This PR closes both holes:
 1. `RedisPopulatingService.PopulateAsync` no longer silently returns
    when another instance holds the populate lock — it now waits for
    the populate to complete (or for the lock to free up) before
    returning.
 2. `CachePopulatingHostedService.StartAsync` no longer swallows
    populate exceptions — it logs Critical and re-throws so the host
    fails to start and the process supervisor can drive recovery via
    its restart policy.
 
 ## Background
 
 The API populates Redis on startup with the flag, segment, and secret
 data the Evaluation Server reads on every SDK request. SDKs never hit
 the API directly; they only see Redis contents via the Evaluation
 Server. So any window where Redis is empty or partial after the API
 goes Ready is a window where SDKs can get wrong evaluations.
 
 ## Bug 1 — Lock-loser race
 
 ### Before
 
 When multiple back-end instances start in parallel (rolling restart,
 scale-up, fresh deploy), only one acquires the populate lock. The
 others previously took this path:
 
 ```csharp
 if (await redis.LockTakeAsync(...)) { /* populate */ }
 // else: silently return, no populate, no wait
 ```
 
 The "else" was missing. Lock-losers returned immediately and went
 Ready while the lock-holder was still populating. Two consequences:
 
 1. **Wrong SDK evaluations on a cold cache.** If the lock-holder's
    populate fails partway through (transient DB error mid-run, network
    blip), Redis is left partially populated. Combined with bug 2
    below, nothing in the system retries. The Evaluation Server is
    happily reading whatever made it into Redis and serving SDK
    requests against incomplete data — flags missing, evaluations
    defaulting, segment matches misfiring. The system looks healthy
    (admin works, API returns 200s) but SDK evaluation is silently
    wrong.
 
 2. **Write-during-populate race.** A lock-loser that returns
    immediately can accept an admin write (flag edit) before the
    lock-holder finishes its populate. The admin write fires
    `OnFeatureFlagChanged → cacheService.UpsertFlagAsync` into a
    partially populated cache. The populate's snapshot of the same
    flag (taken at lock-acquisition time, before the admin write
    committed) can then overwrite the fresh edit. Narrow window, but
    real, and silent when it happens.
 
 ### After
 
 Lock-losers now poll every 2s for either:
 - the populate marker (`featbit:redis-is-populated`) flipping to
   `true` (lock-holder succeeded → safe to proceed), or
 - the lock being releasable (lock-holder crashed → try to take it
   ourselves).
 
 A configurable max-wait (`PopulateMaxWaitSeconds`, default 90s) caps
 the loop so a wedged populator can't block startup forever — instead
 the instance throws, the host fails to start, and the supervisor
 restarts it (see Bug 2).
 
 A re-check of the populate marker **inside** the lock absorbs the
 benign race where another instance finished writing the marker between
 our `StringGet` and our `LockTake`. Without it, we'd run a redundant
 populate immediately after a successful one.
 
 ## Bug 2 — Hosted service swallowed populate failures
 
 ### Before
 
 ```csharp
 try { await _cachePopulatingService.PopulateAsync(); }
 catch (Exception ex) { _logger.LogError(ex, "..."); }
 ```
 
 `IHostedService.StartAsync` exceptions are the host's signal to abort
 startup. By catching and logging, we told the host "all good" while
 the cache was in an unknown state, then Kestrel bound and started
 serving. The instance was permanently broken until manually
 restarted — and the Evaluation Server kept serving SDK requests from
 the partially populated Redis.
 
 ### After
 
 The catch logs `Critical` and re-throws. The host fails to start,
 the process exits non-zero, and whatever supervises the process
 (systemd, Docker, Windows Service Control Manager, a container
 orchestrator, a shell script, etc.) applies its restart policy and
 the populate retries from scratch.
 
 The `IsPopulatedKey` marker is **not** set on failure (the inner
 try-finally that wrapped the populate steps was also removed so the
 marker stays unset on exception), so the restarted instance takes
 the populate path cleanly.
 
 ## New configuration
 
 `RedisOptions` exposes two knobs, both `[Range(1, 3600)]` validated:
 
 | Key                            | Default | Purpose                                                                   |
 | ------------------------------ | ------- | ------------------------------------------------------------------------- |
 | `Redis.PopulateLockTtlSeconds` | `60`     | Distributed lock TTL. Bounded so a crashed populator can't block forever. |
 | `Redis.PopulateMaxWaitSeconds` | `90`    | How long a lock-loser will wait for the populate marker before giving up. |
 
 Both `appsettings.json` and `appsettings.Development.json` include the
 new keys with default values. Existing deployments need no config
 change; defaults match prior behavior for the happy path.
 
 > **Operator note:** `PopulateMaxWaitSeconds` should be greater than
 > your realistic populate time × ~2 for safety. If your populate
 > regularly takes 10s, leave it at 15s. If it takes 30s,
 > bump to 60s+.
 
 ## Files
 
 - `modules/back-end/src/Infrastructure/Caches/Redis/RedisPopulatingService.cs` — lock-loser wait loop, in-lock marker re-check, removed exception-swallowing try-finally around the populate steps.
 - `modules/back-end/src/Infrastructure/Caches/Redis/RedisOptions.cs` — two new validated settings.
 - `modules/back-end/src/Application/Caches/CachePopulatingHostedService.cs` — re-throw on failure, log Critical.
 - `modules/back-end/src/Api/appsettings.json` + `appsettings.Development.json` — defaults for the new keys.
 
 ## Testing
 
 - Multi-instance restart with `FLUSHDB` issued immediately before the
   restart: previously, if the lock-holder hit any error during
   populate, the other instances went Ready and the Evaluation Server
   served SDK requests from a partial Redis with no automatic recovery.
   Now lock-losers wait for the marker (or take over the populate if
   the lock frees up), and a failed populate crashes the lock-holder
   cleanly so the supervisor retries.
 - Populate failure (induced by pointing Redis at an unreachable host
   for one instance): previously the instance logged an error and went
   Ready while SDKs got wrong evaluations indefinitely; now the
   process fails to start cleanly, the supervisor restarts it, and
   once Redis is reachable it populates and becomes healthy normally.
 - `PopulateMaxWaitSeconds` exceeded: tested by holding the lock
   manually via `redis-cli`. Lock-losers throw after the configured
   wait, host fails to start, supervisor restarts. Recovers as soon
   as the lock is released.
 
 ## Labels
 
 `API`