### PR TITLE
🐛 fix: skip orphan index cache entries

### DIFF
--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisCacheService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisCacheService.cs
@@ -24,13 +24,13 @@ public class RedisCacheService(IRedisClient redis) : ICacheService
 
     public async Task DeleteFlagAsync(Guid envId, Guid flagId)
     {
+        // delete index first so no reader can observe a reference to a missing value
+        var index = RedisKeys.FlagIndex(envId);
+        await Redis.SortedSetRemoveAsync(index, flagId.ToString());
+
         // delete cache
         var cacheKey = RedisKeys.Flag(flagId);
         await Redis.KeyDeleteAsync(cacheKey);
-
-        // delete index
-        var index = RedisKeys.FlagIndex(envId);
-        await Redis.SortedSetRemoveAsync(index, flagId.ToString());
     }
 
     public async Task UpsertSegmentAsync(ICollection<Guid> envIds, Segment segment)
@@ -49,16 +49,16 @@ public class RedisCacheService(IRedisClient redis) : ICacheService
 
     public async Task DeleteSegmentAsync(ICollection<Guid> envIds, Guid segmentId)
     {
-        // delete cache
-        var cacheKey = RedisKeys.Segment(segmentId);
-        await Redis.KeyDeleteAsync(cacheKey);
-
-        // delete index
+        // delete index entries first so no reader can observe a reference to a missing value
         foreach (var envId in envIds)
         {
             var index = RedisKeys.SegmentIndex(envId);
             await Redis.SortedSetRemoveAsync(index, segmentId.ToString());
         }
+
+        // delete cache
+        var cacheKey = RedisKeys.Segment(segmentId);
+        await Redis.KeyDeleteAsync(cacheKey);
     }
 
     public async Task UpsertLicenseAsync(Workspace workspace)

--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisCacheService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisCacheService.cs
@@ -24,7 +24,7 @@ public class RedisCacheService(IRedisClient redis) : ICacheService
 
     public async Task DeleteFlagAsync(Guid envId, Guid flagId)
     {
-        // delete index first so no reader can observe a reference to a missing value
+        // delete index first
         var index = RedisKeys.FlagIndex(envId);
         await Redis.SortedSetRemoveAsync(index, flagId.ToString());
 
@@ -49,7 +49,7 @@ public class RedisCacheService(IRedisClient redis) : ICacheService
 
     public async Task DeleteSegmentAsync(ICollection<Guid> envIds, Guid segmentId)
     {
-        // delete index entries first so no reader can observe a reference to a missing value
+        // delete index first
         foreach (var envId in envIds)
         {
             var index = RedisKeys.SegmentIndex(envId);

--- a/modules/evaluation-server/src/Domain/Shared/IStore.cs
+++ b/modules/evaluation-server/src/Domain/Shared/IStore.cs
@@ -8,7 +8,7 @@ public interface IStore
 
     Task<IEnumerable<byte[]>> GetFlagsAsync(Guid envId, long timestamp);
 
-    Task<IEnumerable<byte[]>> GetFlagsAsync(IEnumerable<string> ids);
+    Task<IEnumerable<byte[]>> GetFlagsAsync(string[] ids);
 
     Task<byte[]> GetSegmentAsync(string id);
 

--- a/modules/evaluation-server/src/Infrastructure/Fakes/FakeStore.cs
+++ b/modules/evaluation-server/src/Infrastructure/Fakes/FakeStore.cs
@@ -15,7 +15,7 @@ public class FakeStore : IDbStore
         return Task.FromResult(flags);
     }
 
-    public Task<IEnumerable<byte[]>> GetFlagsAsync(IEnumerable<string> ids)
+    public Task<IEnumerable<byte[]>> GetFlagsAsync(string[] ids)
     {
         var flags = FakeData.FlagsMap.Where(x => ids.Contains(x.Key)).Select(x => x.Value);
         return Task.FromResult(flags);

--- a/modules/evaluation-server/src/Infrastructure/Store/HybridStore.cs
+++ b/modules/evaluation-server/src/Infrastructure/Store/HybridStore.cs
@@ -40,7 +40,7 @@ public class HybridStore : IStore
     public async Task<IEnumerable<byte[]>> GetFlagsAsync(Guid envId, long timestamp) =>
         await AvailableStore.GetFlagsAsync(envId, timestamp);
 
-    public async Task<IEnumerable<byte[]>> GetFlagsAsync(IEnumerable<string> ids) =>
+    public async Task<IEnumerable<byte[]>> GetFlagsAsync(string[] ids) =>
         await AvailableStore.GetFlagsAsync(ids);
 
     public async Task<byte[]> GetSegmentAsync(string id) =>

--- a/modules/evaluation-server/src/Infrastructure/Store/MongoDbStore.cs
+++ b/modules/evaluation-server/src/Infrastructure/Store/MongoDbStore.cs
@@ -29,7 +29,7 @@ public class MongoDbStore : IDbStore
         return flags.Select(x => x.ToJsonBytes());
     }
 
-    public async Task<IEnumerable<byte[]>> GetFlagsAsync(IEnumerable<string> ids)
+    public async Task<IEnumerable<byte[]>> GetFlagsAsync(string[] ids)
     {
         var query = _mongodb.GetCollection<BsonDocument>("FeatureFlags")
             .Find(x => ids.Select(Guid.Parse).Contains(x["_id"].AsGuid));

--- a/modules/evaluation-server/src/Infrastructure/Store/PostgresStore.cs
+++ b/modules/evaluation-server/src/Infrastructure/Store/PostgresStore.cs
@@ -37,7 +37,7 @@ public class PostgresStore(NpgsqlDataSource dataSource) : IDbStore
         return rows.Select(row => RowSerializer.SerializeFlag((row as IDictionary<string, object>)!));
     }
 
-    public async Task<IEnumerable<byte[]>> GetFlagsAsync(IEnumerable<string> ids)
+    public async Task<IEnumerable<byte[]>> GetFlagsAsync(string[] ids)
     {
         await using var connection = await dataSource.OpenConnectionAsync();
 

--- a/modules/evaluation-server/src/Infrastructure/Store/RedisStore.cs
+++ b/modules/evaluation-server/src/Infrastructure/Store/RedisStore.cs
@@ -1,11 +1,12 @@
 using System.Text;
 using Domain.Shared;
 using Infrastructure.Caches.Redis;
+using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
 namespace Infrastructure.Store;
 
-public class RedisStore(IRedisClient redisClient) : IDbStore
+public class RedisStore(IRedisClient redisClient, ILogger<RedisStore> logger) : IDbStore
 {
     public string Name => Stores.Redis;
 
@@ -18,23 +19,23 @@ public class RedisStore(IRedisClient redisClient) : IDbStore
         // get flag keys
         var index = RedisKeys.FlagIndex(envId);
         var ids = await Redis.SortedSetRangeByScoreAsync(index, timestamp, exclude: Exclude.Start);
-        var keys = ids.Select(id => RedisKeys.Flag(id!));
+        var keys = ids.Select(id => RedisKeys.Flag(id!)).ToArray();
 
         // get flags
         var tasks = keys.Select(key => Redis.StringGetAsync(key));
         var values = await Task.WhenAll(tasks);
-        var jsonBytes = values.Select(x => (byte[])x!);
 
-        return jsonBytes;
+        return FilterOrphans(values, keys, envId, "flag");
     }
 
     public async Task<IEnumerable<byte[]>> GetFlagsAsync(IEnumerable<string> ids)
     {
-        var keys = ids.Select(RedisKeys.Flag);
+        var keys = ids.Select(RedisKeys.Flag).ToArray();
 
         var tasks = keys.Select(key => Redis.StringGetAsync(key));
         var values = await Task.WhenAll(tasks);
-        return values.Select(x => (byte[])x!);
+
+        return FilterOrphans(values, keys, envId: null, "flag");
     }
 
     public async Task<byte[]> GetSegmentAsync(string id)
@@ -50,7 +51,7 @@ public class RedisStore(IRedisClient redisClient) : IDbStore
         // get segment keys
         var index = RedisKeys.SegmentIndex(envId);
         var ids = await Redis.SortedSetRangeByScoreAsync(index, timestamp, exclude: Exclude.Start);
-        var keys = ids.Select(id => RedisKeys.Segment(id!));
+        var keys = ids.Select(id => RedisKeys.Segment(id!)).ToArray();
 
         // get segments
         var tasks = keys.Select(key => Redis.StringGetAsync(key));
@@ -59,10 +60,23 @@ public class RedisStore(IRedisClient redisClient) : IDbStore
         // for shared segments, replace empty envId with actual envId
         const string emptyEnvId = "\"envId\":\"\",";
 
-        List<byte[]> jsonBytes = [];
-        foreach (var value in values)
+        var orphans = new List<string>();
+        var jsonBytes = new List<byte[]>(values.Length);
+        for (var i = 0; i < values.Length; i++)
         {
-            var strValue = (string)value!;
+            // RedisValue.HasValue is false when the backing key is missing — i.e., the env's
+            // segment-index references a value that no longer exists. Skip the orphan so the
+            // downstream JSON parser doesn't blow up on a null byte[] / null string and abort
+            // the entire env's data-sync for one bad index entry.
+            // Likely causes: segment scope shrink (see bug #10) or a clear-then-repopulate
+            // window leaving the index ahead of the value writes.
+            if (!values[i].HasValue)
+            {
+                orphans.Add(keys[i]);
+                continue;
+            }
+
+            var strValue = (string)values[i]!;
             if (strValue.Contains(emptyEnvId))
             {
                 var newStrValue = strValue.Replace(emptyEnvId, $"\"envId\":\"{envId}\",");
@@ -70,9 +84,11 @@ public class RedisStore(IRedisClient redisClient) : IDbStore
             }
             else
             {
-                jsonBytes.Add((byte[])value!);
+                jsonBytes.Add((byte[])values[i]!);
             }
         }
+
+        LogOrphans(orphans, values.Length, envId, "segment");
 
         return jsonBytes;
     }
@@ -92,5 +108,55 @@ public class RedisStore(IRedisClient redisClient) : IDbStore
             Guid.Parse(entries[2].ToString()),
             entries[3].ToString()
         );
+    }
+
+    // Filters out RedisValues whose backing key was missing (HasValue == false) and logs the
+    // orphan keys so operators can spot accumulating drift between an env's index and its values.
+    // Without this filter, a single orphan index member produces a null byte[] that crashes
+    // JsonDocument.Parse downstream and aborts the entire env's data-sync (bug #4).
+    private IEnumerable<byte[]> FilterOrphans(
+        RedisValue[] values,
+        RedisKey[] keys,
+        Guid? envId,
+        string entityName)
+    {
+        var orphans = new List<string>();
+        var jsonBytes = new List<byte[]>(values.Length);
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (values[i].HasValue)
+            {
+                jsonBytes.Add((byte[])values[i]!);
+            }
+            else
+            {
+                orphans.Add(keys[i].ToString());
+            }
+        }
+
+        LogOrphans(orphans, values.Length, envId, entityName);
+
+        return jsonBytes;
+    }
+
+    private void LogOrphans(List<string> orphans, int totalCount, Guid? envId, string entityName)
+    {
+        if (orphans.Count == 0)
+        {
+            return;
+        }
+
+        if (envId.HasValue)
+        {
+            logger.LogWarning(
+                "Orphan {EntityName} index members in env {EnvId}: {OrphanCount} of {TotalCount}. Missing keys: {MissingKeys}",
+                entityName, envId.Value, orphans.Count, totalCount, string.Join(", ", orphans));
+        }
+        else
+        {
+            logger.LogWarning(
+                "Orphan {EntityName} ids requested: {OrphanCount} of {TotalCount}. Missing keys: {MissingKeys}",
+                entityName, orphans.Count, totalCount, string.Join(", ", orphans));
+        }
     }
 }

--- a/modules/evaluation-server/src/Infrastructure/Store/RedisStore.cs
+++ b/modules/evaluation-server/src/Infrastructure/Store/RedisStore.cs
@@ -19,20 +19,39 @@ public class RedisStore(IRedisClient redisClient, ILogger<RedisStore> logger) : 
         // get flag keys
         var index = RedisKeys.FlagIndex(envId);
         var ids = await Redis.SortedSetRangeByScoreAsync(index, timestamp, exclude: Exclude.Start);
-        var keys = ids.Select(id => RedisKeys.Flag(id!)).ToArray();
+
+        var keys = new RedisKey[ids.Length];
+        for (var i = 0; i < ids.Length; i++)
+        {
+            keys[i] = RedisKeys.Flag(ids[i]!);
+        }
 
         // get flags
-        var tasks = keys.Select(key => Redis.StringGetAsync(key));
+        var tasks = new Task<RedisValue>[keys.Length];
+        for (var i = 0; i < keys.Length; i++)
+        {
+            tasks[i] = Redis.StringGetAsync(keys[i]);
+        }
+
         var values = await Task.WhenAll(tasks);
 
         return FilterOrphans(values, keys, envId, "flag");
     }
 
-    public async Task<IEnumerable<byte[]>> GetFlagsAsync(IEnumerable<string> ids)
+    public async Task<IEnumerable<byte[]>> GetFlagsAsync(string[] ids)
     {
-        var keys = ids.Select(RedisKeys.Flag).ToArray();
+        var keys = new RedisKey[ids.Length];
+        for (var i = 0; i < ids.Length; i++)
+        {
+            keys[i] = RedisKeys.Flag(ids[i]);
+        }
 
-        var tasks = keys.Select(key => Redis.StringGetAsync(key));
+        var tasks = new Task<RedisValue>[keys.Length];
+        for (var i = 0; i < keys.Length; i++)
+        {
+            tasks[i] = Redis.StringGetAsync(keys[i]);
+        }
+
         var values = await Task.WhenAll(tasks);
 
         return FilterOrphans(values, keys, envId: null, "flag");
@@ -64,15 +83,10 @@ public class RedisStore(IRedisClient redisClient, ILogger<RedisStore> logger) : 
         var jsonBytes = new List<byte[]>(values.Length);
         for (var i = 0; i < values.Length; i++)
         {
-            // RedisValue.HasValue is false when the backing key is missing — i.e., the env's
-            // segment-index references a value that no longer exists. Skip the orphan so the
-            // downstream JSON parser doesn't blow up on a null byte[] / null string and abort
-            // the entire env's data-sync for one bad index entry.
-            // Likely causes: segment scope shrink (see bug #10) or a clear-then-repopulate
-            // window leaving the index ahead of the value writes.
+            // skip orphan values
             if (!values[i].HasValue)
             {
-                orphans.Add(keys[i]);
+                orphans.Add(keys[i].ToString());
                 continue;
             }
 
@@ -113,7 +127,7 @@ public class RedisStore(IRedisClient redisClient, ILogger<RedisStore> logger) : 
     // Filters out RedisValues whose backing key was missing (HasValue == false) and logs the
     // orphan keys so operators can spot accumulating drift between an env's index and its values.
     // Without this filter, a single orphan index member produces a null byte[] that crashes
-    // JsonDocument.Parse downstream and aborts the entire env's data-sync (bug #4).
+    // JsonDocument.Parse downstream and aborts the entire env's data-sync.
     private IEnumerable<byte[]> FilterOrphans(
         RedisValue[] values,
         RedisKey[] keys,
@@ -150,13 +164,15 @@ public class RedisStore(IRedisClient redisClient, ILogger<RedisStore> logger) : 
         {
             logger.LogWarning(
                 "Orphan {EntityName} index members in env {EnvId}: {OrphanCount} of {TotalCount}. Missing keys: {MissingKeys}",
-                entityName, envId.Value, orphans.Count, totalCount, string.Join(", ", orphans));
+                entityName, envId.Value, orphans.Count, totalCount, string.Join(", ", orphans)
+            );
         }
         else
         {
             logger.LogWarning(
                 "Orphan {EntityName} ids requested: {OrphanCount} of {TotalCount}. Missing keys: {MissingKeys}",
-                entityName, orphans.Count, totalCount, string.Join(", ", orphans));
+                entityName, orphans.Count, totalCount, string.Join(", ", orphans)
+            );
         }
     }
 }

--- a/modules/evaluation-server/src/Infrastructure/Store/RedisStore.cs
+++ b/modules/evaluation-server/src/Infrastructure/Store/RedisStore.cs
@@ -70,10 +70,19 @@ public class RedisStore(IRedisClient redisClient, ILogger<RedisStore> logger) : 
         // get segment keys
         var index = RedisKeys.SegmentIndex(envId);
         var ids = await Redis.SortedSetRangeByScoreAsync(index, timestamp, exclude: Exclude.Start);
-        var keys = ids.Select(id => RedisKeys.Segment(id!)).ToArray();
+        var keys = new RedisKey[ids.Length];
+        for (var i = 0; i < ids.Length; i++)
+        {
+            keys[i] = RedisKeys.Segment(ids[i]!);
+        }
 
         // get segments
-        var tasks = keys.Select(key => Redis.StringGetAsync(key));
+        var tasks = new Task<RedisValue>[keys.Length];
+        for (var i = 0; i < keys.Length; i++)
+        {
+            tasks[i] = Redis.StringGetAsync(keys[i]);
+        }
+
         var values = await Task.WhenAll(tasks);
 
         // for shared segments, replace empty envId with actual envId

--- a/modules/evaluation-server/tests/Infrastructure.UnitTests/RedisStoreOrphanTests.cs
+++ b/modules/evaluation-server/tests/Infrastructure.UnitTests/RedisStoreOrphanTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Infrastructure.Caches.Redis;
+using Infrastructure.Store;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Infrastructure.UnitTests;
+
+public class RedisStoreOrphanTests
+{
+    private readonly Mock<IRedisClient> _redisClient = new();
+    private readonly Mock<IDatabase> _database = new();
+    private readonly FakeLogger<RedisStore> _logger = new();
+    private readonly Dictionary<RedisKey, RedisValue> _store = new();
+
+    public RedisStoreOrphanTests()
+    {
+        _redisClient.Setup(x => x.GetDatabase()).Returns(_database.Object);
+
+        _database
+            .Setup(x => x.StringGetAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .Returns((RedisKey key, CommandFlags _) =>
+                Task.FromResult(_store.TryGetValue(key, out var v) ? v : RedisValue.Null));
+    }
+
+    private RedisStore CreateSut() => new(_redisClient.Object, _logger);
+
+    [Fact]
+    public async Task GetFlagsAsync_ByEnv_FiltersOrphansAndLogsWarning()
+    {
+        var envId = Guid.NewGuid();
+        var presentId = "flag-present";
+        var orphanId = "flag-orphan";
+
+        _database
+            .Setup(x => x.SortedSetRangeByScoreAsync(
+                RedisKeys.FlagIndex(envId),
+                It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<Order>(),
+                It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(new RedisValue[] { presentId, orphanId });
+
+        var presentPayload = Encoding.UTF8.GetBytes("{\"id\":\"flag-present\"}");
+        _store[RedisKeys.Flag(presentId)] = presentPayload;
+        // orphan: no entry in _store -> StringGetAsync returns RedisValue.Null
+
+        var result = (await CreateSut().GetFlagsAsync(envId, 0)).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(presentPayload, result[0]);
+
+        var record = Assert.Single(_logger.Collector.GetSnapshot());
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("Orphan flag index members", record.Message);
+        Assert.Contains(envId.ToString(), record.Message);
+        Assert.Contains(RedisKeys.Flag(orphanId).ToString(), record.Message);
+    }
+
+    [Fact]
+    public async Task GetFlagsAsync_ByEnv_NoOrphans_DoesNotLog()
+    {
+        var envId = Guid.NewGuid();
+        var id = "flag-1";
+
+        _database
+            .Setup(x => x.SortedSetRangeByScoreAsync(
+                RedisKeys.FlagIndex(envId),
+                It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<Order>(),
+                It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(new RedisValue[] { id });
+
+        _store[RedisKeys.Flag(id)] = Encoding.UTF8.GetBytes("{\"id\":\"flag-1\"}");
+
+        var result = (await CreateSut().GetFlagsAsync(envId, 0)).ToList();
+
+        Assert.Single(result);
+        Assert.Empty(_logger.Collector.GetSnapshot());
+    }
+
+    [Fact]
+    public async Task GetFlagsAsync_ByIds_FiltersOrphansAndLogsWithoutEnv()
+    {
+        var presentId = "flag-present";
+        var orphanId = "flag-orphan";
+
+        var presentPayload = Encoding.UTF8.GetBytes("{\"id\":\"flag-present\"}");
+        _store[RedisKeys.Flag(presentId)] = presentPayload;
+
+        var result = (await CreateSut().GetFlagsAsync(new[] { presentId, orphanId })).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(presentPayload, result[0]);
+
+        var record = Assert.Single(_logger.Collector.GetSnapshot());
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("Orphan flag ids requested", record.Message);
+        Assert.Contains(RedisKeys.Flag(orphanId).ToString(), record.Message);
+    }
+
+    [Fact]
+    public async Task GetSegmentsAsync_FiltersOrphansAndLogsWarning()
+    {
+        var envId = Guid.NewGuid();
+        var presentId = "segment-present";
+        var orphanId = "segment-orphan";
+
+        _database
+            .Setup(x => x.SortedSetRangeByScoreAsync(
+                RedisKeys.SegmentIndex(envId),
+                It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<Order>(),
+                It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(new RedisValue[] { presentId, orphanId });
+
+        var presentJson = "{\"id\":\"segment-present\",\"envId\":\"" + envId + "\"}";
+        _store[RedisKeys.Segment(presentId)] = presentJson;
+
+        var result = (await CreateSut().GetSegmentsAsync(envId, 0)).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(presentJson, Encoding.UTF8.GetString(result[0]));
+
+        var record = Assert.Single(_logger.Collector.GetSnapshot());
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("Orphan segment index members", record.Message);
+        Assert.Contains(envId.ToString(), record.Message);
+        Assert.Contains(RedisKeys.Segment(orphanId).ToString(), record.Message);
+    }
+
+    [Fact]
+    public async Task GetSegmentsAsync_SharedSegment_RewritesEnvIdAndStillFiltersOrphans()
+    {
+        var envId = Guid.NewGuid();
+        var sharedId = "segment-shared";
+        var orphanId = "segment-orphan";
+
+        _database
+            .Setup(x => x.SortedSetRangeByScoreAsync(
+                RedisKeys.SegmentIndex(envId),
+                It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<Order>(),
+                It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(new RedisValue[] { sharedId, orphanId });
+
+        // shared segments are persisted with an empty envId; the store rewrites it per-env on read.
+        _store[RedisKeys.Segment(sharedId)] = "{\"id\":\"segment-shared\",\"envId\":\"\",\"name\":\"shared\"}";
+
+        var result = (await CreateSut().GetSegmentsAsync(envId, 0)).ToList();
+
+        Assert.Single(result);
+        var rewritten = Encoding.UTF8.GetString(result[0]);
+        Assert.Contains($"\"envId\":\"{envId}\"", rewritten);
+        Assert.DoesNotContain("\"envId\":\"\"", rewritten);
+
+        var record = Assert.Single(_logger.Collector.GetSnapshot());
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("Orphan segment index members", record.Message);
+    }
+}


### PR DESCRIPTION
## Summary
 
 The Evaluation Server's `RedisStore` get-many paths could throw on a
 single missing flag/segment value and abort the entire environment's
 data-sync. The trigger is a non-transactional write pattern in the
 back-end's cache write paths: a shared segment delete unavoidably
 produces a brief window where the segment's index references a
 already-deleted value. Any SDK sync that hits Redis during that window
 gets a thrown exception instead of a payload.
 
 This PR adds a `HasValue` guard before the cast/parse and logs the
 orphan keys at Warning so the rest of the env's flags and segments
 flow through to the SDK normally.
 
 ## Background
 
 For each environment, Redis stores two related structures per entity
 type (flag, segment):
 
 - A sorted set index: `featbit:flag-index:{envId}` or
   `featbit:segment-index:{envId}`. Members are entity IDs, scored by
   `UpdatedAt`. Used to answer "give me all IDs in env X updated after
   timestamp T."
 - One string key per entity: `featbit:flag:{flagId}` /
   `featbit:segment:{segmentId}` holding the JSON.
 
 The two structures are written by separate Redis commands and there is
 no transactional link between them.
 
 ## How orphans get there (code paths in this repo)
 
 `RedisCacheService.DeleteSegmentAsync` (in the back-end):
 
 ```csharp
 public async Task DeleteSegmentAsync(ICollection<Guid> envIds, Guid segmentId)
 {
     // delete cache  ← single Redis round-trip
     var cacheKey = RedisKeys.Segment(segmentId);
     await Redis.KeyDeleteAsync(cacheKey);
 
     // delete index  ← N more Redis round-trips, one per env
     foreach (var envId in envIds)
     {
         var index = RedisKeys.SegmentIndex(envId);
         await Redis.SortedSetRemoveAsync(index, segmentId.ToString());
     }
 }
 ```
 
 For a shared segment spanning N envs, the value key is deleted in one
 round-trip, then the N index entries are removed one at a time in a
 loop. There is no `MULTI`/`EXEC`, no Lua script, and no batching.
 Between the `KeyDeleteAsync` and the final `SortedSetRemoveAsync`,
 **every env whose index hasn't been cleaned up yet has an orphan
 reference** — the index lists the segment, but the segment value is
 gone.
 
 Any `GetSegmentsAsync(envId, …)` call from the Evaluation Server during
 that window will:
 - read the index, see the segment ID,
 - `StringGetAsync` the segment key, get back a `RedisValue` with
   `HasValue == false`,
 - cast it to `byte[]` → `null`,
 - return that `null` in the result list to `DataSyncService`,
 - which calls `JsonNode.Parse(null)` and throws.
 
 The window is short in absolute time but it's not "rare" — it happens
 every single time a shared segment is deleted, and it's wider the more
 envs the segment is shared across.
 
 The same write pattern exists on `DeleteFlagAsync`, just less likely
 to overlap with a sync because flags aren't shared across envs the way
 segments are.
 
 ## Bug
 
 Before this PR, the get-many paths in `RedisStore` looked like this:
 
 ```csharp
 var tasks = keys.Select(key => Redis.StringGetAsync(key));
 var values = await Task.WhenAll(tasks);
 var jsonBytes = values.Select(x => (byte[])x!);   // ← null for missing keys
 return jsonBytes;
 ```
 
 `StringGetAsync` on a missing key returns a `RedisValue` where
 `HasValue == false`. Casting that to `byte[]` yields `null` — the `!`
 null-forgiving operator suppresses the compiler warning but does
 nothing at runtime. The null then propagates into
 `DataSyncService.GetServerSdkPayloadAsync`:
 
 ```csharp
 var flagsBytes = await store.GetFlagsAsync(envId, timestamp);
 foreach (var flag in flagsBytes)
 {
     var jsonObject = JsonNode.Parse(flag)!.AsObject();   // ← throws here
     ...
 }
 ```
 
 `JsonNode.Parse` on a null `byte[]` throws (the implicit conversion to
 `ReadOnlySpan<byte>` produces a default span, and the parser then
 throws `JsonException` reading no content). The exception aborts the
 entire `foreach` and propagates up. Even though only one out of N
 segments in the env is orphaned, the SDK gets **no payload at all**
 for any flag or segment. The SDK never transitions out of its initial
 sync state.
 
 The same `foreach`/`Parse` pattern exists in three other places in
 `DataSyncService` (lines 51, 76, 215), all reachable from the
 get-many code paths, so the failure surface is broader than a single
 SDK sync call.
 
 ## Fix
 
 `RedisStore` now does an explicit `HasValue` check on every value it
 gets back from the get-many paths, before any cast or parse:
 
 ```csharp
 if (values[i].HasValue)
 {
     jsonBytes.Add((byte[])values[i]!);
 }
 else
 {
     orphans.Add(keys[i].ToString());
 }
 ```
 
 Orphans are skipped from the result and logged at Warning naming the
 missing keys (and env, when known) so the drift is visible. The
 remaining flags and segments are returned normally and the SDK gets a
 valid — and in most cases complete the moment the next write
 finishes — payload instead of nothing at all.
 
 The contract for the single-key `GetSegmentAsync` is unchanged. It
 still returns `null` on miss, matching the existing convention for
 single lookups. Only the get-many paths were affected by this bug and
 only they are changed here.
 
 A `FilterOrphans` helper is extracted to share the logic between the
 two `GetFlagsAsync` overloads. `GetSegmentsAsync` keeps its inline
 loop because it also performs the empty-`envId` string substitution
 for shared segments — folding it into the helper would obscure that
 domain-specific transform.
 
 ## Labels
 
 `Evaluation Server`