### PR TITLE
✨ feat: isolate malformed flag and segment evaluation errors

### DIFF
--- a/modules/evaluation-server/src/Domain/Evaluation/EntityJsonReader.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/EntityJsonReader.cs
@@ -139,7 +139,7 @@ public sealed class EntityJsonReader(EvaluationEntityType entityType, string? en
         try
         {
             var values = JsonSerializer.Deserialize<string[]>(json);
-            if (values == null || values.Any(value => !Guid.TryParse(value, out _)))
+            if (values == null || values.Any(value => !IsCanonicalGuid(value)))
             {
                 throw Malformed(
                     $"Property '{propertyName}' must contain valid segment IDs",
@@ -158,6 +158,9 @@ public sealed class EntityJsonReader(EvaluationEntityType entityType, string? en
             );
         }
     }
+
+    private static bool IsCanonicalGuid(string? value) =>
+        value is { Length: 36 } && Guid.TryParseExact(value, "D", out _);
 
     public JsonElement GetRequiredObject(JsonElement json, string propertyName)
     {

--- a/modules/evaluation-server/src/Domain/Evaluation/EntityJsonReader.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/EntityJsonReader.cs
@@ -115,24 +115,13 @@ public sealed class EntityJsonReader(EvaluationEntityType entityType, string? en
         var property = GetRequiredArray(json, propertyName);
         try
         {
-            return property.Deserialize<T[]>(ReusableJsonSerializerOptions.Web) ??
-                   throw Malformed($"Property '{propertyName}' must not be null", propertyName);
-        }
-        catch (JsonException ex)
-        {
-            throw Malformed($"Property '{propertyName}' contains invalid values", propertyName, ex);
-        }
-    }
+            var values = property.Deserialize<T[]>(ReusableJsonSerializerOptions.Web) ??
+                         throw Malformed($"Property '{propertyName}' must not be null", propertyName);
 
-    public string[] DeserializeStringArray(string json, string propertyName)
-    {
-        try
-        {
-            var values = JsonSerializer.Deserialize<string[]>(json);
-            if (values == null || values.Any(string.IsNullOrWhiteSpace))
+            if (values.Any(value => value is null))
             {
                 throw Malformed(
-                    $"Property '{propertyName}' must contain non-empty strings",
+                    $"Property '{propertyName}' must not contain null values",
                     propertyName
                 );
             }
@@ -141,7 +130,32 @@ public sealed class EntityJsonReader(EvaluationEntityType entityType, string? en
         }
         catch (JsonException ex)
         {
-            throw Malformed($"Property '{propertyName}' must be an array of strings", propertyName, ex);
+            throw Malformed($"Property '{propertyName}' contains invalid values", propertyName, ex);
+        }
+    }
+
+    public string[] DeserializeSegmentIds(string json, string propertyName)
+    {
+        try
+        {
+            var values = JsonSerializer.Deserialize<string[]>(json);
+            if (values == null || values.Any(value => !Guid.TryParse(value, out _)))
+            {
+                throw Malformed(
+                    $"Property '{propertyName}' must contain valid segment IDs",
+                    propertyName
+                );
+            }
+
+            return values;
+        }
+        catch (JsonException ex)
+        {
+            throw Malformed(
+                $"Property '{propertyName}' must be an array of segment IDs",
+                propertyName,
+                ex
+            );
         }
     }
 

--- a/modules/evaluation-server/src/Domain/Evaluation/EntityJsonReader.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/EntityJsonReader.cs
@@ -1,0 +1,212 @@
+using System.Text.Json;
+using Domain.Shared;
+
+namespace Domain.Evaluation;
+
+public enum EvaluationEntityType
+{
+    FeatureFlag,
+    Segment
+}
+
+public sealed class MalformedDataException : Exception
+{
+    public EvaluationEntityType EntityType { get; }
+
+    public string? EntityId { get; }
+
+    public string? PropertyPath { get; }
+
+    public MalformedDataException(
+        EvaluationEntityType entityType,
+        string? entityId,
+        string message,
+        string? propertyPath = null,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        EntityType = entityType;
+        EntityId = entityId;
+        PropertyPath = propertyPath;
+    }
+}
+
+public sealed class EntityJsonReader(EvaluationEntityType entityType, string? entityId = null)
+{
+    public static EntityJsonReader FeatureFlag { get; } = new(EvaluationEntityType.FeatureFlag);
+    public static EntityJsonReader ForSegment(string segmentId) => new(EvaluationEntityType.Segment, segmentId);
+
+    public static string? TryGetString(JsonElement json, string propertyName) =>
+        json.ValueKind == JsonValueKind.Object &&
+        json.TryGetProperty(propertyName, out var property) &&
+        property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    public JsonDocument Parse(ReadOnlyMemory<byte> json)
+    {
+        try
+        {
+            return JsonDocument.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            throw Malformed("Entity is not valid JSON", innerException: ex);
+        }
+    }
+
+    public bool GetRequiredBoolean(JsonElement json, string propertyName)
+    {
+        var property = GetRequiredProperty(json, propertyName);
+        if (property.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+        {
+            throw WrongType(propertyName, "boolean", property.ValueKind);
+        }
+
+        return property.GetBoolean();
+    }
+
+    public string GetRequiredString(JsonElement json, string propertyName)
+    {
+        var property = GetRequiredProperty(json, propertyName);
+        return GetRequiredStringValue(property, propertyName);
+    }
+
+    public string? GetNullableString(JsonElement json, string propertyName)
+    {
+        var property = GetRequiredProperty(json, propertyName);
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.String)
+        {
+            throw WrongType(propertyName, "string or null", property.ValueKind);
+        }
+
+        return property.GetString();
+    }
+
+    public double GetRequiredDouble(JsonElement json, string propertyName)
+    {
+        var property = GetRequiredProperty(json, propertyName);
+        if (property.ValueKind != JsonValueKind.Number || !property.TryGetDouble(out var value))
+        {
+            throw WrongType(propertyName, "number", property.ValueKind);
+        }
+
+        return value;
+    }
+
+    public JsonElement GetRequiredArray(JsonElement json, string propertyName)
+    {
+        var property = GetRequiredProperty(json, propertyName);
+        if (property.ValueKind != JsonValueKind.Array)
+        {
+            throw WrongType(propertyName, "array", property.ValueKind);
+        }
+
+        return property;
+    }
+
+    public T[] DeserializeRequiredArray<T>(JsonElement json, string propertyName)
+    {
+        var property = GetRequiredArray(json, propertyName);
+        try
+        {
+            return property.Deserialize<T[]>(ReusableJsonSerializerOptions.Web) ??
+                   throw Malformed($"Property '{propertyName}' must not be null", propertyName);
+        }
+        catch (JsonException ex)
+        {
+            throw Malformed($"Property '{propertyName}' contains invalid values", propertyName, ex);
+        }
+    }
+
+    public string[] DeserializeStringArray(string json, string propertyName)
+    {
+        try
+        {
+            var values = JsonSerializer.Deserialize<string[]>(json);
+            if (values == null || values.Any(string.IsNullOrWhiteSpace))
+            {
+                throw Malformed(
+                    $"Property '{propertyName}' must contain non-empty strings",
+                    propertyName
+                );
+            }
+
+            return values;
+        }
+        catch (JsonException ex)
+        {
+            throw Malformed($"Property '{propertyName}' must be an array of strings", propertyName, ex);
+        }
+    }
+
+    public JsonElement GetRequiredObject(JsonElement json, string propertyName)
+    {
+        var property = GetRequiredProperty(json, propertyName);
+        if (property.ValueKind != JsonValueKind.Object)
+        {
+            throw WrongType(propertyName, "object", property.ValueKind);
+        }
+
+        return property;
+    }
+
+    public DateTimeOffset GetRequiredDateTimeOffset(JsonElement json, string propertyName)
+    {
+        var property = GetRequiredProperty(json, propertyName);
+        if (property.ValueKind != JsonValueKind.String || !property.TryGetDateTimeOffset(out var value))
+        {
+            throw WrongType(propertyName, "ISO-8601 date-time string", property.ValueKind);
+        }
+
+        return value;
+    }
+
+    public string GetRequiredStringValue(JsonElement json, string path)
+    {
+        if (json.ValueKind != JsonValueKind.String)
+        {
+            throw WrongType(path, "string", json.ValueKind);
+        }
+
+        return json.GetString()!;
+    }
+
+    public MalformedDataException Malformed(
+        string message,
+        string? propertyPath = null,
+        Exception? innerException = null) =>
+        new(entityType, entityId, message, propertyPath, innerException);
+
+    private JsonElement GetRequiredProperty(JsonElement json, string propertyName)
+    {
+        if (json.ValueKind != JsonValueKind.Object)
+        {
+            throw Malformed(
+                $"Cannot read property '{propertyName}' from JSON value of type '{json.ValueKind}'",
+                propertyName
+            );
+        }
+
+        if (!json.TryGetProperty(propertyName, out var propertyValue))
+        {
+            throw Malformed($"Missing required property '{propertyName}'", propertyName);
+        }
+
+        return propertyValue;
+    }
+
+    private MalformedDataException WrongType(
+        string propertyName,
+        string expectedType,
+        JsonValueKind actualType) =>
+        Malformed(
+            $"Property '{propertyName}' is expected to be of type '{expectedType}', but was '{actualType}'",
+            propertyName
+        );
+}

--- a/modules/evaluation-server/src/Domain/Evaluation/EvaluationScope.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/EvaluationScope.cs
@@ -20,6 +20,10 @@ public struct EvaluationScope
 
     public Variation GetVariation(string variationId)
     {
-        return Variations.FirstOrDefault(x => x.Id == variationId)!;
+        return Variations.FirstOrDefault(x => x.Id == variationId) ??
+               throw EntityJsonReader.FeatureFlag.Malformed(
+                   $"Variation '{variationId}' does not exist in the feature flag",
+                   "variations"
+               );
     }
 }

--- a/modules/evaluation-server/src/Domain/Evaluation/Evaluator.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/Evaluator.cs
@@ -1,90 +1,92 @@
 namespace Domain.Evaluation;
 
-public class Evaluator : IEvaluator
+public class Evaluator(IRuleMatcher ruleMatcher) : IEvaluator
 {
-    private readonly IRuleMatcher _ruleMatcher;
-
-    public Evaluator(IRuleMatcher ruleMatcher)
-    {
-        _ruleMatcher = ruleMatcher;
-    }
-
     public async ValueTask<UserVariation> EvaluateAsync(EvaluationScope scope)
     {
         var flag = scope.Flag;
         var user = scope.User;
+        var reader = EntityJsonReader.FeatureFlag;
 
         // if flag is archived
-        var isArchived = flag.GetProperty("isArchived").GetBoolean();
+        var isArchived = reader.GetRequiredBoolean(flag, "isArchived");
         if (isArchived)
         {
             return NullUserVariation.Instance;
         }
 
         // if flag is disabled
-        var isEnabled = flag.GetProperty("isEnabled").GetBoolean();
+        var isEnabled = reader.GetRequiredBoolean(flag, "isEnabled");
         if (!isEnabled)
         {
-            var disabledVariationId = flag.GetProperty("disabledVariationId").GetString()!;
+            var disabledVariationId = reader.GetRequiredString(flag, "disabledVariationId");
             return new FeatureFlagDisabledUserVariation(scope.GetVariation(disabledVariationId));
         }
 
-        var exptIncludeAllTargets = flag.GetProperty("exptIncludeAllTargets").GetBoolean();
+        var exptIncludeAllTargets = reader.GetRequiredBoolean(flag, "exptIncludeAllTargets");
 
         // if user is targeted
-        var targetUsers = flag.GetProperty("targetUsers").EnumerateArray();
+        var targetUsers = reader.GetRequiredArray(flag, "targetUsers").EnumerateArray();
         foreach (var targetUser in targetUsers)
         {
-            var keyIds = targetUser.GetProperty("keyIds").EnumerateArray();
-            foreach (var keyId in keyIds)
+            var keyIds = reader.GetRequiredArray(targetUser, "keyIds").EnumerateArray();
+            var keyIdIndex = 0;
+            foreach (var keyIdElement in keyIds)
             {
-                if (user.KeyId == keyId.GetString())
+                var keyId = reader.GetRequiredStringValue(
+                    keyIdElement,
+                    $"targetUsers.keyIds[{keyIdIndex++}]"
+                );
+
+                if (user.KeyId == keyId)
                 {
-                    var targetVariation = scope.GetVariation(targetUser.GetProperty("variationId").GetString()!);
+                    var targetVariation = scope.GetVariation(
+                        reader.GetRequiredString(targetUser, "variationId")
+                    );
                     return new TargetedUserVariation(targetVariation, exptIncludeAllTargets);
                 }
             }
         }
 
-        var flagKey = flag.GetProperty("key").GetString();
+        var flagKey = reader.GetRequiredString(flag, "key");
         string dispatchKey;
 
         // if user is rule matched
-        var rules = flag.GetProperty("rules").EnumerateArray();
+        var rules = reader.GetRequiredArray(flag, "rules").EnumerateArray();
         foreach (var rule in rules)
         {
-            if (await _ruleMatcher.IsMatchAsync(rule, user))
+            if (await ruleMatcher.IsMatchAsync(rule, user))
             {
-                var ruleDispatchKey = rule.GetProperty("dispatchKey").GetString();
+                var ruleDispatchKey = reader.GetNullableString(rule, "dispatchKey");
                 dispatchKey = string.IsNullOrWhiteSpace(ruleDispatchKey)
                     ? $"{flagKey}{user.KeyId}"
                     : $"{flagKey}{user.ValueOf(ruleDispatchKey)}";
 
                 return new RolloutUserVariation(
-                    rule.GetProperty("variations"),
+                    reader.GetRequiredArray(rule, "variations"),
                     dispatchKey,
                     scope.Variations,
                     exptIncludeAllTargets,
-                    rule.GetProperty("includedInExpt").GetBoolean(),
-                    rule.GetProperty("name").GetString()!
+                    reader.GetRequiredBoolean(rule, "includedInExpt"),
+                    reader.GetRequiredString(rule, "name")
                 );
             }
         }
 
         // match default rule
-        var fallthrough = flag.GetProperty("fallthrough");
+        var fallthrough = reader.GetRequiredObject(flag, "fallthrough");
 
-        var fallthroughDispatchKey = fallthrough.GetProperty("dispatchKey").GetString();
+        var fallthroughDispatchKey = reader.GetNullableString(fallthrough, "dispatchKey");
         dispatchKey = string.IsNullOrWhiteSpace(fallthroughDispatchKey)
             ? $"{flagKey}{user.KeyId}"
             : $"{flagKey}{user.ValueOf(fallthroughDispatchKey)}";
 
         return new RolloutUserVariation(
-            fallthrough.GetProperty("variations"),
+            reader.GetRequiredArray(fallthrough, "variations"),
             dispatchKey,
             scope.Variations,
             exptIncludeAllTargets,
-            fallthrough.GetProperty("includedInExpt").GetBoolean(),
+            reader.GetRequiredBoolean(fallthrough, "includedInExpt"),
             "default"
         );
     }

--- a/modules/evaluation-server/src/Domain/Evaluation/Evaluator.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/Evaluator.cs
@@ -30,12 +30,11 @@ public class Evaluator(IRuleMatcher ruleMatcher) : IEvaluator
         foreach (var targetUser in targetUsers)
         {
             var keyIds = reader.GetRequiredArray(targetUser, "keyIds").EnumerateArray();
-            var keyIdIndex = 0;
             foreach (var keyIdElement in keyIds)
             {
                 var keyId = reader.GetRequiredStringValue(
                     keyIdElement,
-                    $"targetUsers.keyIds[{keyIdIndex++}]"
+                    "targetUsers.keyIds"
                 );
 
                 if (user.KeyId == keyId)

--- a/modules/evaluation-server/src/Domain/Evaluation/RuleMatcher.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/RuleMatcher.cs
@@ -73,10 +73,9 @@ public class RuleMatcher(IStore store) : IRuleMatcher
         var root = document.RootElement;
 
         var excludes = reader.GetRequiredArray(root, "excluded").EnumerateArray();
-        var excludeIndex = 0;
         foreach (var excludeElement in excludes)
         {
-            var exclude = reader.GetRequiredStringValue(excludeElement, $"excluded[{excludeIndex++}]");
+            var exclude = reader.GetRequiredStringValue(excludeElement, "excluded");
             if (exclude == user.KeyId)
             {
                 return false;
@@ -84,10 +83,9 @@ public class RuleMatcher(IStore store) : IRuleMatcher
         }
 
         var includes = reader.GetRequiredArray(root, "included").EnumerateArray();
-        var includeIndex = 0;
         foreach (var includeElement in includes)
         {
-            var include = reader.GetRequiredStringValue(includeElement, $"included[{includeIndex++}]");
+            var include = reader.GetRequiredStringValue(includeElement, "included");
             if (include == user.KeyId)
             {
                 return true;

--- a/modules/evaluation-server/src/Domain/Evaluation/RuleMatcher.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/RuleMatcher.cs
@@ -4,21 +4,16 @@ using Domain.Shared;
 
 namespace Domain.Evaluation;
 
-public class RuleMatcher : IRuleMatcher
+public class RuleMatcher(IStore store) : IRuleMatcher
 {
-    private readonly IStore _store;
-
-    public RuleMatcher(IStore store)
-    {
-        _store = store;
-    }
-
     public async ValueTask<bool> IsMatchAsync(JsonElement rule, EndUser user)
     {
-        var conditions = rule.GetProperty("conditions");
+        var reader = EntityJsonReader.FeatureFlag;
+
+        var conditions = reader.GetRequiredArray(rule, "conditions");
         foreach (var condition in conditions.EnumerateArray())
         {
-            var property = condition.GetProperty("property").GetString();
+            var property = reader.GetRequiredString(condition, "property");
 
             // in segment condition
             if (property is "User is in segment")
@@ -37,7 +32,7 @@ public class RuleMatcher : IRuleMatcher
                 }
             }
             // common condition
-            else if (!IsMatchCondition(condition, user))
+            else if (!IsMatchCondition(condition, user, reader))
             {
                 return false;
             }
@@ -48,18 +43,20 @@ public class RuleMatcher : IRuleMatcher
 
     private async Task<bool> IsMatchAnySegmentAsync(JsonElement segmentCondition, EndUser user)
     {
-        var value = segmentCondition.GetProperty("value").GetString()!;
+        var reader = EntityJsonReader.FeatureFlag;
 
-        var segmentIds = JsonSerializer.Deserialize<string[]>(value);
-        if (segmentIds == null || !segmentIds.Any())
+        var value = reader.GetRequiredString(segmentCondition, "value");
+
+        var segmentIds = reader.DeserializeStringArray(value, "value");
+        if (segmentIds.Length == 0)
         {
             return false;
         }
 
         foreach (var segmentId in segmentIds)
         {
-            var segment = await _store.GetSegmentAsync(segmentId);
-            if (IsMatchSegment(segment, user))
+            var segment = await store.GetSegmentAsync(segmentId);
+            if (IsMatchSegment(segmentId, segment, user))
             {
                 return true;
             }
@@ -68,30 +65,36 @@ public class RuleMatcher : IRuleMatcher
         return false;
     }
 
-    private static bool IsMatchSegment(byte[] segment, EndUser user)
+    private static bool IsMatchSegment(string segmentId, byte[] segment, EndUser user)
     {
-        using var document = JsonDocument.Parse(segment);
+        var reader = EntityJsonReader.ForSegment(segmentId);
+
+        using var document = reader.Parse(segment);
         var root = document.RootElement;
 
-        var excludes = root.GetProperty("excluded").EnumerateArray();
-        foreach (var exclude in excludes)
+        var excludes = reader.GetRequiredArray(root, "excluded").EnumerateArray();
+        var excludeIndex = 0;
+        foreach (var excludeElement in excludes)
         {
-            if (exclude.GetString() == user.KeyId)
+            var exclude = reader.GetRequiredStringValue(excludeElement, $"excluded[{excludeIndex++}]");
+            if (exclude == user.KeyId)
             {
                 return false;
             }
         }
 
-        var includes = root.GetProperty("included").EnumerateArray();
-        foreach (var include in includes)
+        var includes = reader.GetRequiredArray(root, "included").EnumerateArray();
+        var includeIndex = 0;
+        foreach (var includeElement in includes)
         {
-            if (include.GetString() == user.KeyId)
+            var include = reader.GetRequiredStringValue(includeElement, $"included[{includeIndex++}]");
+            if (include == user.KeyId)
             {
                 return true;
             }
         }
 
-        var rules = root.GetProperty("rules").EnumerateArray();
+        var rules = reader.GetRequiredArray(root, "rules").EnumerateArray();
         foreach (var rule in rules)
         {
             if (IsMatchRule(rule, user))
@@ -104,10 +107,10 @@ public class RuleMatcher : IRuleMatcher
 
         bool IsMatchRule(JsonElement segmentMatchRule, EndUser endUser)
         {
-            var conditions = segmentMatchRule.GetProperty("conditions").EnumerateArray();
+            var conditions = reader.GetRequiredArray(segmentMatchRule, "conditions").EnumerateArray();
             foreach (var condition in conditions)
             {
-                if (!IsMatchCondition(condition, endUser))
+                if (!IsMatchCondition(condition, endUser, reader))
                 {
                     return false;
                 }
@@ -117,15 +120,25 @@ public class RuleMatcher : IRuleMatcher
         }
     }
 
-    private static bool IsMatchCondition(JsonElement condition, EndUser user)
+    private static bool IsMatchCondition(JsonElement condition, EndUser user, EntityJsonReader reader)
     {
-        var property = condition.GetProperty("property").GetString()!;
-        var op = condition.GetProperty("op").GetString()!;
-        var conditionValue = condition.GetProperty("value").GetString()!;
+        var property = reader.GetRequiredString(condition, "property");
+        var op = reader.GetRequiredString(condition, "op");
+        var conditionValue = reader.GetRequiredString(condition, "value");
 
-        var userValue = user.ValueOf(property);
+        try
+        {
+            var userValue = user.ValueOf(property);
 
-        var theOperator = Operator.Get(op);
-        return theOperator.IsMatch(userValue, conditionValue);
+            var theOperator = Operator.Get(op);
+            return theOperator.IsMatch(userValue, conditionValue);
+        }
+        // Some operators parse the string value again using their own format. IsOneOf/NotOneOf can throw
+        // JsonException for an invalid encoded string array, while regex operators can throw ArgumentException
+        // for an invalid pattern. Treat both as malformed evaluation data for the current flag or segment.
+        catch (Exception ex) when (ex is JsonException or ArgumentException)
+        {
+            throw reader.Malformed("Rule condition contains an invalid value", "conditions", ex);
+        }
     }
 }

--- a/modules/evaluation-server/src/Domain/Evaluation/RuleMatcher.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/RuleMatcher.cs
@@ -47,7 +47,7 @@ public class RuleMatcher(IStore store) : IRuleMatcher
 
         var value = reader.GetRequiredString(segmentCondition, "value");
 
-        var segmentIds = reader.DeserializeStringArray(value, "value");
+        var segmentIds = reader.DeserializeSegmentIds(value, "value");
         if (segmentIds.Length == 0)
         {
             return false;

--- a/modules/evaluation-server/src/Domain/Evaluation/UserVariation.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/UserVariation.cs
@@ -66,15 +66,28 @@ public sealed class RolloutUserVariation : UserVariation
         var dispatchRollout = 0.0;
         var exptRollout = 0.0;
 
+        var reader = EntityJsonReader.FeatureFlag;
         foreach (var rolloutVariation in rolloutVariations.EnumerateArray())
         {
-            var rollouts = rolloutVariation.GetProperty("rollout").Deserialize<double[]>()!;
+            var rollouts = reader.DeserializeRequiredArray<double>(rolloutVariation, "rollout");
+            if (rollouts.Length != 2)
+            {
+                throw reader.Malformed(
+                    "Property 'rollout' must contain exactly two numbers",
+                    "rollout"
+                );
+            }
+
             if (DispatchAlgorithm.IsInRollout(dispatchKey, rollouts))
             {
-                var variationId = rolloutVariation.GetProperty("id").GetString()!;
-                Variation = allVariations.FirstOrDefault(x => x.Id == variationId)!;
+                var variationId = reader.GetRequiredString(rolloutVariation, "id");
+                Variation = allVariations.FirstOrDefault(x => x.Id == variationId) ??
+                            throw reader.Malformed(
+                                $"Rollout references variation '{variationId}' which does not exist in the feature flag",
+                                "id"
+                            );
                 dispatchRollout = rollouts[1] - rollouts[0];
-                exptRollout = rolloutVariation.GetProperty("exptRollout").GetDouble();
+                exptRollout = reader.GetRequiredDouble(rolloutVariation, "exptRollout");
                 break;
             }
         }

--- a/modules/evaluation-server/src/Streaming/Protocol/ClientSdkPayload.cs
+++ b/modules/evaluation-server/src/Streaming/Protocol/ClientSdkPayload.cs
@@ -47,10 +47,12 @@ public class ClientSdkFlag
 
     public ClientSdkFlag(JsonElement flag, UserVariation userVariation, Variation[] allVariations)
     {
-        Id = flag.GetProperty("key").GetString()!;
-        VariationType = flag.GetProperty("variationType").GetString() ?? "string";
+        var reader = EntityJsonReader.FeatureFlag;
+
+        Id = reader.GetRequiredString(flag, "key");
+        VariationType = reader.GetNullableString(flag, "variationType") ?? "string";
         VariationOptions = allVariations;
-        Timestamp = flag.GetProperty("updatedAt").GetDateTimeOffset().ToUnixTimeMilliseconds();
+        Timestamp = reader.GetRequiredDateTimeOffset(flag, "updatedAt").ToUnixTimeMilliseconds();
 
         Variation = userVariation.Variation?.Value;
         VariationId = userVariation.Variation?.Id;

--- a/modules/evaluation-server/src/Streaming/Services/DataSyncService.cs
+++ b/modules/evaluation-server/src/Streaming/Services/DataSyncService.cs
@@ -246,9 +246,6 @@ public class DataSyncService(
 
     private async Task<ClientSdkFlag?> TryEvaluateFlagAsync(JsonElement flag, EndUser user, Guid envId)
     {
-        var flagId = EntityJsonReader.TryGetString(flag, "id");
-        var flagKey = EntityJsonReader.TryGetString(flag, "key");
-
         try
         {
             var variations =
@@ -261,7 +258,12 @@ public class DataSyncService(
         }
         catch (MalformedDataException ex)
         {
-            LogEvaluationFailure(ex, envId, flagId, flagKey);
+            LogEvaluationFailure(
+                ex,
+                envId,
+                EntityJsonReader.TryGetString(flag, "id"),
+                EntityJsonReader.TryGetString(flag, "key")
+            );
 
             return null;
         }

--- a/modules/evaluation-server/src/Streaming/Services/DataSyncService.cs
+++ b/modules/evaluation-server/src/Streaming/Services/DataSyncService.cs
@@ -285,7 +285,7 @@ public class DataSyncService(
             flagId,
             envId,
             entityType,
-            exception.EntityId,
+            exception.EntityId ?? flagId,
             exception.PropertyPath
         );
     }

--- a/modules/evaluation-server/src/Streaming/Services/DataSyncService.cs
+++ b/modules/evaluation-server/src/Streaming/Services/DataSyncService.cs
@@ -3,12 +3,17 @@ using System.Text.Json.Nodes;
 using Domain.EndUsers;
 using Domain.Evaluation;
 using Domain.Shared;
+using Microsoft.Extensions.Logging;
 using Streaming.Connections;
 using Streaming.Protocol;
 
 namespace Streaming.Services;
 
-public class DataSyncService(IStore store, IEvaluator evaluator, IRelayProxyService rpService) : IDataSyncService
+public class DataSyncService(
+    IStore store,
+    IEvaluator evaluator,
+    IRelayProxyService rpService,
+    ILogger<DataSyncService> logger) : IDataSyncService
 {
     private const long FullSyncTimestamp = 0;
 
@@ -43,16 +48,8 @@ public class DataSyncService(IStore store, IEvaluator evaluator, IRelayProxyServ
     public async Task<ClientSdkPayload> GetClientSdkPayloadAsync(Guid envId, EndUser user, long timestamp)
     {
         var eventType = timestamp == FullSyncTimestamp ? DataSyncEventTypes.Full : DataSyncEventTypes.Patch;
-        var flagsBytes = await store.GetFlagsAsync(envId, timestamp);
-
-        var clientSdkFlags = new List<ClientSdkFlag>();
-        foreach (var flagBytes in flagsBytes)
-        {
-            using var document = JsonDocument.Parse(flagBytes);
-            var flag = document.RootElement;
-
-            clientSdkFlags.Add(await GetClientSdkFlagAsync(flag, user));
-        }
+        var flags = await store.GetFlagsAsync(envId, timestamp);
+        var clientSdkFlags = await EvaluateFlagsAsync(flags, user, envId);
 
         return new ClientSdkPayload(eventType, user.KeyId, clientSdkFlags);
     }
@@ -162,7 +159,7 @@ public class DataSyncService(IStore store, IEvaluator evaluator, IRelayProxyServ
 
         object payload = connection.Type switch
         {
-            ConnectionType.Client => await GetClientSdkFlagChangePayloadAsync(flag, connection.User!),
+            ConnectionType.Client => await GetClientSdkFlagChangePayloadAsync(flag, connection.User!, connection.EnvId),
             ConnectionType.Server => GetServerSdkFlagChangePayload(flag),
             _ => throw new ArgumentOutOfRangeException(
                 nameof(connection), $"unsupported sdk type {connection.Type}"
@@ -184,7 +181,11 @@ public class DataSyncService(IStore store, IEvaluator evaluator, IRelayProxyServ
 
         object payload = connection.Type switch
         {
-            ConnectionType.Client => await GetClientSegmentChangePayloadAsync(affectedFlagIds, connection.User!),
+            ConnectionType.Client => await GetClientSegmentChangePayloadAsync(
+                affectedFlagIds,
+                connection.User!,
+                connection.EnvId
+            ),
             ConnectionType.Server => GetServerSdkSegmentChangePayload(segment),
             _ => throw new ArgumentOutOfRangeException(
                 nameof(connection), $"unsupported sdk type {connection.Type}"
@@ -196,38 +197,97 @@ public class DataSyncService(IStore store, IEvaluator evaluator, IRelayProxyServ
 
     #region get client sdk payload
 
-    private async Task<ClientSdkPayload> GetClientSdkFlagChangePayloadAsync(JsonElement flag, EndUser user)
+    private async Task<ClientSdkPayload> GetClientSdkFlagChangePayloadAsync(JsonElement flag, EndUser user, Guid envId)
     {
+        var clientSdkFlag = await TryEvaluateFlagAsync(flag, user, envId);
+
         return new ClientSdkPayload(
             DataSyncEventTypes.Patch,
             user.KeyId,
-            [await GetClientSdkFlagAsync(flag, user)]
+            clientSdkFlag == null ? [] : [clientSdkFlag]
         );
     }
 
-    private async Task<ClientSdkPayload> GetClientSegmentChangePayloadAsync(string[] affectedFlagIds, EndUser user)
+    private async Task<ClientSdkPayload> GetClientSegmentChangePayloadAsync(
+        string[] affectedFlagIds,
+        EndUser user,
+        Guid envId)
     {
-        var clientSdkFlags = new List<ClientSdkFlag>();
-
         var flags = await store.GetFlagsAsync(affectedFlagIds);
-        foreach (var flag in flags)
-        {
-            using var document = JsonDocument.Parse(flag);
-            clientSdkFlags.Add(await GetClientSdkFlagAsync(document.RootElement, user));
-        }
+        var clientSdkFlags = await EvaluateFlagsAsync(flags, user, envId);
 
         return new ClientSdkPayload(DataSyncEventTypes.Patch, user.KeyId, clientSdkFlags);
     }
 
-    private async Task<ClientSdkFlag> GetClientSdkFlagAsync(JsonElement flag, EndUser user)
+    private async Task<List<ClientSdkFlag>> EvaluateFlagsAsync(IEnumerable<byte[]> flags, EndUser user, Guid envId)
     {
-        var variations =
-            flag.GetProperty("variations").Deserialize<Variation[]>(ReusableJsonSerializerOptions.Web)!;
+        var result = new List<ClientSdkFlag>();
 
-        var scope = new EvaluationScope(flag, user, variations);
-        var userVariation = await evaluator.EvaluateAsync(scope);
+        foreach (var flagBytes in flags)
+        {
+            try
+            {
+                using var json = EntityJsonReader.FeatureFlag.Parse(flagBytes);
 
-        return new ClientSdkFlag(flag, userVariation, variations);
+                var flag = await TryEvaluateFlagAsync(json.RootElement, user, envId);
+                if (flag != null)
+                {
+                    result.Add(flag);
+                }
+            }
+            catch (MalformedDataException ex)
+            {
+                LogEvaluationFailure(ex, envId, flagId: null, flagKey: null);
+            }
+        }
+
+        return result;
+    }
+
+    private async Task<ClientSdkFlag?> TryEvaluateFlagAsync(JsonElement flag, EndUser user, Guid envId)
+    {
+        var flagId = EntityJsonReader.TryGetString(flag, "id");
+        var flagKey = EntityJsonReader.TryGetString(flag, "key");
+
+        try
+        {
+            var variations =
+                EntityJsonReader.FeatureFlag.DeserializeRequiredArray<Variation>(flag, "variations");
+
+            var scope = new EvaluationScope(flag, user, variations);
+            var userVariation = await evaluator.EvaluateAsync(scope);
+
+            return new ClientSdkFlag(flag, userVariation, variations);
+        }
+        catch (MalformedDataException ex)
+        {
+            LogEvaluationFailure(ex, envId, flagId, flagKey);
+
+            return null;
+        }
+    }
+
+    private void LogEvaluationFailure(MalformedDataException exception, Guid envId, string? flagId, string? flagKey)
+    {
+        var entityType = exception.EntityType switch
+        {
+            EvaluationEntityType.FeatureFlag => "feature-flag",
+            EvaluationEntityType.Segment => "segment",
+            _ => "unknown"
+        };
+
+        logger.LogError(
+            exception,
+            "Failed to evaluate feature flag {FlagKey} ({FlagId}) in environment {EnvId}. " +
+            "Malformed entity: {EntityType} ({EntityId}), property: {PropertyPath}. " +
+            "The malformed feature flag was skipped without failing the client data-sync.",
+            flagKey,
+            flagId,
+            envId,
+            entityType,
+            exception.EntityId,
+            exception.PropertyPath
+        );
     }
 
     #endregion

--- a/modules/evaluation-server/tests/Domain.UnitTests/Evaluation/EntityJsonReaderTests.cs
+++ b/modules/evaluation-server/tests/Domain.UnitTests/Evaluation/EntityJsonReaderTests.cs
@@ -126,11 +126,14 @@ public class EntityJsonReaderTests
         Assert.Equal("variations", exception.PropertyPath);
     }
 
-    [Fact]
-    public void DeserializeSegmentIds_InvalidGuid_ThrowsWithPropertyPath()
+    [Theory]
+    [InlineData("not-a-guid")]
+    [InlineData("(0779d76b-afc6-4886-ab65-af8c004273ad)")]
+    [InlineData(" 0779d76b-afc6-4886-ab65-af8c004273ad")]
+    public void DeserializeSegmentIds_NonCanonicalGuid_ThrowsWithPropertyPath(string segmentId)
     {
         var exception = Assert.Throws<MalformedDataException>(
-            () => EntityJsonReader.FeatureFlag.DeserializeSegmentIds("[\"not-a-guid\"]", "value")
+            () => EntityJsonReader.FeatureFlag.DeserializeSegmentIds($"[\"{segmentId}\"]", "value")
         );
 
         Assert.Equal(EvaluationEntityType.FeatureFlag, exception.EntityType);

--- a/modules/evaluation-server/tests/Domain.UnitTests/Evaluation/EntityJsonReaderTests.cs
+++ b/modules/evaluation-server/tests/Domain.UnitTests/Evaluation/EntityJsonReaderTests.cs
@@ -1,0 +1,117 @@
+using System.Text;
+using System.Text.Json;
+using Domain.Evaluation;
+
+namespace Domain.UnitTests.Evaluation;
+
+public class EntityJsonReaderTests
+{
+    private const string SegmentId = "0779d76b-afc6-4886-ab65-af8c004273ad";
+
+    [Fact]
+    public void TryGetString_StringProperty_ReturnsValue()
+    {
+        var json = Parse("""{"key":"flag-key"}""");
+
+        var value = EntityJsonReader.TryGetString(json, "key");
+
+        Assert.Equal("flag-key", value);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"key\":null}")]
+    [InlineData("{\"key\":1}")]
+    [InlineData("[]")]
+    public void TryGetString_PropertyCannotBeRead_ReturnsNull(string jsonText)
+    {
+        var json = Parse(jsonText);
+
+        var value = EntityJsonReader.TryGetString(json, "key");
+
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void GetNullableString_NullValue_ReturnsNull()
+    {
+        var json = Parse("""{"dispatchKey":null}""");
+
+        var value = EntityJsonReader.FeatureFlag.GetNullableString(json, "dispatchKey");
+
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void GetRequiredString_MissingFlagProperty_ThrowsWithFlagContext()
+    {
+        var json = Parse("{}");
+
+        var exception = Assert.Throws<MalformedDataException>(
+            () => EntityJsonReader.FeatureFlag.GetRequiredString(json, "key")
+        );
+
+        Assert.Equal(EvaluationEntityType.FeatureFlag, exception.EntityType);
+        Assert.Null(exception.EntityId);
+        Assert.Equal("key", exception.PropertyPath);
+    }
+
+    [Fact]
+    public void Parse_InvalidSegmentJson_ThrowsWithSegmentContextAndOriginalError()
+    {
+        var reader = EntityJsonReader.ForSegment(SegmentId);
+        var bytes = Encoding.UTF8.GetBytes("{");
+
+        var exception = Assert.Throws<MalformedDataException>(() => reader.Parse(bytes));
+
+        Assert.Equal(EvaluationEntityType.Segment, exception.EntityType);
+        Assert.Equal(SegmentId, exception.EntityId);
+        Assert.IsAssignableFrom<JsonException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void Parse_InvalidFlagJson_ThrowsWithFlagContext()
+    {
+        var bytes = Encoding.UTF8.GetBytes("{");
+
+        var exception = Assert.Throws<MalformedDataException>(
+            () => EntityJsonReader.FeatureFlag.Parse(bytes)
+        );
+
+        Assert.Equal(EvaluationEntityType.FeatureFlag, exception.EntityType);
+        Assert.Null(exception.EntityId);
+        Assert.IsAssignableFrom<JsonException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void GetRequiredArray_WrongSegmentPropertyType_ThrowsWithPropertyPath()
+    {
+        var reader = EntityJsonReader.ForSegment(SegmentId);
+        var json = Parse("""{"rules":{}}""");
+
+        var exception = Assert.Throws<MalformedDataException>(
+            () => reader.GetRequiredArray(json, "rules")
+        );
+
+        Assert.Equal(EvaluationEntityType.Segment, exception.EntityType);
+        Assert.Equal(SegmentId, exception.EntityId);
+        Assert.Equal("rules", exception.PropertyPath);
+    }
+
+    [Fact]
+    public void GetRequiredStringValue_NumberInSegment_ThrowsWithElementPath()
+    {
+        var reader = EntityJsonReader.ForSegment(SegmentId);
+        var json = Parse("1");
+
+        var exception = Assert.Throws<MalformedDataException>(
+            () => reader.GetRequiredStringValue(json, "included[0]")
+        );
+
+        Assert.Equal(EvaluationEntityType.Segment, exception.EntityType);
+        Assert.Equal(SegmentId, exception.EntityId);
+        Assert.Equal("included[0]", exception.PropertyPath);
+    }
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement.Clone();
+}

--- a/modules/evaluation-server/tests/Domain.UnitTests/Evaluation/EntityJsonReaderTests.cs
+++ b/modules/evaluation-server/tests/Domain.UnitTests/Evaluation/EntityJsonReaderTests.cs
@@ -113,5 +113,29 @@ public class EntityJsonReaderTests
         Assert.Equal("included[0]", exception.PropertyPath);
     }
 
+    [Fact]
+    public void DeserializeRequiredArray_NullElement_ThrowsWithPropertyPath()
+    {
+        var json = Parse("""{"variations":[null]}""");
+
+        var exception = Assert.Throws<MalformedDataException>(
+            () => EntityJsonReader.FeatureFlag.DeserializeRequiredArray<Variation>(json, "variations")
+        );
+
+        Assert.Equal(EvaluationEntityType.FeatureFlag, exception.EntityType);
+        Assert.Equal("variations", exception.PropertyPath);
+    }
+
+    [Fact]
+    public void DeserializeSegmentIds_InvalidGuid_ThrowsWithPropertyPath()
+    {
+        var exception = Assert.Throws<MalformedDataException>(
+            () => EntityJsonReader.FeatureFlag.DeserializeSegmentIds("[\"not-a-guid\"]", "value")
+        );
+
+        Assert.Equal(EvaluationEntityType.FeatureFlag, exception.EntityType);
+        Assert.Equal("value", exception.PropertyPath);
+    }
+
     private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement.Clone();
 }

--- a/modules/evaluation-server/tests/Streaming.UnitTests/Services/DataSyncServiceTests.cs
+++ b/modules/evaluation-server/tests/Streaming.UnitTests/Services/DataSyncServiceTests.cs
@@ -199,6 +199,52 @@ public class DataSyncServiceTests
     }
 
     [Fact]
+    public async Task GetClientSdkPayloadAsync_InvalidSegmentId_SkipsDependentFlagWithoutCallingStore()
+    {
+        const string invalidSegmentId = "not-a-guid";
+        var store = new Mock<IStore>();
+        store.Setup(s => s.GetFlagsAsync(EnvId, 0L)).ReturnsAsync(
+            new[]
+            {
+                EvaluableFlagBytes("broken-key", invalidSegmentId, isEnabled: true),
+                EvaluableFlagBytes("healthy-key", segmentId: null, isEnabled: false)
+            }
+        );
+        var logger = new FakeLogger<DataSyncService>();
+        var service = new DataSyncService(
+            store.Object,
+            new Evaluator(new RuleMatcher(store.Object)),
+            _rpService.Object,
+            logger
+        );
+
+        var payload = await service.GetClientSdkPayloadAsync(EnvId, NewUser(), timestamp: 0);
+
+        var flag = Assert.Single(payload.FeatureFlags);
+        Assert.Equal("healthy-key", flag.Id);
+        store.Verify(s => s.GetSegmentAsync(It.IsAny<string>()), Times.Never);
+        var record = Assert.Single(logger.Collector.GetSnapshot());
+        var exception = Assert.IsType<MalformedDataException>(record.Exception);
+        Assert.Equal(EvaluationEntityType.FeatureFlag, exception.EntityType);
+        Assert.Equal("value", exception.PropertyPath);
+    }
+
+    [Fact]
+    public async Task GetClientSdkPayloadAsync_NullVariation_SkipsItAndReturnsOtherFlags()
+    {
+        _store.Setup(s => s.GetFlagsAsync(EnvId, 0L)).ReturnsAsync(
+            new[] { FlagWithNullVariationBytes(), FlagBytes("healthy", "healthy-key") }
+        );
+        _evaluator.Setup(x => x.EvaluateAsync(It.IsAny<EvaluationScope>()))
+            .ReturnsAsync(NullUserVariation.Instance);
+
+        var payload = await _service.GetClientSdkPayloadAsync(EnvId, NewUser(), timestamp: 0);
+
+        var flag = Assert.Single(payload.FeatureFlags);
+        Assert.Equal("healthy-key", flag.Id);
+    }
+
+    [Fact]
     public async Task GetClientSegmentChangePayloadAsync_OneFlagCannotBeEvaluated_SkipsItAndReturnsOtherFlags()
     {
         _store.Setup(s => s.GetFlagsAsync(new[] { "broken", "healthy" })).ReturnsAsync(
@@ -292,6 +338,18 @@ public class DataSyncServiceTests
             "envId":"{{EnvId}}",
             "variations":[],
             "variationType":"string",
+            "updatedAt":"2026-08-29T00:00:00Z"
+          }
+          """);
+
+    private static byte[] FlagWithNullVariationBytes() =>
+        Encoding.UTF8.GetBytes($$"""
+          {
+            "id":"4abf8ca8-7dc8-41d9-83ab-73a6d194e926",
+            "key":"broken-key",
+            "envId":"{{EnvId}}",
+            "variations":[null],
+            "variationType":"boolean",
             "updatedAt":"2026-08-29T00:00:00Z"
           }
           """);

--- a/modules/evaluation-server/tests/Streaming.UnitTests/Services/DataSyncServiceTests.cs
+++ b/modules/evaluation-server/tests/Streaming.UnitTests/Services/DataSyncServiceTests.cs
@@ -1,6 +1,10 @@
 using System.Text.Json;
+using System.Text;
+using Domain.EndUsers;
 using Domain.Evaluation;
 using Domain.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using Moq;
 using Streaming.Connections;
 using Streaming.Protocol;
@@ -19,7 +23,12 @@ public class DataSyncServiceTests
 
     public DataSyncServiceTests()
     {
-        _service = new DataSyncService(_store.Object, _evaluator.Object, _rpService.Object);
+        _service = new DataSyncService(
+            _store.Object,
+            _evaluator.Object,
+            _rpService.Object,
+            NullLogger<DataSyncService>.Instance
+        );
     }
 
     [Fact]
@@ -120,9 +129,232 @@ public class DataSyncServiceTests
         Assert.Empty(payload.Segments);
     }
 
+    [Fact]
+    public async Task GetClientSdkPayloadAsync_OneFlagCannotBeEvaluated_SkipsItAndReturnsOtherFlags()
+    {
+        _store.Setup(s => s.GetFlagsAsync(EnvId, 0L)).ReturnsAsync(
+            new[] { FlagBytes("broken", "broken-key"), FlagBytes("healthy", "healthy-key") }
+        );
+        _evaluator.SetupSequence(x => x.EvaluateAsync(It.IsAny<EvaluationScope>()))
+            .ThrowsAsync(EntityJsonReader.FeatureFlag.Malformed("invalid segment condition"))
+            .ReturnsAsync(NullUserVariation.Instance);
+
+        var payload = await _service.GetClientSdkPayloadAsync(EnvId, NewUser(), timestamp: 0);
+
+        Assert.Equal(DataSyncEventTypes.Full, payload.EventType);
+        var flag = Assert.Single(payload.FeatureFlags);
+        Assert.Equal("healthy-key", flag.Id);
+    }
+
+    [Fact]
+    public async Task GetClientSdkPayloadAsync_MalformedFlagJson_SkipsItAndReturnsOtherFlags()
+    {
+        var logger = new FakeLogger<DataSyncService>();
+        var service = new DataSyncService(_store.Object, _evaluator.Object, _rpService.Object, logger);
+        _store.Setup(s => s.GetFlagsAsync(EnvId, 0L)).ReturnsAsync(
+            new[] { "{"u8.ToArray(), FlagBytes("healthy", "healthy-key") }
+        );
+        _evaluator.Setup(x => x.EvaluateAsync(It.IsAny<EvaluationScope>()))
+            .ReturnsAsync(NullUserVariation.Instance);
+
+        var payload = await service.GetClientSdkPayloadAsync(EnvId, NewUser(), timestamp: 0);
+
+        var flag = Assert.Single(payload.FeatureFlags);
+        Assert.Equal("healthy-key", flag.Id);
+        var record = Assert.Single(logger.Collector.GetSnapshot());
+        var exception = Assert.IsType<MalformedDataException>(record.Exception);
+        Assert.Equal(EvaluationEntityType.FeatureFlag, exception.EntityType);
+    }
+
+    [Fact]
+    public async Task GetClientSdkPayloadAsync_SegmentContainsNonStringListValue_SkipsDependentFlag()
+    {
+        const string segmentId = "0779d76b-afc6-4886-ab65-af8c004273ad";
+        var store = new Mock<IStore>();
+        store.Setup(s => s.GetFlagsAsync(EnvId, 0L)).ReturnsAsync(
+            new[]
+            {
+                EvaluableFlagBytes("broken-key", segmentId, isEnabled: true),
+                EvaluableFlagBytes("healthy-key", segmentId: null, isEnabled: false)
+            }
+        );
+        store.Setup(s => s.GetSegmentAsync(segmentId)).ReturnsAsync(BrokenSegmentBytes(segmentId));
+        var evaluator = new Evaluator(new RuleMatcher(store.Object));
+        var logger = new FakeLogger<DataSyncService>();
+        var service = new DataSyncService(
+            store.Object,
+            evaluator,
+            _rpService.Object,
+            logger
+        );
+
+        var payload = await service.GetClientSdkPayloadAsync(EnvId, NewUser(), timestamp: 0);
+
+        var flag = Assert.Single(payload.FeatureFlags);
+        Assert.Equal("healthy-key", flag.Id);
+        var record = Assert.Single(logger.Collector.GetSnapshot());
+        var exception = Assert.IsType<MalformedDataException>(record.Exception);
+        Assert.Equal(EvaluationEntityType.Segment, exception.EntityType);
+        Assert.Equal(segmentId, exception.EntityId);
+    }
+
+    [Fact]
+    public async Task GetClientSegmentChangePayloadAsync_OneFlagCannotBeEvaluated_SkipsItAndReturnsOtherFlags()
+    {
+        _store.Setup(s => s.GetFlagsAsync(new[] { "broken", "healthy" })).ReturnsAsync(
+            new[] { FlagBytes("broken", "broken-key"), FlagBytes("healthy", "healthy-key") }
+        );
+        _evaluator.SetupSequence(x => x.EvaluateAsync(It.IsAny<EvaluationScope>()))
+            .ThrowsAsync(EntityJsonReader.FeatureFlag.Malformed("invalid segment condition"))
+            .ReturnsAsync(NullUserVariation.Instance);
+        var connection = NewConnection(SecretTypes.Client);
+        connection.AttachUser(NewUser());
+
+        var payload = await _service.GetSegmentChangePayloadAsync(
+            connection,
+            ParseJson($$"""{"envId":"{{EnvId}}"}"""),
+            ["broken", "healthy"]
+        );
+
+        var clientPayload = Assert.IsType<ClientSdkPayload>(payload);
+        Assert.Equal(DataSyncEventTypes.Patch, clientPayload.EventType);
+        var flag = Assert.Single(clientPayload.FeatureFlags);
+        Assert.Equal("healthy-key", flag.Id);
+    }
+
+    [Fact]
+    public async Task GetFlagChangePayloadAsync_FlagCannotBeEvaluated_ReturnsEmptyPatch()
+    {
+        _evaluator.Setup(x => x.EvaluateAsync(It.IsAny<EvaluationScope>()))
+            .ThrowsAsync(EntityJsonReader.FeatureFlag.Malformed("invalid flag condition"));
+        var connection = NewConnection(SecretTypes.Client);
+        connection.AttachUser(NewUser());
+        var flag = ParseJson(Encoding.UTF8.GetString(FlagBytes("broken", "broken-key")));
+
+        var payload = await _service.GetFlagChangePayloadAsync(connection, flag);
+
+        var clientPayload = Assert.IsType<ClientSdkPayload>(payload);
+        Assert.Equal(DataSyncEventTypes.Patch, clientPayload.EventType);
+        Assert.Empty(clientPayload.FeatureFlags);
+    }
+
+    [Fact]
+    public async Task GetClientSdkPayloadAsync_InfrastructureFailure_Propagates()
+    {
+        _store.Setup(s => s.GetFlagsAsync(EnvId, 0L)).ReturnsAsync(
+            new[] { FlagBytes("flag", "flag-key") }
+        );
+        _evaluator.Setup(x => x.EvaluateAsync(It.IsAny<EvaluationScope>()))
+            .ThrowsAsync(new TimeoutException("store unavailable"));
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => _service.GetClientSdkPayloadAsync(EnvId, NewUser(), timestamp: 0)
+        );
+    }
+
+    [Fact]
+    public async Task GetClientSdkPayloadAsync_SegmentStoreFailure_PropagatesWithoutBeingWrapped()
+    {
+        const string segmentId = "0779d76b-afc6-4886-ab65-af8c004273ad";
+        var store = new Mock<IStore>();
+        store.Setup(s => s.GetFlagsAsync(EnvId, 0L)).ReturnsAsync(
+            new[] { EvaluableFlagBytes("flag-key", segmentId, isEnabled: true) }
+        );
+        store.Setup(s => s.GetSegmentAsync(segmentId))
+            .ThrowsAsync(new InvalidOperationException("store unavailable"));
+        var service = new DataSyncService(
+            store.Object,
+            new Evaluator(new RuleMatcher(store.Object)),
+            _rpService.Object,
+            NullLogger<DataSyncService>.Instance
+        );
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.GetClientSdkPayloadAsync(EnvId, NewUser(), timestamp: 0)
+        );
+
+        Assert.Equal("store unavailable", exception.Message);
+    }
+
     private static Connection NewConnection(string type) =>
         new(Mock.Of<System.Net.WebSockets.WebSocket>(), new Secret(type, "p", EnvId, "dev"));
 
     private static JsonElement ParseJson(string json) =>
         JsonDocument.Parse(json).RootElement.Clone();
+
+    private static EndUser NewUser() => new() { KeyId = "user-key", Name = "user-name" };
+
+    private static byte[] FlagBytes(string id, string key) =>
+        Encoding.UTF8.GetBytes($$"""
+          {
+            "id":"{{id}}",
+            "key":"{{key}}",
+            "envId":"{{EnvId}}",
+            "variations":[],
+            "variationType":"string",
+            "updatedAt":"2026-08-29T00:00:00Z"
+          }
+          """);
+
+    private static byte[] EvaluableFlagBytes(string key, string? segmentId, bool isEnabled)
+    {
+        const string variationId = "d3e3b90b-9a63-4493-8e2f-25b145e8199d";
+        var rules = segmentId == null
+            ? "[]"
+            : $$"""
+              [{
+                "name":"segment rule",
+                "dispatchKey":null,
+                "includedInExpt":false,
+                "conditions":[{
+                  "property":"User is in segment",
+                  "op":null,
+                  "value":"[\"{{segmentId}}\"]"
+                }],
+                "variations":[{
+                  "id":"{{variationId}}",
+                  "rollout":[0,1],
+                  "exptRollout":1
+                }]
+              }]
+              """;
+
+        return Encoding.UTF8.GetBytes($$"""
+          {
+            "id":"{{Guid.NewGuid()}}",
+            "key":"{{key}}",
+            "envId":"{{EnvId}}",
+            "variations":[{"id":"{{variationId}}","value":"true"}],
+            "variationType":"boolean",
+            "updatedAt":"2026-08-29T00:00:00Z",
+            "isArchived":false,
+            "isEnabled":{{isEnabled.ToString().ToLowerInvariant()}},
+            "disabledVariationId":"{{variationId}}",
+            "exptIncludeAllTargets":false,
+            "targetUsers":[],
+            "rules":{{rules}},
+            "fallthrough":{
+              "dispatchKey":null,
+              "includedInExpt":false,
+              "variations":[{"id":"{{variationId}}","rollout":[0,1],"exptRollout":1}]
+            }
+          }
+          """);
+    }
+
+    private static byte[] BrokenSegmentBytes(string segmentId) =>
+        Encoding.UTF8.GetBytes($$"""
+          {
+            "id":"{{segmentId}}",
+            "included":[],
+            "excluded":[],
+            "rules":[{
+              "conditions":[{
+                "property":"companyId",
+                "op":"IsOneOf",
+                "value":"[1,\"company-2\"]"
+              }]
+            }]
+          }
+          """);
 }

--- a/modules/evaluation-server/tests/Streaming.UnitTests/Services/DataSyncServiceTests.cs
+++ b/modules/evaluation-server/tests/Streaming.UnitTests/Services/DataSyncServiceTests.cs
@@ -198,15 +198,16 @@ public class DataSyncServiceTests
         Assert.Equal(segmentId, exception.EntityId);
     }
 
-    [Fact]
-    public async Task GetClientSdkPayloadAsync_InvalidSegmentId_SkipsDependentFlagWithoutCallingStore()
+    [Theory]
+    [InlineData("(0779d76b-afc6-4886-ab65-af8c004273ad)")]
+    [InlineData("not-a-guid")]
+    public async Task GetClientSdkPayloadAsync_NonCanonicalSegmentId_SkipsDependentFlagWithoutCallingStore(string segmentId)
     {
-        const string invalidSegmentId = "not-a-guid";
         var store = new Mock<IStore>();
         store.Setup(s => s.GetFlagsAsync(EnvId, 0L)).ReturnsAsync(
             new[]
             {
-                EvaluableFlagBytes("broken-key", invalidSegmentId, isEnabled: true),
+                EvaluableFlagBytes("broken-key", segmentId, isEnabled: true),
                 EvaluableFlagBytes("healthy-key", segmentId: null, isEnabled: false)
             }
         );


### PR DESCRIPTION
## Problem

A malformed feature flag or segment could cause evaluation to throw and fail the entire client data-sync for an environment.

As a result, all client SDKs connected to that environment could receive no flags and fall back to their default values, even when only one flag or segment contained invalid data.

## Solution

- Introduce `EntityJsonReader` to consistently validate feature flag and segment JSON during evaluation.
- Wrap malformed evaluation data in `MalformedDataException` with entity type, entity ID, and property path context.
- Isolate malformed data errors at the individual feature flag boundary.
- Skip and log only the affected flag while continuing to evaluate and return the remaining flags.
- Apply the isolation behavior to:
  - Full and patch client data-sync
  - Feature flag change events
  - Segment change events
- Keep infrastructure and store failures propagating instead of treating them as malformed evaluation data.
- Add structured logs identifying the environment, feature flag, malformed entity, and property path.

## Behavior

When a feature flag or one of its referenced segments contains malformed evaluation data:

- The affected feature flag is omitted from the client payload.
- Other valid feature flags continue to be delivered.
- A single flag change produces an empty patch when that flag cannot be evaluated.
- Server SDK payload behavior remains unchanged.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger validation for feature flag and segment data, including clear details about malformed fields and values.
  * Improved handling of missing, invalid, or unknown variations during evaluation.

* **Bug Fixes**
  * Malformed flags and segments no longer interrupt synchronization; they are skipped and logged.
  * Synchronization now continues gracefully when evaluation or infrastructure errors occur.
  * Added validation for rollout data and referenced variation IDs.

* **Tests**
  * Expanded coverage for invalid JSON, malformed evaluation data, and synchronization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR isolates malformed feature-flag and segment evaluation data so client synchronization can continue with unaffected flags.
- Adds contextual JSON validation and malformed-data exceptions.
- Validates segment references before accessing MongoDB, PostgreSQL, or Redis stores.
- Skips malformed flags at client full-sync and patch boundaries while preserving infrastructure-error propagation.
- Adds coverage for malformed JSON, invalid segment identifiers, broken segment data, and partial payload delivery.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The current validation rejects malformed and store-incompatible segment identifiers before store access, while per-flag handling isolates malformed evaluation data and leaves infrastructure failures propagating; no blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| modules/evaluation-server/src/Domain/Evaluation/EntityJsonReader.cs | Introduces contextual JSON validation and strict `D`-format segment-ID validation that resolves both previously reported store-boundary failures. |
| modules/evaluation-server/src/Domain/Evaluation/RuleMatcher.cs | Validates segment IDs before store access and converts malformed condition values into contextual evaluation errors. |
| modules/evaluation-server/src/Streaming/Services/DataSyncService.cs | Establishes per-flag malformed-data isolation across client full-sync and patch payload generation. |
| modules/evaluation-server/tests/Domain.UnitTests/Evaluation/EntityJsonReaderTests.cs | Covers malformed JSON, invalid property shapes, null array members, and noncanonical segment identifiers. |
| modules/evaluation-server/tests/Streaming.UnitTests/Services/DataSyncServiceTests.cs | Verifies partial client payload delivery, empty malformed-flag patches, segment error isolation, and propagation of infrastructure failures. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Client full sync or patch] --> B[Read feature flags]
  B --> C[Validate and evaluate one flag]
  C -->|Valid| D[Add evaluated flag to payload]
  C -->|MalformedDataException| E[Log and skip affected flag]
  C -->|Infrastructure failure| F[Propagate failure]
  D --> G[Continue with remaining flags]
  E --> G
  G --> H[Return client payload]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["remove unneccessary allocations"](https://github.com/featbit/featbit/commit/722bc442e6c7e8a37e42a29cfd3d8e81cec0fd54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58540268)</sub>

**Context used:**

- Knowledge Base — [Feature evaluation and streaming](https://app.greptile.com/featbit/-/custom-context/knowledge-base/featbit/featbit/-/docs/evaluation-and-streaming.md)
- Knowledge Base — [Real-time streaming](https://app.greptile.com/featbit/-/custom-context/knowledge-base/featbit/featbit/-/docs/realtime-streaming.md)

<!-- /greptile_comment -->