### PR TITLE
✨ feat: data validation for flag and segmnet

### DIFF
--- a/modules/back-end/src/Application/FeatureFlags/CreateFlagChangeRequest.cs
+++ b/modules/back-end/src/Application/FeatureFlags/CreateFlagChangeRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Application.Bases.Exceptions;
+using Application.Bases;
 using Application.Users;
 using Domain.FeatureFlags;
 using Domain.FlagChangeRequests;
@@ -23,37 +24,36 @@ public class CreateFlagChangeRequest : IRequest<bool>
     public ICollection<Guid> Reviewers { get; set; }
 }
 
-public class CreateFlagChangeRequestHandler : IRequestHandler<CreateFlagChangeRequest, bool>
+public class CreateFlagChangeRequestValidator : AbstractValidator<CreateFlagChangeRequest>
 {
-    private readonly IFeatureFlagService _flagService;
-    private readonly IFlagChangeRequestService _flagChangeRequestService;
-    private readonly IFlagDraftService _flagDraftService;
-    private readonly ICurrentUser _currentUser;
-
-    public CreateFlagChangeRequestHandler(
-        IFeatureFlagService flagService,
-        IFlagChangeRequestService flagChangeRequestService,
-        IFlagDraftService flagDraftService,
-        ICurrentUser currentUser)
+    public CreateFlagChangeRequestValidator()
     {
-        _flagService = flagService;
-        _flagChangeRequestService = flagChangeRequestService;
-        _flagDraftService = flagDraftService;
-        _currentUser = currentUser;
+        RuleFor(x => x.Targeting)
+            .NotNull().WithErrorCode(ErrorCodes.Required("targeting"));
     }
+}
 
+public class CreateFlagChangeRequestHandler(
+    IFeatureFlagService flagService,
+    IFlagChangeRequestService flagChangeRequestService,
+    IFlagDraftService flagDraftService,
+    ICurrentUser currentUser)
+    : IRequestHandler<CreateFlagChangeRequest, bool>
+{
     public async Task<bool> Handle(CreateFlagChangeRequest request, CancellationToken cancellationToken)
     {
-        var flag = await _flagService.GetAsync(request.EnvId, request.Key);
+        var flag = await flagService.GetAsync(request.EnvId, request.Key);
         if (!flag.Revision.Equals(request.Revision))
         {
             throw new ConflictException(nameof(FeatureFlag), flag.Id);
         }
 
+        FlagTargetingValidator.EnsureValid(request.Targeting, flag.Variations);
+
         // create flag draft
-        var dataChange = flag.UpdateTargeting(request.Targeting, _currentUser.Id);
-        var flagDraft = new FlagDraft(request.EnvId, flag.Id, dataChange, _currentUser.Id, comment: request.Reason);
-        await _flagDraftService.AddOneAsync(flagDraft);
+        var dataChange = flag.UpdateTargeting(request.Targeting, currentUser.Id);
+        var flagDraft = new FlagDraft(request.EnvId, flag.Id, dataChange, currentUser.Id, comment: request.Reason);
+        await flagDraftService.AddOneAsync(flagDraft);
 
         // create change request
         var flagChangeRequest = new FlagChangeRequest(
@@ -62,10 +62,10 @@ public class CreateFlagChangeRequestHandler : IRequestHandler<CreateFlagChangeRe
             flagDraft.Id,
             flag.Id,
             request.Reviewers,
-            _currentUser.Id,
+            currentUser.Id,
             reason: request.Reason
         );
-        await _flagChangeRequestService.AddOneAsync(flagChangeRequest);
+        await flagChangeRequestService.AddOneAsync(flagChangeRequest);
 
         return true;
     }

--- a/modules/back-end/src/Application/FeatureFlags/CreateFlagSchedule.cs
+++ b/modules/back-end/src/Application/FeatureFlags/CreateFlagSchedule.cs
@@ -34,44 +34,39 @@ public class CreateFlagSchedule : IRequest<bool>
     public ICollection<Guid> Reviewers { get; set; }
 }
 
-public class CreateFlagScheduleHandler : IRequestHandler<CreateFlagSchedule, bool>
+public class CreateFlagScheduleValidator : AbstractValidator<CreateFlagSchedule>
 {
-    private readonly IFeatureFlagService _flagService;
-    private readonly ILicenseService _licenseService;
-    private readonly IFlagScheduleService _flagScheduleService;
-    private readonly IFlagChangeRequestService _flagChangeRequestService;
-    private readonly IFlagDraftService _flagDraftService;
-    private readonly ICurrentUser _currentUser;
-
-    public CreateFlagScheduleHandler(
-        IFeatureFlagService flagService,
-        ILicenseService licenseService,
-        IFlagScheduleService flagScheduleService,
-        IFlagChangeRequestService flagChangeRequestService,
-        IFlagDraftService flagDraftService,
-        ICurrentUser currentUser)
+    public CreateFlagScheduleValidator()
     {
-        _flagService = flagService;
-        _licenseService = licenseService;
-        _flagScheduleService = flagScheduleService;
-        _flagChangeRequestService = flagChangeRequestService;
-        _flagDraftService = flagDraftService;
-        _currentUser = currentUser;
+        RuleFor(x => x.Targeting)
+            .NotNull().WithErrorCode(ErrorCodes.Required("targeting"));
     }
+}
 
+public class CreateFlagScheduleHandler(
+    IFeatureFlagService flagService,
+    ILicenseService licenseService,
+    IFlagScheduleService flagScheduleService,
+    IFlagChangeRequestService flagChangeRequestService,
+    IFlagDraftService flagDraftService,
+    ICurrentUser currentUser)
+    : IRequestHandler<CreateFlagSchedule, bool>
+{
     public async Task<bool> Handle(CreateFlagSchedule request, CancellationToken cancellationToken)
     {
-        var flag = await _flagService.GetAsync(request.EnvId, request.Key);
+        var flag = await flagService.GetAsync(request.EnvId, request.Key);
         if (!flag.Revision.Equals(request.Revision))
         {
             throw new ConflictException(nameof(FeatureFlag), flag.Id);
         }
 
-        var dataChange = flag.UpdateTargeting(request.Targeting, _currentUser.Id);
+        FlagTargetingValidator.EnsureValid(request.Targeting, flag.Variations);
+
+        var dataChange = flag.UpdateTargeting(request.Targeting, currentUser.Id);
 
         // create draft
-        var flagDraft = new FlagDraft(request.EnvId, flag.Id, dataChange, _currentUser.Id, comment: request.Reason);
-        await _flagDraftService.AddOneAsync(flagDraft);
+        var flagDraft = new FlagDraft(request.EnvId, flag.Id, dataChange, currentUser.Id, comment: request.Reason);
+        await flagDraftService.AddOneAsync(flagDraft);
 
         // create change request if needed
         var changeRequest = request.WithChangeRequest ? await CreateChangeRequest() : null;
@@ -83,7 +78,7 @@ public class CreateFlagScheduleHandler : IRequestHandler<CreateFlagSchedule, boo
         if (changeRequest != null)
         {
             changeRequest.AttachSchedule(schedule.Id);
-            await _flagChangeRequestService.UpdateAsync(changeRequest);
+            await flagChangeRequestService.UpdateAsync(changeRequest);
         }
 
         return true;
@@ -102,10 +97,10 @@ public class CreateFlagScheduleHandler : IRequestHandler<CreateFlagSchedule, boo
                 status,
                 request.Title,
                 request.ScheduledTime,
-                _currentUser.Id,
+                currentUser.Id,
                 changeRequestId
             );
-            await _flagScheduleService.AddOneAsync(newSchedule);
+            await flagScheduleService.AddOneAsync(newSchedule);
 
             return newSchedule;
         }
@@ -114,7 +109,7 @@ public class CreateFlagScheduleHandler : IRequestHandler<CreateFlagSchedule, boo
         {
             // check license
             var isChangeRequestGranted =
-                await _licenseService.IsFeatureGrantedAsync(request.WorkspaceId, LicenseFeatures.ChangeRequest);
+                await licenseService.IsFeatureGrantedAsync(request.WorkspaceId, LicenseFeatures.ChangeRequest);
             if (!isChangeRequestGranted)
             {
                 throw new BusinessException(ErrorCodes.Unauthorized);
@@ -127,10 +122,10 @@ public class CreateFlagScheduleHandler : IRequestHandler<CreateFlagSchedule, boo
                 flagDraft.Id,
                 flag.Id,
                 request.Reviewers,
-                _currentUser.Id,
+                currentUser.Id,
                 reason: request.Reason
             );
-            await _flagChangeRequestService.AddOneAsync(newChangeRequest);
+            await flagChangeRequestService.AddOneAsync(newChangeRequest);
 
             return newChangeRequest;
         }

--- a/modules/back-end/src/Application/FeatureFlags/FlagTargetingValidator.cs
+++ b/modules/back-end/src/Application/FeatureFlags/FlagTargetingValidator.cs
@@ -1,0 +1,26 @@
+using Application.Bases;
+using Domain.FeatureFlags;
+using FluentValidation.Results;
+
+namespace Application.FeatureFlags;
+
+public static class FlagTargetingValidator
+{
+    private static readonly ValidationFailure[] Failures =
+    [
+        new(nameof(FlagTargeting), "Invalid targeting")
+        {
+            ErrorCode = ErrorCodes.Invalid("targeting")
+        }
+    ];
+
+    public static void EnsureValid(FlagTargeting targeting, ICollection<Variation> flagVariations)
+    {
+        if (targeting?.IsValid(flagVariations) == true)
+        {
+            return;
+        }
+
+        throw new ValidationException(Failures);
+    }
+}

--- a/modules/back-end/src/Application/FeatureFlags/UpdateTargeting.cs
+++ b/modules/back-end/src/Application/FeatureFlags/UpdateTargeting.cs
@@ -55,12 +55,6 @@ public class UpdateTargetingValidator : AbstractValidator<UpdateTargeting>
     {
         RuleFor(x => x.Targeting)
             .NotNull().WithErrorCode(ErrorCodes.Required("targeting"));
-
-        When(x => x.Targeting is not null, () =>
-        {
-            RuleFor(x => x.Targeting.DisabledVariationId)
-                .NotEmpty().WithErrorCode(ErrorCodes.Required("disabledVariationId"));
-        });
     }
 }
 
@@ -78,6 +72,8 @@ public class UpdateTargetingHandler(
         {
             throw new ConflictException(nameof(FeatureFlag), flag.Id);
         }
+
+        FlagTargetingValidator.EnsureValid(request.Targeting, flag.Variations);
 
         var dataChange = flag.UpdateTargeting(request.Targeting, currentUser.Id);
 

--- a/modules/back-end/src/Application/Segments/UpdateTargeting.cs
+++ b/modules/back-end/src/Application/Segments/UpdateTargeting.cs
@@ -47,11 +47,9 @@ public class UpdateTargetingValidator : AbstractValidator<UpdateTargeting>
     public UpdateTargetingValidator()
     {
         RuleFor(x => x.Rules)
-            .Must(rules =>
-            {
-                var conditions = rules.SelectMany(x => x.Conditions);
-                return conditions.All(x => !x.IsSegmentCondition());
-            }).WithErrorCode(ErrorCodes.Invalid("rules"));
+            .NotNull().WithErrorCode(ErrorCodes.Required("rules"))
+            .Must(rules => rules.All(rule => rule != null && rule.IsValid()))
+            .WithErrorCode(ErrorCodes.Invalid("rules"));
     }
 }
 

--- a/modules/back-end/src/Domain/FeatureFlags/FlagTargeting.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/FlagTargeting.cs
@@ -31,6 +31,11 @@ public class FlagTargeting
 
     public bool IsValid(ICollection<Variation> flagVariations)
     {
+        if (flagVariations.All(variation => variation.Id != DisabledVariationId))
+        {
+            return false;
+        }
+
         if (Rules == null || Fallthrough == null)
         {
             return false;

--- a/modules/back-end/src/Domain/FeatureFlags/FlagTargeting.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/FlagTargeting.cs
@@ -28,4 +28,19 @@ public class FlagTargeting
     /// Whether all targets should be included in experiments related to this feature flag. Defaults to `true`.
     /// </summary>
     public bool ExptIncludeAllTargets { get; set; } = true;
+
+    public bool IsValid(ICollection<Variation> flagVariations)
+    {
+        if (Rules == null || Fallthrough == null)
+        {
+            return false;
+        }
+
+        if (Rules.Any(rule => rule == null || !rule.IsValid(flagVariations)))
+        {
+            return false;
+        }
+
+        return ServedVariationsValidator.IsValid(Fallthrough.Variations, flagVariations);
+    }
 }

--- a/modules/back-end/src/Domain/FeatureFlags/FlagTargeting.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/FlagTargeting.cs
@@ -50,7 +50,7 @@ public class FlagTargeting
         }
 
         // validate that all target users have valid variations
-        if (TargetUsers.Any(tu => tu == null || flagVariations.All(variation => variation.Id != tu.VariationId)))
+        if (TargetUsers.Any(tu => tu?.KeyIds == null || flagVariations.All(variation => variation.Id != tu.VariationId)))
         {
             return false;
         }

--- a/modules/back-end/src/Domain/FeatureFlags/FlagTargeting.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/FlagTargeting.cs
@@ -31,21 +31,37 @@ public class FlagTargeting
 
     public bool IsValid(ICollection<Variation> flagVariations)
     {
+        // flag variations not null and not empty
+        if (flagVariations.IsNullOrEmpty())
+        {
+            return false;
+        }
+
+        // non-nulls
+        if (TargetUsers == null || Rules == null || Fallthrough == null)
+        {
+            return false;
+        }
+
+        // validate that the disabled variation exists in the flag variations
         if (flagVariations.All(variation => variation.Id != DisabledVariationId))
         {
             return false;
         }
 
-        if (Rules == null || Fallthrough == null)
+        // validate that all target users have valid variations
+        if (TargetUsers.Any(tu => tu == null || flagVariations.All(variation => variation.Id != tu.VariationId)))
         {
             return false;
         }
 
+        // validate that all rules are valid
         if (Rules.Any(rule => rule == null || !rule.IsValid(flagVariations)))
         {
             return false;
         }
 
+        // validate that the fallthrough variations are valid
         return ServedVariationsValidator.IsValid(Fallthrough.Variations, flagVariations);
     }
 }

--- a/modules/back-end/src/Domain/FeatureFlags/RolloutVariation.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/RolloutVariation.cs
@@ -19,6 +19,21 @@ public class RolloutVariation
     /// </summary>
     public double ExptRollout { get; set; }
 
+    public bool IsValid(ICollection<Variation> flagVariations)
+    {
+        if (flagVariations.All(variation => variation.Id != Id))
+        {
+            return false;
+        }
+
+        return Rollout is { Length: 2 } &&
+               double.IsFinite(Rollout[0]) &&
+               double.IsFinite(Rollout[1]) &&
+               Rollout[0] >= 0 &&
+               Rollout[0] <= Rollout[1] &&
+               Rollout[1] <= 1;
+    }
+
     public bool IsEmpty()
     {
         return Rollout[1] - Rollout[0] == 0;

--- a/modules/back-end/src/Domain/FeatureFlags/RolloutVariation.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/RolloutVariation.cs
@@ -21,6 +21,11 @@ public class RolloutVariation
 
     public bool IsValid(ICollection<Variation> flagVariations)
     {
+        if (flagVariations.IsNullOrEmpty())
+        {
+            return false;
+        }
+
         if (flagVariations.All(variation => variation.Id != Id))
         {
             return false;

--- a/modules/back-end/src/Domain/FeatureFlags/ServedVariationsValidator.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/ServedVariationsValidator.cs
@@ -1,0 +1,28 @@
+namespace Domain.FeatureFlags;
+
+public static class ServedVariationsValidator
+{
+    private const double Tolerance = 0.00001;
+
+    public static bool IsValid(ICollection<RolloutVariation> servedVariations, ICollection<Variation> flagVariations)
+    {
+        if (servedVariations == null || servedVariations.Count == 0)
+        {
+            return false;
+        }
+
+        if (servedVariations.Any(variation => variation == null || !variation.IsValid(flagVariations)))
+        {
+            return false;
+        }
+
+        var ordered = servedVariations.OrderBy(variation => variation.Rollout[0]).ToArray();
+        if (Math.Abs(ordered[0].Rollout[0]) > Tolerance || Math.Abs(ordered[^1].Rollout[1] - 1) > Tolerance)
+        {
+            return false;
+        }
+
+        return ordered.Zip(ordered.Skip(1), (current, next) =>
+            Math.Abs(current.Rollout[1] - next.Rollout[0]) <= Tolerance).All(isContinuous => isContinuous);
+    }
+}

--- a/modules/back-end/src/Domain/FeatureFlags/ServedVariationsValidator.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/ServedVariationsValidator.cs
@@ -4,7 +4,7 @@ public static class ServedVariationsValidator
 {
     public static bool IsValid(ICollection<RolloutVariation> servedVariations, ICollection<Variation> flagVariations)
     {
-        if (servedVariations == null || servedVariations.Count == 0)
+        if (servedVariations.IsNullOrEmpty() || flagVariations.IsNullOrEmpty())
         {
             return false;
         }

--- a/modules/back-end/src/Domain/FeatureFlags/ServedVariationsValidator.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/ServedVariationsValidator.cs
@@ -2,8 +2,6 @@ namespace Domain.FeatureFlags;
 
 public static class ServedVariationsValidator
 {
-    private const double Tolerance = 0.00001;
-
     public static bool IsValid(ICollection<RolloutVariation> servedVariations, ICollection<Variation> flagVariations)
     {
         if (servedVariations == null || servedVariations.Count == 0)
@@ -17,12 +15,16 @@ public static class ServedVariationsValidator
         }
 
         var ordered = servedVariations.OrderBy(variation => variation.Rollout[0]).ToArray();
-        if (Math.Abs(ordered[0].Rollout[0]) > Tolerance || Math.Abs(ordered[^1].Rollout[1] - 1) > Tolerance)
+        if (!ordered[0].Rollout[0].Equals(0d) || !ordered[^1].Rollout[1].Equals(1d))
         {
             return false;
         }
 
-        return ordered.Zip(ordered.Skip(1), (current, next) =>
-            Math.Abs(current.Rollout[1] - next.Rollout[0]) <= Tolerance).All(isContinuous => isContinuous);
+        return ordered
+            .Zip(
+                ordered.Skip(1),
+                (current, next) => current.Rollout[1].Equals(next.Rollout[0])
+            )
+            .All(isContinuous => isContinuous);
     }
 }

--- a/modules/back-end/src/Domain/Targeting/Condition.cs
+++ b/modules/back-end/src/Domain/Targeting/Condition.cs
@@ -71,4 +71,27 @@ public class Condition
                condition.Op == Op &&
                condition.Value == Value;
     }
+
+    public bool IsValid(bool isSegmentConditionAllowed)
+    {
+        // missing property
+        if (string.IsNullOrWhiteSpace(Property))
+        {
+            return false;
+        }
+
+        var isSegmentCondition = IsSegmentCondition();
+
+        // segment condition is not allowed in some contexts, e.g., in segment targeting rules
+        if (isSegmentCondition && !isSegmentConditionAllowed)
+        {
+            return false;
+        }
+
+        // for segment conditions, the value must be a valid JSON array of strings;
+        // for non-segment conditions, the value must be valid according to the operator
+        return isSegmentCondition
+            ? OpValueValidator.IsStringArray(Value)
+            : OpValueValidator.IsValid(Op, Value);
+    }
 }

--- a/modules/back-end/src/Domain/Targeting/MatchRule.cs
+++ b/modules/back-end/src/Domain/Targeting/MatchRule.cs
@@ -16,4 +16,14 @@ public class MatchRule
     /// The collection of conditions that make up the match rule.
     /// </summary>
     public ICollection<Condition> Conditions { get; set; } = Array.Empty<Condition>();
+
+    public bool IsValid()
+    {
+        if (Conditions == null)
+        {
+            return false;
+        }
+
+        return Conditions.All(condition => condition != null && condition.IsValid(isSegmentConditionAllowed: false));
+    }
 }

--- a/modules/back-end/src/Domain/Targeting/MatchRule.cs
+++ b/modules/back-end/src/Domain/Targeting/MatchRule.cs
@@ -19,7 +19,7 @@ public class MatchRule
 
     public bool IsValid()
     {
-        if (Conditions == null)
+        if (Conditions == null || Conditions.Count == 0)
         {
             return false;
         }

--- a/modules/back-end/src/Domain/Targeting/MatchRule.cs
+++ b/modules/back-end/src/Domain/Targeting/MatchRule.cs
@@ -19,7 +19,7 @@ public class MatchRule
 
     public bool IsValid()
     {
-        if (Conditions == null || Conditions.Count == 0)
+        if (Conditions.IsNullOrEmpty())
         {
             return false;
         }

--- a/modules/back-end/src/Domain/Targeting/OpValueValidator.cs
+++ b/modules/back-end/src/Domain/Targeting/OpValueValidator.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Domain.Targeting;
+
+public static class OpValueValidator
+{
+    public static bool IsValid(string op, string value)
+    {
+        return op switch
+        {
+            // Equality operators, value must be non-null
+            OperatorTypes.Equal or OperatorTypes.NotEqual => value != null,
+
+            // Boolean operators, value is always valid
+            OperatorTypes.IsTrue or OperatorTypes.IsFalse => true,
+
+            // Numeric operators, value must be a valid number
+            OperatorTypes.LessThan or OperatorTypes.BiggerThan or
+                OperatorTypes.LessEqualThan or OperatorTypes.BiggerEqualThan => IsNumber(value),
+
+            // Array operators, value must be a valid JSON array of strings
+            OperatorTypes.IsOneOf or OperatorTypes.NotOneOf => IsStringArray(value),
+
+            // String operators, value must be a non-empty string
+            OperatorTypes.Contains or OperatorTypes.NotContain or
+                OperatorTypes.StartsWith or OperatorTypes.EndsWith => !string.IsNullOrWhiteSpace(value),
+
+            // Regex operators, value must be a valid regular expression
+            OperatorTypes.MatchRegex or OperatorTypes.NotMatchRegex => IsRegex(value),
+
+            _ => false
+        };
+    }
+
+    public static bool IsStringArray(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            var root = document.RootElement;
+            return root.ValueKind == JsonValueKind.Array &&
+                   root.EnumerateArray().All(item => item.ValueKind == JsonValueKind.String);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    public static bool IsNumber(string value) =>
+        double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number) &&
+        double.IsFinite(number);
+
+    public static bool IsRegex(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        try
+        {
+            _ = Regex.IsMatch(string.Empty, value);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+}

--- a/modules/back-end/src/Domain/Targeting/Operator.cs
+++ b/modules/back-end/src/Domain/Targeting/Operator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -44,14 +45,8 @@ public class Operator
     ) => (userValue, ruleValue) =>
     {
         // not a number, return false
-        if (!double.TryParse(userValue, out var userDoubleValue) ||
-            !double.TryParse(ruleValue, out var ruleDoubleValue))
-        {
-            return false;
-        }
-
-        // is NaN, return false
-        if (double.IsNaN(userDoubleValue) || double.IsNaN(ruleDoubleValue))
+        if (!TryParseFiniteNumber(userValue, out var userDoubleValue) ||
+            !TryParseFiniteNumber(ruleValue, out var ruleDoubleValue))
         {
             return false;
         }
@@ -59,6 +54,10 @@ public class Operator
         var result = userDoubleValue.CompareTo(ruleDoubleValue);
         return result == desiredComparisonResult || result == otherDesiredComparisonResult;
     };
+
+    private static bool TryParseFiniteNumber(string value, out double number) =>
+        double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out number) &&
+        double.IsFinite(number);
 
     #endregion
 

--- a/modules/back-end/src/Domain/Targeting/OperatorTypes.cs
+++ b/modules/back-end/src/Domain/Targeting/OperatorTypes.cs
@@ -1,6 +1,6 @@
 namespace Domain.Targeting;
 
-public class OperatorTypes
+public static class OperatorTypes
 {
     // numeric
     public const string LessThan = "LessThan";
@@ -31,4 +31,32 @@ public class OperatorTypes
     // is true/ is false
     public const string IsTrue = "IsTrue";
     public const string IsFalse = "IsFalse";
+
+    public static readonly string[] All =
+    [
+        LessThan,
+        BiggerThan,
+        LessEqualThan,
+        BiggerEqualThan,
+
+        Equal,
+        NotEqual,
+
+        Contains,
+        NotContain,
+
+        StartsWith,
+        EndsWith,
+
+        MatchRegex,
+        NotMatchRegex,
+
+        IsOneOf,
+        NotOneOf,
+
+        IsTrue,
+        IsFalse
+    ];
+
+    public static bool IsDefined(string op) => All.Contains(op);
 }

--- a/modules/back-end/src/Domain/Targeting/TargetRule.cs
+++ b/modules/back-end/src/Domain/Targeting/TargetRule.cs
@@ -33,4 +33,19 @@ public class TargetRule
     /// The served variations.
     /// </summary>
     public ICollection<RolloutVariation> Variations { get; set; }
+
+    public bool IsValid(ICollection<Variation> flagVariations)
+    {
+        if (Conditions == null || Variations == null)
+        {
+            return false;
+        }
+
+        if (Conditions.Any(condition => condition == null || !condition.IsValid(isSegmentConditionAllowed: true)))
+        {
+            return false;
+        }
+
+        return ServedVariationsValidator.IsValid(Variations, flagVariations);
+    }
 }

--- a/modules/back-end/src/Domain/Targeting/TargetRule.cs
+++ b/modules/back-end/src/Domain/Targeting/TargetRule.cs
@@ -36,8 +36,7 @@ public class TargetRule
 
     public bool IsValid(ICollection<Variation> flagVariations)
     {
-        if (Conditions == null ||
-            Conditions.Count == 0 ||
+        if (Conditions.IsNullOrEmpty() ||
             Conditions.Any(condition => condition == null || !condition.IsValid(isSegmentConditionAllowed: true)))
         {
             return false;

--- a/modules/back-end/src/Domain/Targeting/TargetRule.cs
+++ b/modules/back-end/src/Domain/Targeting/TargetRule.cs
@@ -36,12 +36,9 @@ public class TargetRule
 
     public bool IsValid(ICollection<Variation> flagVariations)
     {
-        if (Conditions == null || Variations == null)
-        {
-            return false;
-        }
-
-        if (Conditions.Any(condition => condition == null || !condition.IsValid(isSegmentConditionAllowed: true)))
+        if (Conditions == null ||
+            Conditions.Count == 0 ||
+            Conditions.Any(condition => condition == null || !condition.IsValid(isSegmentConditionAllowed: true)))
         {
             return false;
         }

--- a/modules/back-end/src/Domain/Utils/CollectionExtensions.cs
+++ b/modules/back-end/src/Domain/Utils/CollectionExtensions.cs
@@ -2,6 +2,8 @@ namespace Domain.Utils;
 
 public static class CollectionExtensions
 {
+    public static bool IsNullOrEmpty<T>(this ICollection<T> collection) => collection == null || collection.Count == 0;
+
     public static bool AreEquivalent<T>(this ICollection<T> source, ICollection<T> destination)
     {
         if (source == null && destination == null)

--- a/modules/back-end/tests/Application.UnitTests/Validators/FeatureFlagValidatorTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/Validators/FeatureFlagValidatorTests.cs
@@ -2,6 +2,7 @@ using Application.Bases;
 using Application.FeatureFlags;
 using Domain.FeatureFlags;
 using Domain.Policies;
+using FluentValidation;
 
 namespace Application.UnitTests.Validators;
 
@@ -201,4 +202,64 @@ public class FeatureFlagValidatorTests
         Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Invalid("key"));
     }
 
+    [Fact]
+    public void GetInsights_FromZeroAndUndefinedInterval_InvalidErrors()
+    {
+        var req = new GetInsights
+        {
+            EnvId = Guid.NewGuid(),
+            Filter = new StatsByVariationFilter { FeatureFlagKey = "k", IntervalType = "n/a", From = 0, To = 0 }
+        };
+
+        var result = new GetInsightsValidator().Validate(req);
+
+        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Invalid("from"));
+        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Invalid("to"));
+        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Invalid("intervalType"));
+    }
+
+    [Fact]
+    public void GetVariationReferences_MissingIds_RequiredErrors()
+    {
+        var result = new GetVariationReferencesValidator().Validate(new GetVariationReferences());
+
+        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Required("featureFlagId"));
+        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Required("variationId"));
+    }
+
+    [Fact]
+    public void FlagTargeting_AllServedVariationsBelongToFlag_NoErrors()
+    {
+        Variation[] flagVariations = [V("variation-1")];
+        var targeting = new FlagTargeting
+        {
+            Rules = [],
+            Fallthrough = new Fallthrough
+            {
+                Variations = [new RolloutVariation { Id = "variation-1", Rollout = [0, 1] }]
+            }
+        };
+
+        FlagTargetingValidator.EnsureValid(targeting, flagVariations);
+    }
+
+    [Fact]
+    public void FlagTargeting_InvalidServedVariation_TargetingInvalidError()
+    {
+        Variation[] flagVariations = [V("variation-1")];
+        var targeting = new FlagTargeting
+        {
+            Rules = [],
+            Fallthrough = new Fallthrough
+            {
+                Variations = [new RolloutVariation { Id = "unknown", Rollout = [0, 1] }]
+            }
+        };
+
+        var exception = Assert.Throws<ValidationException>(() =>
+            FlagTargetingValidator.EnsureValid(targeting, flagVariations)
+        );
+
+        Assert.Contains(exception.Errors, error => error.ErrorCode == ErrorCodes.Invalid("targeting"));
+    }
 }

--- a/modules/back-end/tests/Application.UnitTests/Validators/FeatureFlagValidatorTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/Validators/FeatureFlagValidatorTests.cs
@@ -127,24 +127,6 @@ public class FeatureFlagValidatorTests
     }
 
     [Fact]
-    public void UpdateTargeting_EmptyDisabledVariationId_RequiredError()
-    {
-        var request = new UpdateTargeting(
-            Guid.NewGuid(),
-            Guid.NewGuid(),
-            "flag",
-            new UpdateTargetingPayload
-            {
-                Targeting = new FlagTargeting { DisabledVariationId = string.Empty }
-            },
-            Array.Empty<PolicyStatement>());
-
-        var result = new UpdateTargetingValidator().Validate(request);
-
-        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Required("disabledVariationId"));
-    }
-
-    [Fact]
     public void UpdateVariations_NullValueOk_VariationsValid()
     {
         var req = new UpdateVariations { Variations = new[] { V("a") } };
@@ -203,36 +185,12 @@ public class FeatureFlagValidatorTests
     }
 
     [Fact]
-    public void GetInsights_FromZeroAndUndefinedInterval_InvalidErrors()
-    {
-        var req = new GetInsights
-        {
-            EnvId = Guid.NewGuid(),
-            Filter = new StatsByVariationFilter { FeatureFlagKey = "k", IntervalType = "n/a", From = 0, To = 0 }
-        };
-
-        var result = new GetInsightsValidator().Validate(req);
-
-        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Invalid("from"));
-        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Invalid("to"));
-        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Invalid("intervalType"));
-    }
-
-    [Fact]
-    public void GetVariationReferences_MissingIds_RequiredErrors()
-    {
-        var result = new GetVariationReferencesValidator().Validate(new GetVariationReferences());
-
-        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Required("featureFlagId"));
-        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Required("variationId"));
-    }
-
-    [Fact]
     public void FlagTargeting_AllServedVariationsBelongToFlag_NoErrors()
     {
         Variation[] flagVariations = [V("variation-1")];
         var targeting = new FlagTargeting
         {
+            DisabledVariationId = "variation-1",
             Rules = [],
             Fallthrough = new Fallthrough
             {
@@ -249,10 +207,32 @@ public class FeatureFlagValidatorTests
         Variation[] flagVariations = [V("variation-1")];
         var targeting = new FlagTargeting
         {
+            DisabledVariationId = "variation-1",
             Rules = [],
             Fallthrough = new Fallthrough
             {
                 Variations = [new RolloutVariation { Id = "unknown", Rollout = [0, 1] }]
+            }
+        };
+
+        var exception = Assert.Throws<ValidationException>(() =>
+            FlagTargetingValidator.EnsureValid(targeting, flagVariations)
+        );
+
+        Assert.Contains(exception.Errors, error => error.ErrorCode == ErrorCodes.Invalid("targeting"));
+    }
+
+    [Fact]
+    public void FlagTargeting_InvalidDisabledVariation_TargetingInvalidError()
+    {
+        Variation[] flagVariations = [V("variation-1")];
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "unknown",
+            Rules = [],
+            Fallthrough = new Fallthrough
+            {
+                Variations = [new RolloutVariation { Id = "variation-1", Rollout = [0, 1] }]
             }
         };
 

--- a/modules/back-end/tests/Application.UnitTests/Validators/FeatureFlagValidatorTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/Validators/FeatureFlagValidatorTests.cs
@@ -288,4 +288,26 @@ public class FeatureFlagValidatorTests
 
         Assert.Contains(exception.Errors, error => error.ErrorCode == ErrorCodes.Invalid("targeting"));
     }
+
+    [Fact]
+    public void FlagTargeting_TargetUserWithoutKeys_TargetingInvalidError()
+    {
+        Variation[] flagVariations = [V("variation-1")];
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "variation-1",
+            TargetUsers = [new TargetUser { VariationId = "variation-1", KeyIds = null! }],
+            Rules = [],
+            Fallthrough = new Fallthrough
+            {
+                Variations = [new RolloutVariation { Id = "variation-1", Rollout = [0, 1] }]
+            }
+        };
+
+        var exception = Assert.Throws<ValidationException>(() =>
+            FlagTargetingValidator.EnsureValid(targeting, flagVariations)
+        );
+
+        Assert.Contains(exception.Errors, error => error.ErrorCode == ErrorCodes.Invalid("targeting"));
+    }
 }

--- a/modules/back-end/tests/Application.UnitTests/Validators/FeatureFlagValidatorTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/Validators/FeatureFlagValidatorTests.cs
@@ -1,7 +1,7 @@
 using Application.Bases;
 using Application.FeatureFlags;
 using Domain.FeatureFlags;
-using Domain.Policies;
+using Domain.Targeting;
 using FluentValidation;
 
 namespace Application.UnitTests.Validators;
@@ -191,6 +191,7 @@ public class FeatureFlagValidatorTests
         var targeting = new FlagTargeting
         {
             DisabledVariationId = "variation-1",
+            TargetUsers = [],
             Rules = [],
             Fallthrough = new Fallthrough
             {
@@ -208,6 +209,7 @@ public class FeatureFlagValidatorTests
         var targeting = new FlagTargeting
         {
             DisabledVariationId = "variation-1",
+            TargetUsers = [],
             Rules = [],
             Fallthrough = new Fallthrough
             {
@@ -229,6 +231,7 @@ public class FeatureFlagValidatorTests
         var targeting = new FlagTargeting
         {
             DisabledVariationId = "unknown",
+            TargetUsers = [],
             Rules = [],
             Fallthrough = new Fallthrough
             {
@@ -238,6 +241,49 @@ public class FeatureFlagValidatorTests
 
         var exception = Assert.Throws<ValidationException>(() =>
             FlagTargetingValidator.EnsureValid(targeting, flagVariations)
+        );
+
+        Assert.Contains(exception.Errors, error => error.ErrorCode == ErrorCodes.Invalid("targeting"));
+    }
+
+    [Fact]
+    public void FlagTargeting_InvalidTargetUserVariation_TargetingInvalidError()
+    {
+        Variation[] flagVariations = [V("variation-1")];
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "variation-1",
+            TargetUsers = [new TargetUser { VariationId = "unknown", KeyIds = ["user-1"] }],
+            Rules = [],
+            Fallthrough = new Fallthrough
+            {
+                Variations = [new RolloutVariation { Id = "variation-1", Rollout = [0, 1] }]
+            }
+        };
+
+        var exception = Assert.Throws<ValidationException>(() =>
+            FlagTargetingValidator.EnsureValid(targeting, flagVariations)
+        );
+
+        Assert.Contains(exception.Errors, error => error.ErrorCode == ErrorCodes.Invalid("targeting"));
+    }
+
+    [Fact]
+    public void FlagTargeting_NullFlagVariations_TargetingInvalidError()
+    {
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "variation-1",
+            TargetUsers = [],
+            Rules = [],
+            Fallthrough = new Fallthrough
+            {
+                Variations = [new RolloutVariation { Id = "variation-1", Rollout = [0, 1] }]
+            }
+        };
+
+        var exception = Assert.Throws<ValidationException>(() =>
+            FlagTargetingValidator.EnsureValid(targeting, null!)
         );
 
         Assert.Contains(exception.Errors, error => error.ErrorCode == ErrorCodes.Invalid("targeting"));

--- a/modules/back-end/tests/Application.UnitTests/Validators/SegmentValidatorTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/Validators/SegmentValidatorTests.cs
@@ -118,7 +118,7 @@ public class SegmentValidatorTests
         var rule = new MatchRule
         {
             Id = "r1",
-            Conditions = new[] { new Condition { Id = "c", Property = "email", Op = "is", Value = "x" } }
+            Conditions = new[] { new Condition { Id = "c", Property = "email", Op = OperatorTypes.Equal, Value = "x" } }
         };
         var request = new UpdateTargeting(Guid.NewGuid(), new UpdateTargetingPayload { Rules = new[] { rule } }, Array.Empty<Domain.Policies.PolicyStatement>());
 
@@ -141,4 +141,27 @@ public class SegmentValidatorTests
 
         Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Invalid("rules"));
     }
+
+    [Theory]
+    [InlineData("", "Equal", "x")]
+    [InlineData("email", "", "x")]
+    [InlineData("email", "Unknown", "x")]
+    public void UpdateTargeting_InvalidCondition_RulesInvalidError(string property, string op, string value)
+    {
+        var rule = new MatchRule
+        {
+            Id = "r1",
+            Conditions = new[] { new Condition { Id = "c", Property = property, Op = op, Value = value } }
+        };
+        var request = new UpdateTargeting(
+            Guid.NewGuid(),
+            new UpdateTargetingPayload { Rules = new[] { rule } },
+            Array.Empty<Domain.Policies.PolicyStatement>()
+        );
+
+        var result = new UpdateTargetingValidator().Validate(request);
+
+        Assert.Contains(result.Errors, e => e.ErrorCode == ErrorCodes.Invalid("rules"));
+    }
+
 }

--- a/modules/back-end/tests/Domain.UnitTests/FeatureFlags/RolloutVariationTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/FeatureFlags/RolloutVariationTests.cs
@@ -1,0 +1,46 @@
+using Domain.FeatureFlags;
+
+namespace Domain.UnitTests.FeatureFlags;
+
+public class RolloutVariationTests
+{
+    private static readonly Variation[] FlagVariations =
+    [
+        new() { Id = "variation-1" },
+        new() { Id = "variation-2" }
+    ];
+
+    [Fact]
+    public void IsValid_KnownVariationAndValidRange_ReturnsTrue()
+    {
+        var variation = new RolloutVariation { Id = "variation-1", Rollout = [0, 1] };
+
+        Assert.True(variation.IsValid(FlagVariations));
+    }
+
+    [Theory]
+    [InlineData("unknown", 0, 1)]
+    [InlineData("variation-1", -0.1, 1)]
+    [InlineData("variation-1", 0, 1.1)]
+    [InlineData("variation-1", 0.8, 0.2)]
+    [InlineData("variation-1", double.NaN, 1)]
+    [InlineData("variation-1", 0, double.PositiveInfinity)]
+    public void IsValid_InvalidIdOrRange_ReturnsFalse(string id, double start, double end)
+    {
+        var variation = new RolloutVariation { Id = id, Rollout = [start, end] };
+
+        Assert.False(variation.IsValid(FlagVariations));
+    }
+
+    [Fact]
+    public void IsValid_RangeDoesNotHaveTwoValues_ReturnsFalse()
+    {
+        double[][] invalidRollouts = [[], [0], [0, 0.5, 1]];
+
+        foreach (var rollout in invalidRollouts)
+        {
+            var variation = new RolloutVariation { Id = "variation-1", Rollout = rollout };
+            Assert.False(variation.IsValid(FlagVariations));
+        }
+    }
+}

--- a/modules/back-end/tests/Domain.UnitTests/FeatureFlags/RolloutVariationTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/FeatureFlags/RolloutVariationTests.cs
@@ -43,4 +43,13 @@ public class RolloutVariationTests
             Assert.False(variation.IsValid(FlagVariations));
         }
     }
+
+    [Fact]
+    public void IsValid_NoFlagVariations_ReturnsFalse()
+    {
+        var variation = new RolloutVariation { Id = "variation-1", Rollout = [0, 1] };
+
+        Assert.False(variation.IsValid(null!));
+        Assert.False(variation.IsValid([]));
+    }
 }

--- a/modules/back-end/tests/Domain.UnitTests/FeatureFlags/ServedVariationsValidatorTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/FeatureFlags/ServedVariationsValidatorTests.cs
@@ -1,0 +1,61 @@
+using Domain.FeatureFlags;
+
+namespace Domain.UnitTests.FeatureFlags;
+
+public class ServedVariationsValidatorTests
+{
+    private static readonly Variation[] FlagVariations =
+    [
+        new() { Id = "variation-1" },
+        new() { Id = "variation-2" }
+    ];
+
+    [Fact]
+    public void IsValid_ContinuousRolloutCoveringOneHundredPercent_ReturnsTrue()
+    {
+        RolloutVariation[] servedVariations =
+        [
+            new() { Id = "variation-1", Rollout = [0, 0.4] },
+            new() { Id = "variation-2", Rollout = [0.4, 1] }
+        ];
+
+        Assert.True(ServedVariationsValidator.IsValid(servedVariations, FlagVariations));
+    }
+
+    [Theory]
+    [InlineData(0, 0.4, 0.5, 1)]
+    [InlineData(0, 0.6, 0.5, 1)]
+    [InlineData(0.1, 0.5, 0.5, 1)]
+    [InlineData(0, 0.5, 0.5, 0.9)]
+    public void IsValid_RolloutDoesNotCompletelyAllocateOneHundredPercent_ReturnsFalse(
+        double firstStart,
+        double firstEnd,
+        double secondStart,
+        double secondEnd)
+    {
+        RolloutVariation[] servedVariations =
+        [
+            new() { Id = "variation-1", Rollout = [firstStart, firstEnd] },
+            new() { Id = "variation-2", Rollout = [secondStart, secondEnd] }
+        ];
+
+        Assert.False(ServedVariationsValidator.IsValid(servedVariations, FlagVariations));
+    }
+
+    [Fact]
+    public void IsValid_UnknownVariationId_ReturnsFalse()
+    {
+        RolloutVariation[] servedVariations =
+        [
+            new() { Id = "unknown", Rollout = [0, 1] }
+        ];
+
+        Assert.False(ServedVariationsValidator.IsValid(servedVariations, FlagVariations));
+    }
+
+    [Fact]
+    public void IsValid_NoServedVariations_ReturnsFalse()
+    {
+        Assert.False(ServedVariationsValidator.IsValid([], FlagVariations));
+    }
+}

--- a/modules/back-end/tests/Domain.UnitTests/FeatureFlags/ServedVariationsValidatorTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/FeatureFlags/ServedVariationsValidatorTests.cs
@@ -27,6 +27,10 @@ public class ServedVariationsValidatorTests
     [InlineData(0, 0.6, 0.5, 1)]
     [InlineData(0.1, 0.5, 0.5, 1)]
     [InlineData(0, 0.5, 0.5, 0.9)]
+    [InlineData(0, 0.5, 0.500001, 1)]
+    [InlineData(0, 0.500001, 0.5, 1)]
+    [InlineData(0.000001, 0.5, 0.5, 1)]
+    [InlineData(0, 0.5, 0.5, 0.999999)]
     public void IsValid_RolloutDoesNotCompletelyAllocateOneHundredPercent_ReturnsFalse(
         double firstStart,
         double firstEnd,

--- a/modules/back-end/tests/Domain.UnitTests/Targeting/OpValueValidatorTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/Targeting/OpValueValidatorTests.cs
@@ -1,0 +1,91 @@
+using System.Globalization;
+using Domain.Targeting;
+
+namespace Domain.UnitTests.Targeting;
+
+public class OpValueValidatorTests
+{
+    [Theory]
+    [InlineData(OperatorTypes.Equal, "")]
+    [InlineData(OperatorTypes.NotEqual, "")]
+    [InlineData(OperatorTypes.IsTrue, null)]
+    [InlineData(OperatorTypes.IsFalse, null)]
+    [InlineData(OperatorTypes.BiggerThan, "10.5")]
+    [InlineData(OperatorTypes.IsOneOf, "[\"company-1\",\"company-2\"]")]
+    [InlineData(OperatorTypes.Contains, "value")]
+    [InlineData(OperatorTypes.MatchRegex, "^[a-z]+$")]
+    public void IsValid_ValidOperatorValue_ReturnsTrue(string op, string? value)
+    {
+        Assert.True(OpValueValidator.IsValid(op, value!));
+    }
+
+    [Theory]
+    [InlineData("Unknown", "value")]
+    [InlineData(OperatorTypes.BiggerThan, "not-a-number")]
+    [InlineData(OperatorTypes.BiggerThan, "NaN")]
+    [InlineData(OperatorTypes.IsOneOf, "[1]")]
+    [InlineData(OperatorTypes.IsOneOf, "[\"company-1\",1]")]
+    [InlineData(OperatorTypes.IsOneOf, "not-json")]
+    [InlineData(OperatorTypes.Contains, "")]
+    [InlineData(OperatorTypes.StartsWith, "")]
+    [InlineData(OperatorTypes.MatchRegex, "")]
+    [InlineData(OperatorTypes.MatchRegex, "[")]
+    public void IsValid_InvalidOperatorValue_ReturnsFalse(string op, string value)
+    {
+        Assert.False(OpValueValidator.IsValid(op, value));
+    }
+
+    [Theory]
+    [InlineData("[\"segment-1\"]", true)]
+    [InlineData("[]", true)]
+    [InlineData("[1]", false)]
+    [InlineData("[\"segment-1\",1]", false)]
+    [InlineData("not-json", false)]
+    [InlineData("", false)]
+    public void IsStringArray_Value_ReturnsExpectedResult(string value, bool expected)
+    {
+        Assert.Equal(expected, OpValueValidator.IsStringArray(value));
+    }
+
+    [Theory]
+    [InlineData("10", true)]
+    [InlineData("-10.5", true)]
+    [InlineData("1e3", true)]
+    [InlineData("NaN", false)]
+    [InlineData("Infinity", false)]
+    [InlineData("-Infinity", false)]
+    [InlineData("1e9999", false)]
+    [InlineData("-1e9999", false)]
+    [InlineData("not-a-number", false)]
+    [InlineData("", false)]
+    public void IsNumber_Value_ReturnsExpectedResult(string value, bool expected)
+    {
+        Assert.Equal(expected, OpValueValidator.IsNumber(value));
+    }
+
+    [Fact]
+    public void IsNumber_DotDecimalUnderNonDotCulture_ReturnsTrue()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            Assert.True(OpValueValidator.IsNumber("10.5"));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Theory]
+    [InlineData("^[a-z]+$", true)]
+    [InlineData("a|b", true)]
+    [InlineData("", false)]
+    [InlineData("[", false)]
+    [InlineData("(?<", false)]
+    public void IsRegex_Value_ReturnsExpectedResult(string value, bool expected)
+    {
+        Assert.Equal(expected, OpValueValidator.IsRegex(value));
+    }
+}

--- a/modules/back-end/tests/Domain.UnitTests/Targeting/OperatorTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/Targeting/OperatorTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Domain.Targeting;
 
 namespace Domain.UnitTests.Targeting;
@@ -26,9 +27,26 @@ public class OperatorTests
     [InlineData(OperatorTypes.LessThan, "not-a-number", "2")]
     [InlineData(OperatorTypes.LessThan, "1", "not-a-number")]
     [InlineData(OperatorTypes.BiggerThan, "NaN", "1")]
+    [InlineData(OperatorTypes.BiggerThan, "Infinity", "1")]
+    [InlineData(OperatorTypes.BiggerThan, "1e9999", "1")]
     public void IsMatch_NumericOperators_NonNumericInput_ReturnsFalse(string op, string user, string rule)
     {
         Assert.False(Operator.Get(op).IsMatch(user, rule));
+    }
+
+    [Fact]
+    public void IsMatch_NumericOperatorUnderNonDotCulture_UsesInvariantCulture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            Assert.True(Operator.Get(OperatorTypes.BiggerThan).IsMatch("10.5", "10.4"));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     [Theory]

--- a/modules/back-end/tests/Domain.UnitTests/Targeting/RuleValidationTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/Targeting/RuleValidationTests.cs
@@ -109,6 +109,7 @@ public class RuleValidationTests
     {
         var targeting = new FlagTargeting
         {
+            DisabledVariationId = "variation-1",
             Rules =
             [
                 new TargetRule
@@ -128,6 +129,7 @@ public class RuleValidationTests
     {
         var targeting = new FlagTargeting
         {
+            DisabledVariationId = "variation-1",
             Rules =
             [
                 new TargetRule
@@ -147,11 +149,25 @@ public class RuleValidationTests
     {
         var targeting = new FlagTargeting
         {
+            DisabledVariationId = "variation-1",
             Rules = [],
             Fallthrough = new Fallthrough
             {
                 Variations = [FullRollout("unknown-variation")]
             }
+        };
+
+        Assert.False(targeting.IsValid(FlagVariations("variation-1")));
+    }
+
+    [Fact]
+    public void FlagTargeting_DisabledVariationDoesNotBelongToFlag_IsInvalid()
+    {
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "unknown-variation",
+            Rules = [],
+            Fallthrough = ValidFallthrough()
         };
 
         Assert.False(targeting.IsValid(FlagVariations("variation-1")));

--- a/modules/back-end/tests/Domain.UnitTests/Targeting/RuleValidationTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/Targeting/RuleValidationTests.cs
@@ -1,0 +1,159 @@
+using Domain.Segments;
+using Domain.FeatureFlags;
+using Domain.Targeting;
+
+namespace Domain.UnitTests.Targeting;
+
+public class RuleValidationTests
+{
+    private static Condition CommonCondition => new()
+    {
+        Property = "companyId",
+        Op = OperatorTypes.IsOneOf,
+        Value = "[\"company-1\"]"
+    };
+
+    private static Condition SegmentCondition => new()
+    {
+        Property = SegmentConsts.IsInSegment,
+        Op = null,
+        Value = "[\"segment-1\"]"
+    };
+
+    private static RolloutVariation FullRollout(string id = "variation-1") => new()
+    {
+        Id = id,
+        Rollout = [0, 1]
+    };
+
+    private static Variation[] FlagVariations(params string[] ids) =>
+        ids.Select(id => new Variation { Id = id }).ToArray();
+
+    private static Fallthrough ValidFallthrough(string variationId = "variation-1") => new()
+    {
+        Variations = [FullRollout(variationId)]
+    };
+
+    [Fact]
+    public void MatchRule_CommonCondition_IsValid()
+    {
+        var rule = new MatchRule { Conditions = [CommonCondition] };
+
+        Assert.True(rule.IsValid());
+    }
+
+    [Fact]
+    public void MatchRule_SegmentCondition_IsInvalid()
+    {
+        var rule = new MatchRule { Conditions = [SegmentCondition] };
+
+        Assert.False(rule.IsValid());
+    }
+
+    [Fact]
+    public void TargetRule_SegmentCondition_IsValid()
+    {
+        var rule = new TargetRule { Conditions = [SegmentCondition], Variations = [FullRollout()] };
+
+        Assert.True(rule.IsValid(FlagVariations("variation-1")));
+    }
+
+    [Fact]
+    public void TargetRule_InvalidCondition_IsInvalid()
+    {
+        var rule = new TargetRule
+        {
+            Conditions = [new Condition { Property = "companyId", Op = OperatorTypes.IsOneOf, Value = "[1]" }],
+            Variations = [FullRollout()]
+        };
+
+        Assert.False(rule.IsValid(FlagVariations("variation-1", "variation-2")));
+    }
+
+    [Fact]
+    public void TargetRule_VariationBelongsToFlagAndRolloutIsComplete_IsValid()
+    {
+        var rule = new TargetRule
+        {
+            Conditions = [CommonCondition],
+            Variations =
+            [
+                new RolloutVariation { Id = "variation-1", Rollout = [0, 0.4] },
+                new RolloutVariation { Id = "variation-2", Rollout = [0.4, 1] }
+            ]
+        };
+        Variation[] flagVariations =
+        [
+            new() { Id = "variation-1" },
+            new() { Id = "variation-2" }
+        ];
+
+        Assert.True(rule.IsValid(flagVariations));
+    }
+
+    [Fact]
+    public void TargetRule_VariationDoesNotBelongToFlag_IsInvalid()
+    {
+        var rule = new TargetRule
+        {
+            Conditions = [CommonCondition],
+            Variations = [FullRollout("unknown-variation")]
+        };
+        Variation[] flagVariations = [new() { Id = "variation-1" }];
+
+        Assert.False(rule.IsValid(flagVariations));
+    }
+
+    [Fact]
+    public void FlagTargeting_AllRulesAreValid_IsValid()
+    {
+        var targeting = new FlagTargeting
+        {
+            Rules =
+            [
+                new TargetRule
+                {
+                    Conditions = [CommonCondition],
+                    Variations = [FullRollout("variation-1")]
+                }
+            ],
+            Fallthrough = ValidFallthrough()
+        };
+
+        Assert.True(targeting.IsValid(FlagVariations("variation-1")));
+    }
+
+    [Fact]
+    public void FlagTargeting_ContainsInvalidRule_IsInvalid()
+    {
+        var targeting = new FlagTargeting
+        {
+            Rules =
+            [
+                new TargetRule
+                {
+                    Conditions = [CommonCondition],
+                    Variations = [FullRollout("unknown-variation")]
+                }
+            ],
+            Fallthrough = ValidFallthrough()
+        };
+
+        Assert.False(targeting.IsValid(FlagVariations("variation-1")));
+    }
+
+    [Fact]
+    public void FlagTargeting_InvalidFallthrough_IsInvalid()
+    {
+        var targeting = new FlagTargeting
+        {
+            Rules = [],
+            Fallthrough = new Fallthrough
+            {
+                Variations = [FullRollout("unknown-variation")]
+            }
+        };
+
+        Assert.False(targeting.IsValid(FlagVariations("variation-1")));
+    }
+}

--- a/modules/back-end/tests/Domain.UnitTests/Targeting/RuleValidationTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/Targeting/RuleValidationTests.cs
@@ -51,6 +51,14 @@ public class RuleValidationTests
     }
 
     [Fact]
+    public void MatchRule_NoConditions_IsInvalid()
+    {
+        var rule = new MatchRule { Conditions = [] };
+
+        Assert.False(rule.IsValid());
+    }
+
+    [Fact]
     public void TargetRule_SegmentCondition_IsValid()
     {
         var rule = new TargetRule { Conditions = [SegmentCondition], Variations = [FullRollout()] };
@@ -68,6 +76,18 @@ public class RuleValidationTests
         };
 
         Assert.False(rule.IsValid(FlagVariations("variation-1", "variation-2")));
+    }
+
+    [Fact]
+    public void TargetRule_NoConditions_IsInvalid()
+    {
+        var rule = new TargetRule
+        {
+            Conditions = [],
+            Variations = [FullRollout()]
+        };
+
+        Assert.False(rule.IsValid(FlagVariations("variation-1")));
     }
 
     [Fact]

--- a/modules/back-end/tests/Domain.UnitTests/Targeting/RuleValidationTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/Targeting/RuleValidationTests.cs
@@ -130,6 +130,7 @@ public class RuleValidationTests
         var targeting = new FlagTargeting
         {
             DisabledVariationId = "variation-1",
+            TargetUsers = [],
             Rules =
             [
                 new TargetRule
@@ -150,6 +151,7 @@ public class RuleValidationTests
         var targeting = new FlagTargeting
         {
             DisabledVariationId = "variation-1",
+            TargetUsers = [],
             Rules =
             [
                 new TargetRule
@@ -170,6 +172,7 @@ public class RuleValidationTests
         var targeting = new FlagTargeting
         {
             DisabledVariationId = "variation-1",
+            TargetUsers = [],
             Rules = [],
             Fallthrough = new Fallthrough
             {
@@ -186,6 +189,78 @@ public class RuleValidationTests
         var targeting = new FlagTargeting
         {
             DisabledVariationId = "unknown-variation",
+            TargetUsers = [],
+            Rules = [],
+            Fallthrough = ValidFallthrough()
+        };
+
+        Assert.False(targeting.IsValid(FlagVariations("variation-1")));
+    }
+
+    [Fact]
+    public void FlagTargeting_NoFlagVariations_IsInvalid()
+    {
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "variation-1",
+            TargetUsers = [],
+            Rules = [],
+            Fallthrough = ValidFallthrough()
+        };
+
+        Assert.False(targeting.IsValid(null!));
+        Assert.False(targeting.IsValid([]));
+    }
+
+    [Fact]
+    public void FlagTargeting_TargetUserVariationBelongsToFlag_IsValid()
+    {
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "variation-1",
+            TargetUsers = [new TargetUser { VariationId = "variation-1", KeyIds = ["user-1"] }],
+            Rules = [],
+            Fallthrough = ValidFallthrough()
+        };
+
+        Assert.True(targeting.IsValid(FlagVariations("variation-1")));
+    }
+
+    [Fact]
+    public void FlagTargeting_TargetUserVariationDoesNotBelongToFlag_IsInvalid()
+    {
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "variation-1",
+            TargetUsers = [new TargetUser { VariationId = "unknown-variation", KeyIds = ["user-1"] }],
+            Rules = [],
+            Fallthrough = ValidFallthrough()
+        };
+
+        Assert.False(targeting.IsValid(FlagVariations("variation-1")));
+    }
+
+    [Fact]
+    public void FlagTargeting_NullTargetUser_IsInvalid()
+    {
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "variation-1",
+            TargetUsers = [null!],
+            Rules = [],
+            Fallthrough = ValidFallthrough()
+        };
+
+        Assert.False(targeting.IsValid(FlagVariations("variation-1")));
+    }
+
+    [Fact]
+    public void FlagTargeting_NoTargetUsersCollection_IsInvalid()
+    {
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "variation-1",
+            TargetUsers = null!,
             Rules = [],
             Fallthrough = ValidFallthrough()
         };

--- a/modules/back-end/tests/Domain.UnitTests/Targeting/RuleValidationTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/Targeting/RuleValidationTests.cs
@@ -267,4 +267,32 @@ public class RuleValidationTests
 
         Assert.False(targeting.IsValid(FlagVariations("variation-1")));
     }
+
+    [Fact]
+    public void FlagTargeting_TargetUserWithoutKeys_IsInvalid()
+    {
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "variation-1",
+            TargetUsers = [new TargetUser { VariationId = "variation-1", KeyIds = null! }],
+            Rules = [],
+            Fallthrough = ValidFallthrough()
+        };
+
+        Assert.False(targeting.IsValid(FlagVariations("variation-1")));
+    }
+
+    [Fact]
+    public void FlagTargeting_TargetUserWithEmptyKeys_IsValid()
+    {
+        var targeting = new FlagTargeting
+        {
+            DisabledVariationId = "variation-1",
+            TargetUsers = [new TargetUser { VariationId = "variation-1", KeyIds = [] }],
+            Rules = [],
+            Fallthrough = ValidFallthrough()
+        };
+
+        Assert.True(targeting.IsValid(FlagVariations("variation-1")));
+    }
 }

--- a/modules/evaluation-server/src/Domain/Evaluation/Operator.cs
+++ b/modules/evaluation-server/src/Domain/Evaluation/Operator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Domain.Evaluation;
@@ -44,14 +45,8 @@ public class Operator
     ) => (userValue, ruleValue) =>
     {
         // not a number, return false
-        if (!double.TryParse(userValue, out var userDoubleValue) ||
-            !double.TryParse(ruleValue, out var ruleDoubleValue))
-        {
-            return false;
-        }
-
-        // is NaN, return false
-        if (double.IsNaN(userDoubleValue) || double.IsNaN(ruleDoubleValue))
+        if (!TryParseFiniteNumber(userValue, out var userDoubleValue) ||
+            !TryParseFiniteNumber(ruleValue, out var ruleDoubleValue))
         {
             return false;
         }
@@ -59,6 +54,10 @@ public class Operator
         var result = userDoubleValue.CompareTo(ruleDoubleValue);
         return result == desiredComparisonResult || result == otherDesiredComparisonResult;
     };
+
+    private static bool TryParseFiniteNumber(string value, out double number) =>
+        double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out number) &&
+        double.IsFinite(number);
 
     #endregion
 


### PR DESCRIPTION
Port from #968 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive validation for feature flag targeting, including rules, fallthroughs, disabled variations, rollout allocations, and variation references.
  * Added validation for targeting values such as numbers, arrays, strings, and regular expressions.

* **Bug Fixes**
  * Invalid targeting configurations are now rejected when creating or updating flag changes and schedules.
  * Segment targeting rules now provide clearer validation for missing or invalid conditions.
  * Numeric targeting consistently supports invariant decimal formatting and rejects non-finite values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds centralized validation for feature-flag and segment targeting before invalid configurations can be persisted.
- Validates disabled, targeted, rule, fallthrough, and rollout variation references.
- Requires complete, finite, contiguous rollout allocations.
- Validates operator values, including invariant-culture numbers, JSON string arrays, and regular expressions.
- Applies validation to direct updates, change requests, schedules, and segment targeting.
- Aligns backend and evaluation-server numeric parsing behavior.
- Adds unit coverage for valid and invalid targeting configurations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no outstanding or newly introduced actionable defects were identified.

The previously reported rollout-continuity, empty-rule, and null-target-key findings are resolved, and the only change since the previous review preserves the existing null-or-empty validation semantics.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| modules/back-end/src/Application/FeatureFlags/FlagTargetingValidator.cs | Centralizes rejection of invalid feature-flag targeting payloads. |
| modules/back-end/src/Domain/FeatureFlags/FlagTargeting.cs | Validates targeting structure, variation references, target users, rules, and fallthrough behavior. |
| modules/back-end/src/Domain/FeatureFlags/ServedVariationsValidator.cs | Requires rollout ranges to cover the entire allocation without gaps or overlaps. |
| modules/back-end/src/Domain/Targeting/OpValueValidator.cs | Validates values according to each targeting operator’s runtime contract. |
| modules/back-end/src/Application/Segments/UpdateTargeting.cs | Rejects null or structurally invalid segment targeting rules. |
| modules/evaluation-server/src/Domain/Evaluation/Operator.cs | Aligns evaluation-server numeric comparisons with finite invariant-culture parsing. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Request[Targeting request] --> AppValidation[Application validation]
    AppValidation --> DomainValidation[Domain targeting validation]
    DomainValidation --> Conditions[Condition and operator values]
    DomainValidation --> References[Variation references]
    DomainValidation --> Rollouts[Complete contiguous rollouts]
    Conditions --> Decision{Valid?}
    References --> Decision
    Rollouts --> Decision
    Decision -->|No| Reject[Validation error]
    Decision -->|Yes| Persist[Create draft or update targeting]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["nit"](https://github.com/featbit/featbit/commit/1a1d487492a46e41f299199c245206cf77d28bba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60356855)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Backend platform](https://app.greptile.com/featbit/-/custom-context/knowledge-base/featbit/featbit/-/docs/backend-platform.md)
- Knowledge Base — [Management domain workflows](https://app.greptile.com/featbit/-/custom-context/knowledge-base/featbit/featbit/-/docs/management-domain-workflows.md)
- Knowledge Base — [Feature evaluation and streaming](https://app.greptile.com/featbit/-/custom-context/knowledge-base/featbit/featbit/-/docs/evaluation-and-streaming.md)
</details>


<!-- /greptile_comment -->