### PR TITLE
🧹 refactor: replace UnionWith with parallel queries

### DIFF
--- a/modules/back-end/src/Infrastructure/Services/MongoDb/EndUserService.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/EndUserService.cs
@@ -106,20 +106,21 @@ public class EndUserService(MongoDbClient mongoDb) : MongoDbService<EndUser>(mon
             return globalUsers;
         }
 
-        // Use $unionWith so each branch hits its own index (workspaceId or envId),
-        // then sort + limit the merged result set — mirrors the PostgreSQL UNION ALL approach.
         var envFilter = builder.And(builder.Eq(x => x.EnvId, envId), extraFilters);
-        var envPipeline = new EmptyPipelineDefinition<EndUser>().Match(envFilter);
 
-        var users = await Collection.Aggregate()
-            .Match(globalFilter)
-            .UnionWith(Collection, envPipeline)
+        var results = await Task.WhenAll(FindAsync(globalFilter), FindAsync(envFilter));
+        return results
+            .SelectMany(x => x)
+            .OrderByDescending(x => x.UpdatedAt)
+            .ThenByDescending(x => x.Id)
+            .Take(limit)
+            .ToArray();
+
+        Task<List<EndUser>> FindAsync(FilterDefinition<EndUser> userFilter) => Collection.Find(userFilter)
             .SortByDescending(x => x.UpdatedAt)
             .ThenByDescending(x => x.Id)
             .Limit(limit)
             .ToListAsync();
-
-        return users;
 
         FilterDefinition<EndUser> BuildExtraFilters()
         {

--- a/modules/back-end/tests/Infrastructure.IntegrationTests/Fixtures/Collections.cs
+++ b/modules/back-end/tests/Infrastructure.IntegrationTests/Fixtures/Collections.cs
@@ -8,6 +8,12 @@ public sealed class MongoCollection : ICollectionFixture<MongoDbFixture>
     public const string Name = "Mongo";
 }
 
+[CollectionDefinition(CosmosMongoCollection.Name)]
+public sealed class CosmosMongoCollection : ICollectionFixture<CosmosMongoDbFixture>
+{
+    public const string Name = "CosmosMongo";
+}
+
 [CollectionDefinition(PostgresCollection.Name)]
 public sealed class PostgresCollection : ICollectionFixture<PostgresFixture>
 {

--- a/modules/back-end/tests/Infrastructure.IntegrationTests/Fixtures/CosmosMongoDbFixture.cs
+++ b/modules/back-end/tests/Infrastructure.IntegrationTests/Fixtures/CosmosMongoDbFixture.cs
@@ -1,0 +1,68 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Infrastructure.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Spins up the Azure Cosmos DB emulator with its MongoDB endpoint enabled.
+/// </summary>
+public sealed class CosmosMongoDbFixture : IAsyncLifetime
+{
+    private const string EmulatorKey =
+        "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+
+    private readonly IContainer _container = new ContainerBuilder(
+            "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest")
+        .WithEnvironment("AZURE_COSMOS_EMULATOR_ENABLE_MONGODB_ENDPOINT", "4.2")
+        .WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", "1")
+        .WithPortBinding(8081, 8081)
+        .WithPortBinding(10255, 10255)
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(10255))
+        .Build();
+
+    public string ConnectionString =>
+        $"mongodb://localhost:{Uri.EscapeDataString(EmulatorKey)}@localhost:10255/admin" +
+        "?tls=true&tlsInsecure=true&retrywrites=false";
+
+    public async Task InitializeAsync()
+    {
+        if (!DockerAvailability.IsAvailable)
+        {
+            return;
+        }
+
+        await _container.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (!DockerAvailability.IsAvailable)
+        {
+            return;
+        }
+
+        await _container.DisposeAsync();
+    }
+
+    public async Task CreateDatabaseAsync(string databaseName, params string[] collectionNames)
+    {
+        var database = new MongoClient(ConnectionString).GetDatabase(databaseName);
+
+        await database.RunCommandAsync<BsonDocument>(new BsonDocument
+        {
+            { "customAction", "CreateDatabase" },
+            { "offerThroughput", 400 }
+        });
+
+        foreach (var collectionName in collectionNames)
+        {
+            await database.RunCommandAsync<BsonDocument>(new BsonDocument
+            {
+                { "customAction", "CreateCollection" },
+                { "collection", collectionName }
+            });
+        }
+    }
+}

--- a/modules/back-end/tests/Infrastructure.IntegrationTests/Fixtures/CosmosMongoDbFixture.cs
+++ b/modules/back-end/tests/Infrastructure.IntegrationTests/Fixtures/CosmosMongoDbFixture.cs
@@ -22,7 +22,7 @@ public sealed class CosmosMongoDbFixture : IAsyncLifetime
         .Build();
 
     public string ConnectionString =>
-        $"mongodb://localhost:{Uri.EscapeDataString(EmulatorKey)}@localhost:{_container.GetMappedPublicPort(10255)}/admin" +
+        $"mongodb://localhost:{Uri.EscapeDataString(EmulatorKey)}@{_container.Hostname}:{_container.GetMappedPublicPort(10255)}/admin" +
         "?tls=true&tlsInsecure=true&retrywrites=false&directConnection=true";
 
     public async Task InitializeAsync()

--- a/modules/back-end/tests/Infrastructure.IntegrationTests/Fixtures/CosmosMongoDbFixture.cs
+++ b/modules/back-end/tests/Infrastructure.IntegrationTests/Fixtures/CosmosMongoDbFixture.cs
@@ -13,18 +13,17 @@ public sealed class CosmosMongoDbFixture : IAsyncLifetime
     private const string EmulatorKey =
         "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 
-    private readonly IContainer _container = new ContainerBuilder(
-            "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest")
+    // private readonly IContainer _container = new ContainerBuilder("mcr.azure.cn/cosmosdb/linux/azure-cosmos-emulator:latest")
+    private readonly IContainer _container = new ContainerBuilder("mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest")
         .WithEnvironment("AZURE_COSMOS_EMULATOR_ENABLE_MONGODB_ENDPOINT", "4.2")
         .WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", "1")
-        .WithPortBinding(8081, 8081)
-        .WithPortBinding(10255, 10255)
+        .WithPortBinding(10255, true)
         .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(10255))
         .Build();
 
     public string ConnectionString =>
-        $"mongodb://localhost:{Uri.EscapeDataString(EmulatorKey)}@localhost:10255/admin" +
-        "?tls=true&tlsInsecure=true&retrywrites=false";
+        $"mongodb://localhost:{Uri.EscapeDataString(EmulatorKey)}@localhost:{_container.GetMappedPublicPort(10255)}/admin" +
+        "?tls=true&tlsInsecure=true&retrywrites=false&directConnection=true";
 
     public async Task InitializeAsync()
     {

--- a/modules/back-end/tests/Infrastructure.IntegrationTests/Services/CosmosDB/EndUserServiceTests.cs
+++ b/modules/back-end/tests/Infrastructure.IntegrationTests/Services/CosmosDB/EndUserServiceTests.cs
@@ -1,0 +1,98 @@
+using Application.EndUsers;
+using Domain.EndUsers;
+using Infrastructure.IntegrationTests.Fixtures;
+using Infrastructure.Persistence.MongoDb;
+using Infrastructure.Services.MongoDb;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+
+namespace Infrastructure.IntegrationTests.Services.CosmosDB;
+
+[Collection(CosmosMongoCollection.Name)]
+public class EndUserServiceTests : IntegrationTestBase
+{
+    private readonly CosmosMongoDbFixture _fixture;
+
+    public EndUserServiceTests(CosmosMongoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [DockerFact]
+    public async Task SearchAsync_GlobalAndEnvironmentUsers_ReturnsMergedFilteredPage()
+    {
+        var databaseName = $"end-user-search-{Guid.NewGuid():N}";
+        await _fixture.CreateDatabaseAsync(databaseName, "EndUsers");
+        var client = new MongoDbClient(Options.Create(new MongoDbOptions
+        {
+            ConnectionString = _fixture.ConnectionString,
+            Database = databaseName
+        }));
+        var workspaceId = Guid.NewGuid();
+        var envId = Guid.NewGuid();
+        var excludedKeyId = "match-excluded";
+        var users = new[]
+        {
+            NewUser(workspaceId, null, "match-global-1", "Global one", 9,
+                Guid.Parse("00000000-0000-0000-0000-000000000001")),
+            NewUser(null, envId, "match-env-1", "Environment one", 9,
+                Guid.Parse("00000000-0000-0000-0000-000000000002")),
+            NewUser(workspaceId, null, "global-2", "Match global two", 6),
+            NewUser(null, envId, "env-2", "Match environment two", 7),
+            NewUser(workspaceId, null, "match-global-3", "Global three", 4),
+            NewUser(null, envId, "match-env-3", "Environment three", 5),
+            NewUser(workspaceId, null, excludedKeyId, "Match excluded", 10),
+            NewUser(Guid.NewGuid(), null, "match-other-workspace", "Other workspace", 12),
+            NewUser(null, Guid.NewGuid(), "match-other-env", "Other environment", 11),
+            NewUser(workspaceId, null, "not-in-result", "No result", 13)
+        };
+        var collection = client.CollectionOf<EndUser>();
+        await collection.Indexes.CreateManyAsync([
+            new CreateIndexModel<EndUser>(
+                Builders<EndUser>.IndexKeys
+                    .Ascending(x => x.EnvId)
+                    .Descending(x => x.UpdatedAt)
+                    .Descending(x => x.Id)),
+            new CreateIndexModel<EndUser>(
+                Builders<EndUser>.IndexKeys
+                    .Ascending(x => x.WorkspaceId)
+                    .Descending(x => x.UpdatedAt)
+                    .Descending(x => x.Id)),
+            new CreateIndexModel<EndUser>(
+                Builders<EndUser>.IndexKeys
+                    .Descending(x => x.UpdatedAt)
+                    .Descending(x => x.Id))
+        ]);
+        await collection.InsertManyAsync(users);
+        var sut = new EndUserService(client);
+
+        var result = await sut.SearchAsync(workspaceId, envId, new EndUserSearchFilter
+        {
+            SearchText = "match",
+            ExcludedKeyIds = [excludedKeyId],
+            GlobalUserOnly = false,
+            Limit = 5
+        });
+
+        Assert.Equal(
+            ["match-env-1", "match-global-1", "env-2", "global-2", "match-env-3"],
+            result.Select(x => x.KeyId));
+    }
+
+    private static EndUser NewUser(
+        Guid? workspaceId,
+        Guid? envId,
+        string keyId,
+        string name,
+        int updatedAtMinute,
+        Guid? id = null)
+    {
+        var timestamp = new DateTime(2026, 8, 19, 0, updatedAtMinute, 0, DateTimeKind.Utc);
+        return new EndUser(workspaceId, envId, keyId, name, [])
+        {
+            Id = id ?? Guid.NewGuid(),
+            CreatedAt = timestamp,
+            UpdatedAt = timestamp
+        };
+    }
+}


### PR DESCRIPTION
Cosmos DB does not support `$unionWith` operator

New index required for cosmos DB

```javascript
db.EndUsers.createIndex({updatedAt: -1, _id: -1});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search results by combining global and environment-specific matches before sorting and applying result limits.
  * Search requests now process multiple result sources concurrently for more responsive performance.

* **Tests**
  * Added integration coverage to verify filtering, ordering, merging, and result limits across search scopes.
  * Added automated validation using an isolated database environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the Cosmos-incompatible `$unionWith` aggregation with two bounded parallel queries followed by in-memory merging, sorting, and limiting.
- Runs global-user and environment-user searches concurrently.
- Adds a Cosmos DB emulator fixture with dynamic host-port allocation.
- Adds Cosmos integration coverage for filtering, ordering, merging, exclusions, and result limits.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/back-end/src/Infrastructure/Services/MongoDb/EndUserService.cs | Replaces the unsupported database-side union with parallel, independently limited queries and deterministic in-memory merging. |
| modules/back-end/tests/Infrastructure.IntegrationTests/Fixtures/Collections.cs | Registers a dedicated xUnit collection fixture for Cosmos MongoDB integration tests. |
| modules/back-end/tests/Infrastructure.IntegrationTests/Fixtures/CosmosMongoDbFixture.cs | Adds the Cosmos emulator lifecycle and uses a randomly mapped MongoDB host port, resolving the previously reported fixed-port collision. |
| modules/back-end/tests/Infrastructure.IntegrationTests/Services/CosmosDB/EndUserServiceTests.cs | Covers merged Cosmos search results, filtering, exclusions, deterministic ordering, and limiting. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SearchAsync request] --> B[Build shared filters]
    B --> C[Query global users]
    B --> D[Query environment users]
    C --> E[Task.WhenAll]
    D --> E
    E --> F[Merge results]
    F --> G[Sort by UpdatedAt and Id descending]
    G --> H[Apply result limit]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["pr feedback"](https://github.com/featbit/featbit/commit/c021b4a836e158b318f2ed5e5d547ace8f7f840e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54752347)</sub>

<!-- /greptile_comment -->