### PR TITLE
🏗 infra: update api docs when new release published

### DIFF
--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -52,7 +52,7 @@ jobs:
           script: |
             function parseVersion(tag) {
               const match = tag.trim().match(
-                /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/,
+                /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/,
               );
 
               if (!match) {
@@ -144,8 +144,8 @@ jobs:
               );
             }
 
-  update:
-    name: Build backend and update docs
+  build-openapi:
+    name: Build backend and export OpenAPI
     needs: check-version
     if: needs.check-version.outputs.should_run == 'true'
     runs-on: ubuntu-latest
@@ -157,14 +157,7 @@ jobs:
         with:
           ref: ${{ env.SOURCE_REF }}
           path: featbit
-
-      - name: Check out documentation
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.DOCS_REPOSITORY }}
-          ref: main
-          path: docs
-          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          persist-credentials: false
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
@@ -192,10 +185,44 @@ jobs:
           ASPNETCORE_ENVIRONMENT: Production
           Jwt__Key: swagger-generation-only-key-at-least-32-characters
         run: |
+          mkdir -p "$RUNNER_TEMP/openapi"
           "$RUNNER_TEMP/dotnet-tools/swagger" tofile \
-            --output "$GITHUB_WORKSPACE/docs/openapi/featbit.json" \
+            --output "$RUNNER_TEMP/openapi/featbit.json" \
             Api.dll \
             OpenApi
+
+      - name: Upload OpenAPI document
+        uses: actions/upload-artifact@v4
+        with:
+          name: featbit-openapi
+          path: ${{ runner.temp }}/openapi/featbit.json
+          if-no-files-found: error
+          retention-days: 1
+
+  generate-docs:
+    name: Generate and validate documentation
+    needs:
+      - check-version
+      - build-openapi
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      has_changes: ${{ steps.changes.outputs.has_changes }}
+
+    steps:
+      - name: Check out documentation without credentials
+        run: >-
+          git clone
+          --branch main
+          --depth 1
+          "https://github.com/${DOCS_REPOSITORY}.git"
+          docs
+
+      - name: Download OpenAPI document
+        uses: actions/download-artifact@v5
+        with:
+          name: featbit-openapi
+          path: docs/openapi
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -232,7 +259,17 @@ jobs:
             echo "API Reference is already up to date for ${CANDIDATE_VERSION}."
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            git diff --cached --binary > "$RUNNER_TEMP/api-reference.patch"
           fi
+
+      - name: Upload generated documentation patch
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-reference-patch
+          path: ${{ runner.temp }}/api-reference.patch
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Report dry-run changes
         if: steps.changes.outputs.has_changes == 'true' && github.event_name == 'workflow_dispatch' && inputs.dry_run
@@ -251,12 +288,55 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Commit and push documentation changes
-        if: steps.changes.outputs.has_changes == 'true' && (github.event_name == 'release' || inputs.dry_run == false)
+  publish-docs:
+    name: Publish documentation
+    needs:
+      - check-version
+      - generate-docs
+    if: needs.generate-docs.outputs.has_changes == 'true' && (github.event_name == 'release' || inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out documentation without credentials
+        run: >-
+          git clone
+          --branch main
+          --depth 1
+          "https://github.com/${DOCS_REPOSITORY}.git"
+          docs
+
+      - name: Download generated documentation patch
+        uses: actions/download-artifact@v5
+        with:
+          name: api-reference-patch
+          path: ${{ runner.temp }}/generated-docs
+
+      - name: Apply and commit documentation changes
         working-directory: docs
         run: |
+          git apply --index "$RUNNER_TEMP/generated-docs/api-reference.patch"
+
+          unexpected_paths="$(
+            git diff --cached --name-only --diff-filter=ACDMRTUXB | \
+              grep -Ev '^(openapi/featbit\.json|openapi/api-reference-generated-files\.json|content/api-reference/)' || true
+          )"
+
+          if [ -n "$unexpected_paths" ]; then
+            echo "Generated patch contains unexpected paths:" >&2
+            echo "$unexpected_paths" >&2
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "docs(api): update reference for FeatBit ${CANDIDATE_VERSION}"
-          git pull --rebase origin main
-          git push origin HEAD:main
+
+      - name: Push documentation changes
+        working-directory: docs
+        env:
+          DOCS_REPO_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+        run: |
+          authorization="$(printf 'x-access-token:%s' "$DOCS_REPO_TOKEN" | base64 | tr -d '\n')"
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${authorization}" \
+            push origin HEAD:main

--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -1,0 +1,262 @@
+name: Update API Reference
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Branch or tag to build
+        required: true
+        default: main
+      candidate_version:
+        description: Semantic version to compare with existing releases
+        required: true
+      dry_run:
+        description: Run validation without committing or pushing documentation changes
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-api-reference
+  cancel-in-progress: false
+
+env:
+  DOCS_REPOSITORY: featbit/featbit-docs
+  DOTNET_VERSION: 10.0.x
+  NODE_VERSION: 24
+  PNPM_VERSION: 9.6.0
+  SWASHBUCKLE_CLI_VERSION: 10.1.7
+  CANDIDATE_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.candidate_version }}
+  SOURCE_REF: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.source_ref }}
+
+jobs:
+  check-version:
+    name: Check release version
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.compare.outputs.should_run }}
+
+    steps:
+      - name: Compare with existing releases
+        id: compare
+        uses: actions/github-script@v8
+        env:
+          CURRENT_RELEASE_ID: ${{ github.event.release.id }}
+        with:
+          script: |
+            function parseVersion(tag) {
+              const match = tag.trim().match(
+                /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/,
+              );
+
+              if (!match) {
+                throw new Error(
+                  `Release tag "${tag}" is not a valid semantic version. ` +
+                    'Expected a tag such as 5.4.7 or 5.5.0-preview1.',
+                );
+              }
+
+              return {
+                tag,
+                major: Number(match[1]),
+                minor: Number(match[2]),
+                patch: Number(match[3]),
+                prerelease: match[4]?.split('.') ?? [],
+              };
+            }
+
+            function compareIdentifiers(left, right) {
+              const leftIsNumber = /^\d+$/.test(left);
+              const rightIsNumber = /^\d+$/.test(right);
+
+              if (leftIsNumber && rightIsNumber) return Number(left) - Number(right);
+              if (leftIsNumber) return -1;
+              if (rightIsNumber) return 1;
+              return left.localeCompare(right, 'en', { sensitivity: 'case' });
+            }
+
+            function compareVersions(left, right) {
+              for (const field of ['major', 'minor', 'patch']) {
+                if (left[field] !== right[field]) return left[field] - right[field];
+              }
+
+              if (left.prerelease.length === 0 && right.prerelease.length > 0) return 1;
+              if (left.prerelease.length > 0 && right.prerelease.length === 0) return -1;
+
+              const identifierCount = Math.max(
+                left.prerelease.length,
+                right.prerelease.length,
+              );
+
+              for (let index = 0; index < identifierCount; index += 1) {
+                const leftIdentifier = left.prerelease[index];
+                const rightIdentifier = right.prerelease[index];
+
+                if (leftIdentifier === undefined) return -1;
+                if (rightIdentifier === undefined) return 1;
+
+                const comparison = compareIdentifiers(leftIdentifier, rightIdentifier);
+                if (comparison !== 0) return comparison;
+              }
+
+              return 0;
+            }
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+
+            const previousVersions = releases
+              .filter(
+                (release) =>
+                  !release.draft && String(release.id) !== process.env.CURRENT_RELEASE_ID,
+              )
+              .map((release) => parseVersion(release.tag_name));
+            const currentVersion = parseVersion(process.env.CANDIDATE_VERSION);
+            const highestPreviousVersion = previousVersions.reduce(
+              (highest, version) =>
+                highest === null || compareVersions(version, highest) > 0 ? version : highest,
+              null,
+            );
+            const shouldRun =
+              highestPreviousVersion === null ||
+              compareVersions(currentVersion, highestPreviousVersion) > 0;
+
+            core.setOutput('should_run', shouldRun ? 'true' : 'false');
+
+            if (shouldRun) {
+              core.notice(
+                highestPreviousVersion === null
+                  ? `Running for ${currentVersion.tag}; no previous releases exist.`
+                  : `Running for ${currentVersion.tag}; previous maximum is ${highestPreviousVersion.tag}.`,
+              );
+            } else {
+              core.notice(
+                `Skipping ${currentVersion.tag}; it is not greater than existing release ${highestPreviousVersion.tag}.`,
+              );
+            }
+
+  update:
+    name: Build backend and update docs
+    needs: check-version
+    if: needs.check-version.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out FeatBit source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          path: featbit
+
+      - name: Check out documentation
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.DOCS_REPOSITORY }}
+          ref: main
+          path: docs
+          token: ${{ secrets.DOCS_REPO_TOKEN }}
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore backend dependencies
+        working-directory: featbit/modules/back-end
+        run: dotnet restore Backend.slnx
+
+      - name: Build backend
+        working-directory: featbit/modules/back-end
+        run: dotnet build Backend.slnx --configuration Release --no-restore
+
+      - name: Install Swagger CLI
+        run: >-
+          dotnet tool install
+          --tool-path "$RUNNER_TEMP/dotnet-tools"
+          Swashbuckle.AspNetCore.Cli
+          --version "${SWASHBUCKLE_CLI_VERSION}"
+
+      - name: Export OpenAPI document
+        working-directory: featbit/modules/back-end/src/Api/bin/Release/net10.0
+        env:
+          ASPNETCORE_ENVIRONMENT: Production
+          Jwt__Key: swagger-generation-only-key-at-least-32-characters
+        run: |
+          "$RUNNER_TEMP/dotnet-tools/swagger" tofile \
+            --output "$GITHUB_WORKSPACE/docs/openapi/featbit.json" \
+            Api.dll \
+            OpenApi
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: docs/pnpm-lock.yaml
+
+      - name: Install documentation dependencies
+        working-directory: docs
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate and validate API Reference
+        working-directory: docs
+        run: pnpm api-reference:update
+
+      - name: Stage documentation changes
+        id: changes
+        working-directory: docs
+        run: |
+          git add \
+            openapi/featbit.json \
+            openapi/api-reference-generated-files.json \
+            content/api-reference
+
+          if git diff --cached --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "API Reference is already up to date for ${CANDIDATE_VERSION}."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report dry-run changes
+        if: steps.changes.outputs.has_changes == 'true' && github.event_name == 'workflow_dispatch' && inputs.dry_run
+        working-directory: docs
+        run: |
+          echo "Dry run completed. The following files would be committed:"
+          git diff --cached --stat
+          {
+            echo "### API Reference dry run"
+            echo
+            echo "Candidate version: \`${CANDIDATE_VERSION}\`"
+            echo "Source ref: \`${SOURCE_REF}\`"
+            echo
+            echo '```text'
+            git diff --cached --stat
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit and push documentation changes
+        if: steps.changes.outputs.has_changes == 'true' && (github.event_name == 'release' || inputs.dry_run == false)
+        working-directory: docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "docs(api): update reference for FeatBit ${CANDIDATE_VERSION}"
+          git pull --rebase origin main
+          git push origin HEAD:main


### PR DESCRIPTION
Usage:
1. Commit the workflow and merge it into the default branch of featbit.
2. Open GitHub → Actions → Update API Reference.
3. Click Run workflow.
4. Enter:
   - source_ref: main
   - candidate_version: Must be higher than the current highest version, for example, 5.4.8
   - dry_run: Leave this checked
A dry run performs the complete build, Swagger export, API Reference generation, type checking, and production build without committing or pushing any changes. The change summary will appear in the Action Summary.
To commit the generated changes to featbit-docs/main, uncheck dry_run before running the workflow.

<!--
# Instructions

1. Pick a meaningful and result oriented title for your pull request. (Use sentence case, don't include any words indicating the way you achived this result, we just want the result. Keep it short < 70 characters)
  - Prefix the title with an emoji to categorize what is being done. (Copy-paste the emoji from the list below.)
  - Assign the appropriate label(s) to the pull request. (Use one of the labels from the list below.)
  
2. Enter a succinct description that says why the PR is necessary, and what it does.
  - Implement aspect X
  - Leave out feature Y because of A
  - Improve performance by B
  - Improve accessibility by C

3. Provide clear testing instructions that include any pertinent information, i.e. seat, roles, etc.
4. Include screenshots of your changes if they impact the UI (Before & After).
5. Update the preview link with your pull request number.
6. Include any JIRA tickets, design documents, GitHub issues, or other related items to the bottom of the PR.

# Available labels
UI
API
Evaluation Server
OLAP

# Emojis for categorizing pull requests

✨ New feature or functionality
🐛 Bugfix
🔥 P0 fix
✅ Tests
🚀 Performance improvements
🖍 CSS / Styling
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
↩️ Reverting a previous change
🧹 Refactoring / Housekeeping
🔧 Package Upgrades / Maintenance
🗑️ Deleting code

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * API reference documentation is now refreshed automatically when new releases are published.
  * Documentation updates can also be triggered manually with semantic-version validation.
  * Generated changes are validated before publication, with dry-run reporting available for review.

* **Chores**
  * Improved the reliability and consistency of API reference updates across releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a release/manual workflow that builds the backend, exports OpenAPI, generates and validates API-reference changes, and optionally publishes them to the documentation repository.
- Compares the candidate semantic version with existing releases before running.
- Separates uncredentialed build and generation jobs from the credentialed publication step.
- Supports dry-run summaries and artifact-based transfer of the generated patch.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until non-dry-run publication is restricted to an authorized release or protected source ref.

The manual path passes an unrestricted source_ref through backend generation and then publishes its derived content to featbit-docs/main using the privileged documentation token, with no provenance or approval gate before the push.

**Files Needing Attention:** .github/workflows/update-api-reference.yml

<details open><summary><h3>Security Review</h3></summary>

A non-dry-run manual dispatch can publish documentation derived from an unrestricted `source_ref`. Publication should be restricted to an authorized release tag or protected ref, or require a separately protected approval boundary before using the documentation token.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/update-api-reference.yml | Adds the complete API-reference generation and publication workflow, but the manual publishing path trusts an unrestricted source_ref across the documentation-repository authorization boundary. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  actor User as Workflow dispatcher
  participant Build as build-openapi
  participant Generate as generate-docs
  participant Publish as publish-docs
  participant Docs as featbit-docs/main
  User->>Build: "source_ref, candidate_version, dry_run=false"
  Build->>Build: Checkout source_ref and export OpenAPI
  Build->>Generate: OpenAPI artifact
  Generate->>Generate: Generate allowlisted documentation patch
  Generate->>Publish: Patch artifact
  Publish->>Docs: Push generated commit using DOCS_REPO_TOKEN
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/update-api-reference.yml:158
**Unrestricted ref crosses publication boundary**

If a workflow dispatcher can select a ref they control without equivalent write access to the documentation repository, a non-dry-run dispatch builds that ref and publishes its generated OpenAPI and API-reference content directly to `featbit-docs/main`. The path allowlist constrains only the destination files, so branch-controlled documentation content still crosses the repository authorization boundary.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["comment fix"](https://github.com/featbit/featbit/commit/99faf7191008a62fb30bef15db524beaa61d8da2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56570747)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->