### PR TITLE
🏗 fix: API and ELS docker builds

### DIFF
--- a/modules/back-end/deploy/Dockerfile
+++ b/modules/back-end/deploy/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 WORKDIR /source
 
 # copy sln
-COPY *.sln .
+COPY *.slnx .
 
 # copy src project files
 COPY src/*/*.csproj ./

--- a/modules/evaluation-server/deploy/Dockerfile
+++ b/modules/evaluation-server/deploy/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 WORKDIR /source
 
 # copy sln
-COPY *.sln .
+COPY *.slnx .
 
 # copy src project files
 COPY src/*/*.csproj ./


### PR DESCRIPTION
introduced in #959

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs API and evaluation-server container builds by copying the solution format currently used by both modules before dependency restoration.
- Updates the backend build stage to copy `Backend.slnx`.
- Updates the evaluation-server build stage to copy `EvaluationServer.slnx`.
- Adds trailing newlines to both Dockerfiles.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and corrects the Docker build inputs for both affected services.

All identified CI, Compose, e2e, and documented build paths use module-level contexts containing the newly copied `.slnx` files, while the obsolete `.sln` files are absent.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| modules/back-end/deploy/Dockerfile | Replaces the obsolete `*.sln` copy pattern with `*.slnx`, matching the solution file present at the root of the backend build context. |
| modules/evaluation-server/deploy/Dockerfile | Replaces the obsolete `*.sln` copy pattern with `*.slnx`, matching the solution file present at the root of the evaluation-server build context. |

<sub>Reviews (1): Last reviewed commit: ["fix: API and ELS docker builds"](https://github.com/featbit/featbit/commit/1a38be2b1f3e28b968153dd396c1c6a54cdb6671) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57033644)</sub>

<!-- /greptile_comment -->