### PR TITLE
🐛 fix: cannot update segment & feature flag

### DIFF
--- a/modules/back-end/src/Domain/FeatureFlags/FeatureFlag.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/FeatureFlag.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Domain.AuditLogs;
 using Domain.FlagDrafts;
 using Domain.Targeting;
@@ -51,6 +52,15 @@ public class FeatureFlag : FullAuditedEntity
     /// committed value and ignore this pending change until it is promoted.
     /// </summary>
     public PendingFlagChange Pending { get; set; }
+
+    /// <summary>
+    /// Postgres <c>xmin</c> system column, used as the optimistic concurrency token. It is a real
+    /// property rather than an EF shadow property because the DbContext queries with no tracking,
+    /// and shadow values only live on a tracking entry - they would be lost before the update.
+    /// Unused by the Mongo provider.
+    /// </summary>
+    [JsonIgnore]
+    public uint Xmin { get; set; }
 
     public FeatureFlag()
     {

--- a/modules/back-end/src/Domain/FeatureFlags/FeatureFlag.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/FeatureFlag.cs
@@ -60,7 +60,7 @@ public class FeatureFlag : FullAuditedEntity
     /// Unused by the Mongo provider.
     /// </summary>
     [JsonIgnore]
-    public uint Xmin { get; set; }
+    public uint Xmin { get; private set; }
 
     public FeatureFlag()
     {

--- a/modules/back-end/src/Domain/Segments/Segment.cs
+++ b/modules/back-end/src/Domain/Segments/Segment.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Domain.AuditLogs;
 using Domain.EndUsers;
 using Domain.Targeting;
@@ -46,6 +47,15 @@ public class Segment : AuditedEntity
     /// committed value and ignore this pending change until it is promoted.
     /// </summary>
     public PendingSegmentChange Pending { get; set; }
+
+    /// <summary>
+    /// Postgres <c>xmin</c> system column, used as the optimistic concurrency token. It is a real
+    /// property rather than an EF shadow property because the DbContext queries with no tracking,
+    /// and shadow values only live on a tracking entry - they would be lost before the update.
+    /// Unused by the Mongo provider.
+    /// </summary>
+    [JsonIgnore]
+    public uint Xmin { get; set; }
 
     public bool IsEnvironmentSpecific => Type == SegmentType.EnvironmentSpecific;
 

--- a/modules/back-end/src/Domain/Segments/Segment.cs
+++ b/modules/back-end/src/Domain/Segments/Segment.cs
@@ -55,7 +55,7 @@ public class Segment : AuditedEntity
     /// Unused by the Mongo provider.
     /// </summary>
     [JsonIgnore]
-    public uint Xmin { get; set; }
+    public uint Xmin { get; private set; }
 
     public bool IsEnvironmentSpecific => Type == SegmentType.EnvironmentSpecific;
 

--- a/modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/Configurations/FeatureFlagConfiguration.cs
+++ b/modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/Configurations/FeatureFlagConfiguration.cs
@@ -35,6 +35,6 @@ public class FeatureFlagConfiguration : IEntityTypeConfiguration<FeatureFlag>
         // Postgres xmin as an optimistic concurrency token (#72): changes on every row
         // update, so a racing writer makes SaveChanges throw DbUpdateConcurrencyException
         // instead of silently overwriting. System column - no DDL, Mongo unaffected.
-        builder.Property<uint>("xmin").IsRowVersion();
+        builder.Property(x => x.Xmin).HasColumnName("xmin").HasColumnType("xid").IsRowVersion();
     }
 }

--- a/modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/Configurations/SegmentConfiguration.cs
+++ b/modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/Configurations/SegmentConfiguration.cs
@@ -29,6 +29,6 @@ public class SegmentConfiguration : IEntityTypeConfiguration<Segment>
         // Postgres xmin as an optimistic concurrency token (#72): changes on every row
         // update, so a racing writer makes SaveChanges throw DbUpdateConcurrencyException
         // instead of silently overwriting. System column - no DDL, Mongo unaffected.
-        builder.Property<uint>("xmin").IsRowVersion();
+        builder.Property(x => x.Xmin).HasColumnName("xmin").HasColumnType("xid").IsRowVersion();
     }
 }

--- a/modules/back-end/src/Infrastructure/Persistence/MongoDb/ClassMaps.cs
+++ b/modules/back-end/src/Infrastructure/Persistence/MongoDb/ClassMaps.cs
@@ -1,6 +1,7 @@
 using Domain.ControlPlane;
 using Domain.FeatureFlags;
 using Domain.Organizations;
+using Domain.Segments;
 using Domain.Users;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
@@ -22,6 +23,17 @@ public static class ClassMaps
         {
             map.AutoMap();
             map.MapMember(x => x.Tags).SetDefaultValue(Array.Empty<string>());
+
+            // Postgres-only concurrency token; never persisted to Mongo.
+            map.UnmapMember(x => x.Xmin);
+        });
+
+        BsonClassMap.RegisterClassMap<Segment>(map =>
+        {
+            map.AutoMap();
+
+            // Postgres-only concurrency token; never persisted to Mongo.
+            map.UnmapMember(x => x.Xmin);
         });
 
         BsonClassMap.RegisterClassMap<User>(map =>


### PR DESCRIPTION
introduced in #940 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency when updating feature flags and segments through PostgreSQL.
  * Prevented PostgreSQL-only concurrency metadata from being exposed in API responses or stored in MongoDB.

* **Reliability**
  * Enhanced optimistic concurrency handling to detect conflicting updates and help prevent unintended data overwrites.
  * Improved consistency across PostgreSQL and MongoDB persistence without changing the data presented through the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores PostgreSQL optimistic concurrency support for feature flags and segments while keeping the provider-specific token out of serialized and MongoDB data.
- Replaces shadow `xmin` mappings with CLR-backed row-version properties that survive no-tracking queries.
- Excludes the PostgreSQL-only property from System.Text.Json output and MongoDB persistence.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/back-end/src/Domain/FeatureFlags/FeatureFlag.cs | Adds a JSON-ignored CLR property for the PostgreSQL `xmin` concurrency token. |
| modules/back-end/src/Domain/Segments/Segment.cs | Adds the equivalent JSON-ignored concurrency property to segments. |
| modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/Configurations/FeatureFlagConfiguration.cs | Maps the feature-flag concurrency property to PostgreSQL's `xmin` system column as an `xid` row version. |
| modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/Configurations/SegmentConfiguration.cs | Maps the segment concurrency property to PostgreSQL's `xmin` system column as an `xid` row version. |
| modules/back-end/src/Infrastructure/Persistence/MongoDb/ClassMaps.cs | Explicitly excludes the PostgreSQL-only concurrency properties from MongoDB mappings. |

<sub>Reviews (2): Last reviewed commit: ["make \`Xmin\` setter private"](https://github.com/featbit/featbit/commit/b9b7e9589ae73e32c02674c186b24ddbaa4fe05b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50404008)</sub>

<!-- /greptile_comment -->