### PR TITLE
🐛 fix: get 404 when fetching variation insights data

### DIFF
--- a/modules/front-end/src/features/flags/details/insights/insights-api.test.ts
+++ b/modules/front-end/src/features/flags/details/insights/insights-api.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { fetchApi } from "@/lib/api/authenticated-api"
+import { fetchEvaluatedEndUsers } from "./insights-api"
+
+vi.mock("@/lib/api/authenticated-api", () => ({
+  fetchApi: vi.fn(),
+}))
+
+describe("insights API", () => {
+  beforeEach(() => vi.mocked(fetchApi).mockReset())
+
+  it("requests evaluated users from the current stats endpoint", async () => {
+    vi.mocked(fetchApi).mockResolvedValue({ totalCount: 0, items: [] })
+
+    await fetchEvaluatedEndUsers("env/1", {
+      from: 1,
+      to: 2,
+      featureFlagKey: "change request",
+      variationId: "variation-1",
+      query: "Ada Lovelace",
+      pageIndex: 2,
+      pageSize: 10,
+    })
+
+    expect(fetchApi).toHaveBeenCalledWith(
+      "/api/v1/envs/env%2F1/end-users/stats?from=1&to=2&featureFlagKey=change+request&variationId=variation-1&query=Ada+Lovelace&pageIndex=1&pageSize=10"
+    )
+  })
+})

--- a/modules/front-end/src/features/flags/details/insights/insights-api.ts
+++ b/modules/front-end/src/features/flags/details/insights/insights-api.ts
@@ -42,7 +42,7 @@ export function fetchEvaluatedEndUsers(
 ) {
   const params = queryString({ ...input, pageIndex: input.pageIndex - 1 })
   return fetchApi<EvaluatedEndUsersPage>(
-    `/api/v1/envs/${encodeURIComponent(envId)}/end-users/get-by-featureflag?${params}`
+    `/api/v1/envs/${encodeURIComponent(envId)}/end-users/stats?${params}`
   )
 }
 


### PR DESCRIPTION
API route changed in #959 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated evaluated end-user insights to use the correct statistics endpoint, improving data retrieval for flag insights.

* **Tests**
  * Added automated coverage to verify request parameters, encoding, and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes evaluated end-user loading on the flag Insights page by replacing the obsolete endpoint with the current environment-scoped statistics endpoint.
- Preserves encoded environment IDs, filtering parameters, and pagination conversion.
- Adds a focused test covering endpoint selection, query encoding, and page-index conversion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| modules/front-end/src/features/flags/details/insights/insights-api.ts | Updates the evaluated-end-users request to the backend route whose parameters, pagination convention, and response shape match the existing frontend contract. |
| modules/front-end/src/features/flags/details/insights/insights-api.test.ts | Adds focused coverage for the corrected route, URL encoding, filters, and conversion from one-based UI pagination to the backend's zero-based index. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;refs/heads/main&#39; into fix/..."](https://github.com/featbit/featbit/commit/499d5b91966c4ead86a4ba335af186ac3da26684) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55976074)</sub>

<!-- /greptile_comment -->