### PR TITLE
🐛 fix: cannot log in if the first project has no environments

### DIFF
--- a/modules/front-end/src/app/core/guards/auth.guard.ts
+++ b/modules/front-end/src/app/core/guards/auth.guard.ts
@@ -158,7 +158,7 @@ const trySetAccessibleProjectEnv = async (projectService: ProjectService): Promi
     project = projects.find(pro => pro.id === localProjectEnv.projectId);
     env = project?.environments?.find(env => env.id === localProjectEnv.envId);
   } else {
-    project = projects[0];
+    project = projects.find(project => project.environments?.length > 0);
     env = project?.environments[0];
   }
 


### PR DESCRIPTION
if the first project has no environments but a later project does, access is incorrectly denied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project selection when no environment is currently selected by choosing the first project with an available environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes initial project/environment selection so authentication can continue when the first project has no environments but a later project does.
- Selects the first project containing at least one environment.
- Uses that project's first environment as the initial active environment.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed fallback correctly selecting a usable project when earlier projects have no environments.

The new search preserves project ordering while skipping empty environment lists, and no concrete changed-code failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/front-end/src/app/core/guards/auth.guard.ts | The fallback selection now skips projects without environments, directly addressing the reported login denial without changing persisted-selection behavior. |

<sub>Reviews (1): Last reviewed commit: ["find the first project with at least one..."](https://github.com/featbit/featbit/commit/9f5b843ca9d3dfddfc49280cd31ac17e05968c1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50495459)</sub>

<!-- /greptile_comment -->