### PR TITLE
✨ feat: allow users to retry failed subscription payments

### DIFF
--- a/modules/front-end/src/features/workspace/billing/billing-api.ts
+++ b/modules/front-end/src/features/workspace/billing/billing-api.ts
@@ -3,6 +3,10 @@ import { fetchApi } from "@/lib/api/authenticated-api"
 export type BillingCycle = "monthly" | "yearly" | string
 
 export type BillingSubscription = {
+  status?: string
+  retryPaymentUrl?: string | null
+  retryPaymentState?:
+    "not_required" | "available" | "unavailable" | "no_open_invoice"
   plan?: string
   billingCycle?: BillingCycle
   baseMau?: number

--- a/modules/front-end/src/features/workspace/billing/billing-page.tsx
+++ b/modules/front-end/src/features/workspace/billing/billing-page.tsx
@@ -29,7 +29,11 @@ import {
   updateSubscription,
   type SubscriptionChangePayload,
 } from "./billing-api"
-import { CheckoutAlert, type CheckoutState } from "./components/billing-alerts"
+import {
+  CheckoutAlert,
+  PaymentFailedAlert,
+  type CheckoutState,
+} from "./components/billing-alerts"
 import { BillingInformationPanel } from "./components/billing-information-panel"
 import { InvoiceHistoryPanel } from "./components/invoice-history-panel"
 import { PricingDrawer } from "./components/pricing-drawer"
@@ -78,6 +82,7 @@ export function BillingPage() {
     queryKey: ["billing", "subscription"],
     queryFn: fetchSubscription,
     enabled: isSaas,
+    refetchOnWindowFocus: "always",
   })
   const cycleQuery = useQuery({
     queryKey: ["billing", "current-cycle"],
@@ -255,6 +260,30 @@ export function BillingPage() {
     void invoiceQuery.refetch()
   }
 
+  async function refreshPaymentStatus() {
+    const result = await subscriptionQuery.refetch()
+    if (result.isError || !result.data) {
+      toast.error(t("workspace.billing.paymentFailed.refreshError"))
+      return
+    }
+    void invoiceQuery.refetch()
+    if (result.data.status === "active") {
+      toast.success(t("workspace.billing.paymentFailed.confirmed"))
+    } else if (result.data.status === "payment_failed") {
+      if (result.data.retryPaymentState === "unavailable") {
+        toast.error(t("workspace.billing.paymentFailed.linkUnavailable"))
+      } else {
+        toast.info(
+          t(
+            result.data.retryPaymentState === "no_open_invoice"
+              ? "workspace.billing.paymentFailed.syncingDescription"
+              : "workspace.billing.paymentFailed.stillPending"
+          )
+        )
+      }
+    }
+  }
+
   function startChange(payload: SubscriptionChangePayload) {
     const nextTotal = planTotal(payload)
     const current = currentTotal(subscription)
@@ -300,6 +329,15 @@ export function BillingPage() {
               .catch(() => setCheckoutState("timeout"))
           }
         />
+
+        {subscription?.status === "payment_failed" ? (
+          <PaymentFailedAlert
+            retryPaymentUrl={subscription.retryPaymentUrl}
+            retryPaymentState={subscription.retryPaymentState}
+            isRefreshing={subscriptionQuery.isFetching}
+            onRefresh={() => void refreshPaymentStatus()}
+          />
+        ) : null}
 
         {subscriptionQuery.isError ? (
           <Alert className="flex items-center gap-4 rounded-md border-destructive/30 bg-destructive/5 px-5 py-4 text-foreground">

--- a/modules/front-end/src/features/workspace/billing/components/billing-alerts.tsx
+++ b/modules/front-end/src/features/workspace/billing/components/billing-alerts.tsx
@@ -1,12 +1,109 @@
-import { AlertCircle, CheckCircle2, Info, Loader2 } from "lucide-react"
+import {
+  AlertCircle,
+  CheckCircle2,
+  ExternalLink,
+  Info,
+  Loader2,
+  RefreshCw,
+} from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import type { BillingSubscription } from "../billing-api"
 
 export type CheckoutState =
   "verifying" | "confirmed" | "timeout" | "cancelled" | null
+
+export function PaymentFailedAlert({
+  retryPaymentUrl,
+  retryPaymentState,
+  isRefreshing,
+  onRefresh,
+}: {
+  retryPaymentUrl?: string | null
+  retryPaymentState?: BillingSubscription["retryPaymentState"]
+  isRefreshing: boolean
+  onRefresh: () => void
+}) {
+  const { t } = useTranslation()
+  const isSyncing = retryPaymentState === "no_open_invoice"
+  const canPay =
+    Boolean(retryPaymentUrl) &&
+    (retryPaymentState === "available" || retryPaymentState === undefined)
+
+  return (
+    <Alert
+      className={cn(
+        "flex flex-wrap items-center gap-4 rounded-md px-5 py-4 text-foreground",
+        isSyncing ? "bg-muted/30" : "border-destructive/30 bg-destructive/5"
+      )}
+    >
+      <span className={cn("shrink-0", !isSyncing && "text-destructive")}>
+        {isSyncing ? (
+          <Info className="h-5 w-5" />
+        ) : (
+          <AlertCircle className="h-5 w-5" />
+        )}
+      </span>
+      <div className="min-w-0 flex-1 basis-96">
+        <AlertTitle className="mb-1 text-sm font-semibold">
+          {t(
+            isSyncing
+              ? "workspace.billing.paymentFailed.syncingTitle"
+              : "workspace.billing.paymentFailed.title"
+          )}
+        </AlertTitle>
+        <AlertDescription className="text-sm text-muted-foreground">
+          {t(
+            isSyncing
+              ? "workspace.billing.paymentFailed.syncingDescription"
+              : "workspace.billing.paymentFailed.description"
+          )}
+        </AlertDescription>
+        {!isSyncing && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t(
+              canPay
+                ? "workspace.billing.paymentFailed.returnHint"
+                : "workspace.billing.paymentFailed.linkUnavailable"
+            )}
+          </p>
+        )}
+      </div>
+      <div className="flex shrink-0 flex-wrap gap-2">
+        {canPay && retryPaymentUrl ? (
+          <a
+            className={buttonVariants()}
+            href={retryPaymentUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t("workspace.billing.paymentFailed.payNow")}
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        ) : null}
+        <Button
+          variant={canPay || isSyncing ? "outline" : "default"}
+          disabled={isRefreshing}
+          onClick={onRefresh}
+        >
+          <RefreshCw
+            className={cn("h-4 w-4", isRefreshing && "animate-spin")}
+          />
+          {t(
+            isRefreshing
+              ? "workspace.billing.paymentFailed.refreshing"
+              : canPay || isSyncing
+                ? "workspace.billing.paymentFailed.refreshStatus"
+                : "workspace.billing.paymentFailed.retryLink"
+          )}
+        </Button>
+      </div>
+    </Alert>
+  )
+}
 
 export function CheckoutAlert({
   state,

--- a/modules/front-end/src/features/workspace/billing/components/invoice-history-panel.tsx
+++ b/modules/front-end/src/features/workspace/billing/components/invoice-history-panel.tsx
@@ -62,7 +62,10 @@ export function InvoiceHistoryPanel({
         accessorKey: "amountPaid",
         header: t("workspace.billing.invoices.amount"),
         cell: ({ row }) => {
-          const cents = row.original.amountPaid ?? row.original.amountDue ?? 0
+          const cents =
+            row.original.status === "open"
+              ? (row.original.amountDue ?? 0)
+              : (row.original.amountPaid ?? row.original.amountDue ?? 0)
           return (
             <span className="font-medium">
               {formatCurrency(cents / 100, row.original.currency ?? "USD")}
@@ -181,13 +184,17 @@ function InvoiceStatus({ status }: { status?: string }) {
       </Badge>
     )
   }
-  if (normalized === "pending") {
+  if (normalized === "pending" || normalized === "open") {
     return (
       <Badge
         variant="outline"
         className="border-amber-300 bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-300"
       >
-        {t("workspace.billing.invoices.pending")}
+        {t(
+          normalized === "open"
+            ? "workspace.billing.invoices.open"
+            : "workspace.billing.invoices.pending"
+        )}
       </Badge>
     )
   }

--- a/modules/front-end/src/features/workspace/billing/components/subscription-overview.tsx
+++ b/modules/front-end/src/features/workspace/billing/components/subscription-overview.tsx
@@ -96,14 +96,27 @@ export function SubscriptionOverview({
               <h2 className="text-2xl font-semibold tracking-normal">
                 {t(plan.nameKey)}
               </h2>
-              <Badge
-                  variant="default"
-                  className="whitespace-nowrap"
-                >
+              <Badge variant="default" className="whitespace-nowrap">
                 {subscription?.billingCycle === "yearly"
                   ? t("workspace.billing.overview.yearlyBilling")
                   : t("workspace.billing.overview.monthlyBilling")}
               </Badge>
+              {subscription?.status === "payment_failed" ? (
+                <Badge
+                  variant="outline"
+                  className={
+                    subscription.retryPaymentState === "no_open_invoice"
+                      ? "bg-muted/30"
+                      : "border-destructive/30 bg-destructive/5 text-destructive"
+                  }
+                >
+                  {t(
+                    subscription.retryPaymentState === "no_open_invoice"
+                      ? "workspace.billing.paymentFailed.syncingTitle"
+                      : "workspace.billing.paymentFailed.title"
+                  )}
+                </Badge>
+              ) : null}
             </div>
             <div className="mt-2 flex items-end gap-1">
               <span className="text-2xl font-semibold">
@@ -129,7 +142,13 @@ export function SubscriptionOverview({
             ) : null}
           </div>
         </div>
-        <Button className="h-10 px-5" onClick={onManage}>
+        <Button
+          className="h-10 px-5"
+          variant={
+            subscription?.status === "payment_failed" ? "outline" : "default"
+          }
+          onClick={onManage}
+        >
           {t("workspace.billing.actions.manageSubscription")}
         </Button>
       </div>

--- a/modules/front-end/src/lib/i18n/resources/workspace.ts
+++ b/modules/front-end/src/lib/i18n/resources/workspace.ts
@@ -162,6 +162,25 @@ export const enWorkspace = {
     },
   },
   billing: {
+    paymentFailed: {
+      title: "Payment failed",
+      syncingTitle: "Syncing subscription status",
+      syncingDescription:
+        "No outstanding invoice was found. Subscription status is awaiting confirmation. Please refresh shortly.",
+      description:
+        "We couldn’t collect your latest payment. Please complete payment to settle your invoice.",
+      returnHint: "After paying, return here to refresh your payment status.",
+      linkUnavailable:
+        "The payment link is temporarily unavailable. Please try again.",
+      payNow: "Pay now",
+      refreshStatus: "Refresh status",
+      refreshing: "Refreshing…",
+      retryLink: "Retry payment link",
+      refreshError: "Unable to refresh payment status. Please try again.",
+      confirmed: "Payment confirmed.",
+      stillPending:
+        "Payment has not been confirmed yet. If you have paid, refresh again shortly.",
+    },
     errors: {
       subscriptionTitle: "Failed to load subscription",
       subscriptionDescription:
@@ -251,6 +270,7 @@ export const enWorkspace = {
       amount: "Amount",
       empty: "No invoices yet",
       paid: "Paid",
+      open: "Open",
       pending: "Pending",
       overdue: "Overdue",
       unknown: "Unknown",
@@ -637,6 +657,21 @@ export const zhWorkspace = {
     },
   },
   billing: {
+    paymentFailed: {
+      title: "支付失败",
+      syncingTitle: "订阅状态同步中",
+      syncingDescription: "当前没有待支付账单，订阅状态仍待确认，请稍后刷新。",
+      description: "本期账单未能完成扣款，请前往支付页面完成支付。",
+      returnHint: "支付完成后返回此页面刷新支付状态。",
+      linkUnavailable: "暂时无法获取支付链接，请重试。",
+      payNow: "立即支付",
+      refreshStatus: "刷新支付状态",
+      refreshing: "正在刷新…",
+      retryLink: "重试获取链接",
+      refreshError: "无法刷新支付状态，请重试。",
+      confirmed: "已确认支付成功。",
+      stillPending: "暂未确认支付成功。如果你已支付，请稍后再次刷新。",
+    },
     errors: {
       subscriptionTitle: "加载订阅失败",
       subscriptionDescription:
@@ -724,6 +759,7 @@ export const zhWorkspace = {
       amount: "金额",
       empty: "暂无发票",
       paid: "已支付",
+      open: "待支付",
       pending: "待支付",
       overdue: "已逾期",
       unknown: "未知",

--- a/modules/front-end/src/test/e2e/billing.spec.ts
+++ b/modules/front-end/src/test/e2e/billing.spec.ts
@@ -230,11 +230,12 @@ test.describe("workspace billing", () => {
   test("reports failed refresh and allows recovery without claiming payment succeeded", async ({
     page,
   }) => {
-    await setupBillingPage(page, {
+    const subscription: Partial<BillingSubscription> = {
       status: "payment_failed",
       retryPaymentState: "available",
       retryPaymentUrl: paymentUrl,
-    })
+    }
+    await setupBillingPage(page, subscription)
     await page.goto("/en/workspace/billing")
     const refresh = page.getByRole("button", {
       name: "Refresh status",
@@ -259,6 +260,10 @@ test.describe("workspace billing", () => {
         exact: true,
       })
     ).toBeVisible({ timeout: 15000 })
+    const subscriptionError = page.getByRole("alert").filter({
+      hasText: "Failed to load subscription",
+    })
+    await expect(subscriptionError).toBeVisible()
     await expect(
       page.getByText("Payment confirmed.", { exact: true })
     ).toHaveCount(0)
@@ -268,13 +273,23 @@ test.describe("workspace billing", () => {
     await expect(refresh).toBeEnabled()
 
     fail = false
+    const refreshedPaymentUrl = `${paymentUrl}-refreshed`
+    subscription.retryPaymentUrl = refreshedPaymentUrl
+    const successfulRefresh = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === "/api/v1/billing/subscription" &&
+        response.request().method() === "GET" &&
+        response.status() === 200
+    )
     await refresh.click()
+    await successfulRefresh
+    await expect(subscriptionError).toHaveCount(0)
     await expect(
       page.getByRole("heading", { name: "Growth", exact: true })
     ).toBeVisible()
     await expect(page.getByRole("link", { name: "Pay now" })).toHaveAttribute(
       "href",
-      paymentUrl
+      refreshedPaymentUrl
     )
   })
 

--- a/modules/front-end/src/test/e2e/billing.spec.ts
+++ b/modules/front-end/src/test/e2e/billing.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test"
 import type { Page } from "@playwright/test"
+import type { BillingSubscription } from "../../features/workspace/billing/billing-api"
 import {
   createLicense,
   mockContextEndpoints,
@@ -8,7 +9,10 @@ import {
   setCurrentContext,
 } from "./helpers"
 
-async function setupBillingPage(page: Page) {
+async function setupBillingPage(
+  page: Page,
+  subscription: Partial<BillingSubscription> = {}
+) {
   await mockRuntimeEnv(page, {
     API_URL: "http://localhost:5000",
     HOSTING_MODE: "saas",
@@ -46,6 +50,7 @@ async function setupBillingPage(page: Page) {
           currentPeriodStart: "2026-07-01T00:00:00.000Z",
           currentPeriodEnd: "2026-08-01T00:00:00.000Z",
           createdAt: "2026-01-01T00:00:00.000Z",
+          ...subscription,
         },
       },
     })
@@ -100,6 +105,179 @@ async function setupBillingPage(page: Page) {
 }
 
 test.describe("workspace billing", () => {
+  const paymentUrl = "https://invoice.stripe.com/i/billing-test"
+
+  test("offers the available payment link in a separate tab", async ({
+    page,
+  }) => {
+    await setupBillingPage(page, {
+      status: "payment_failed",
+      retryPaymentState: "available",
+      retryPaymentUrl: paymentUrl,
+    })
+    await page.goto("/en/workspace/billing")
+
+    const alert = page.getByRole("alert").filter({ hasText: "Payment failed" })
+    await expect(alert).toBeVisible()
+    const pay = alert.getByRole("link", { name: "Pay now" })
+    await expect(pay).toHaveAttribute("href", paymentUrl)
+    await expect(pay).toHaveAttribute("target", "_blank")
+    await expect(pay).toHaveAttribute("rel", /noopener/)
+    await expect(
+      alert.getByRole("button", { name: "Refresh status" })
+    ).toBeEnabled()
+
+    await page
+      .context()
+      .route(paymentUrl, (route) => route.fulfill({ body: "Invoice preview" }))
+    const popupPromise = page.waitForEvent("popup")
+    await pay.click()
+    const popup = await popupPromise
+    await expect(popup).toHaveURL(paymentUrl)
+    await popup.close()
+  })
+
+  test("retries an unavailable payment link without offering a stale URL", async ({
+    page,
+  }) => {
+    const subscription: Partial<BillingSubscription> = {
+      status: "payment_failed",
+      retryPaymentState: "unavailable",
+      retryPaymentUrl: paymentUrl,
+    }
+    await setupBillingPage(page, subscription)
+    await page.goto("/en/workspace/billing")
+
+    const alert = page.getByRole("alert").filter({ hasText: "Payment failed" })
+    await expect(alert).toContainText(
+      "The payment link is temporarily unavailable."
+    )
+    await expect(page.getByRole("link", { name: "Pay now" })).toHaveCount(0)
+    subscription.retryPaymentState = "available"
+    await alert.getByRole("button", { name: "Retry payment link" }).click()
+    await expect(alert.getByRole("link", { name: "Pay now" })).toHaveAttribute(
+      "href",
+      paymentUrl
+    )
+    await expect(alert).not.toContainText(
+      "The payment link is temporarily unavailable."
+    )
+  })
+
+  test("shows synchronization guidance when no open invoice remains", async ({
+    page,
+  }) => {
+    await setupBillingPage(page, {
+      status: "payment_failed",
+      retryPaymentState: "no_open_invoice",
+      retryPaymentUrl: null,
+    })
+    await page.goto("/en/workspace/billing")
+
+    const alert = page
+      .getByRole("alert")
+      .filter({ hasText: "Syncing subscription status" })
+    await expect(alert).toContainText("No outstanding invoice was found.")
+    await expect(
+      alert.getByRole("button", { name: "Refresh status" })
+    ).toBeEnabled()
+    await expect(page.getByText("Payment failed", { exact: true })).toHaveCount(
+      0
+    )
+    await expect(page.getByRole("link", { name: "Pay now" })).toHaveCount(0)
+    await expect(
+      page.getByRole("button", { name: "Retry payment link" })
+    ).toHaveCount(0)
+    await expect(
+      page.getByText("Payment confirmed.", { exact: true })
+    ).toHaveCount(0)
+  })
+
+  test("removes repayment guidance only after refresh confirms an active subscription", async ({
+    page,
+  }) => {
+    const subscription: Partial<BillingSubscription> = {
+      status: "payment_failed",
+      retryPaymentState: "available",
+      retryPaymentUrl: paymentUrl,
+    }
+    await setupBillingPage(page, subscription)
+    await page.goto("/en/workspace/billing")
+    const refresh = page.getByRole("button", {
+      name: "Refresh status",
+      exact: true,
+    })
+    await expect(refresh).toBeEnabled()
+
+    subscription.status = "active"
+    subscription.retryPaymentState = "not_required"
+    subscription.retryPaymentUrl = null
+    await refresh.click()
+
+    await expect(
+      page.getByText("Payment confirmed.", { exact: true })
+    ).toBeVisible()
+    await expect(page.getByText("Payment failed", { exact: true })).toHaveCount(
+      0
+    )
+    await expect(page.getByRole("link", { name: "Pay now" })).toHaveCount(0)
+    await expect(refresh).toHaveCount(0)
+    await expect(
+      page.getByRole("heading", { name: "Growth", exact: true })
+    ).toBeVisible()
+  })
+
+  test("reports failed refresh and allows recovery without claiming payment succeeded", async ({
+    page,
+  }) => {
+    await setupBillingPage(page, {
+      status: "payment_failed",
+      retryPaymentState: "available",
+      retryPaymentUrl: paymentUrl,
+    })
+    await page.goto("/en/workspace/billing")
+    const refresh = page.getByRole("button", {
+      name: "Refresh status",
+      exact: true,
+    })
+    await expect(refresh).toBeEnabled()
+
+    let fail = true
+    await page.route("**/api/v1/billing/subscription", async (route) => {
+      if (fail) {
+        await route.fulfill({
+          status: 500,
+          json: { success: false, errors: ["InternalServerError"] },
+        })
+      } else {
+        await route.fallback()
+      }
+    })
+    await refresh.click()
+    await expect(
+      page.getByText("Unable to refresh payment status. Please try again.", {
+        exact: true,
+      })
+    ).toBeVisible({ timeout: 15000 })
+    await expect(
+      page.getByText("Payment confirmed.", { exact: true })
+    ).toHaveCount(0)
+    await expect(
+      page.getByRole("alert").filter({ hasText: "Payment failed" })
+    ).toBeVisible()
+    await expect(refresh).toBeEnabled()
+
+    fail = false
+    await refresh.click()
+    await expect(
+      page.getByRole("heading", { name: "Growth", exact: true })
+    ).toBeVisible()
+    await expect(page.getByRole("link", { name: "Pay now" })).toHaveAttribute(
+      "href",
+      paymentUrl
+    )
+  })
+
   test("renders subscription, billing information, and invoices", async ({
     page,
   }) => {

--- a/modules/front-end/src/test/e2e/helpers.ts
+++ b/modules/front-end/src/test/e2e/helpers.ts
@@ -238,6 +238,40 @@ async function mockContextEndpointResponses(page: Page) {
 }
 
 async function mockOrganizationAndProjectResponses(page: Page) {
+  // The authenticated SaaS layout loads billing data on every app page.
+  // Feature-specific fixtures can override these defaults after setup.
+  await page.route("**/api/v1/billing/subscription", async (route) => {
+    await route.fulfill({
+      json: {
+        success: true,
+        data: {
+          plan: "Growth",
+          status: "active",
+          retryPaymentState: "not_required",
+          retryPaymentUrl: null,
+          billingCycle: "monthly",
+          mau: 60000,
+          baseMau: 40000,
+          usage: { mau: 18000 },
+          currentPeriodStart: "2026-07-01T00:00:00.000Z",
+          currentPeriodEnd: "2026-08-01T00:00:00.000Z",
+        },
+      },
+    })
+  })
+  await page.route("**/api/v1/billing/current-cycle", async (route) => {
+    await route.fulfill({
+      json: {
+        success: true,
+        data: {
+          mau: 18000,
+          start: "2026-07-01T00:00:00.000Z",
+          end: "2026-08-01T00:00:00.000Z",
+        },
+      },
+    })
+  })
+
   await page.route("**/api/v1/organizations**", async (route) => {
     await route.fulfill({
       json: {


### PR DESCRIPTION
Previously, nn SaaS mode, for an existing subscription, if the automatic paymemt failed due to any reason, payment method expired for example, user would need to contact FeatBit team to complete the payment. Current PR added the current payment status to the billing page and a repay button allowing user to complete the payment.

<img width="1631" height="522" alt="image" src="https://github.com/user-attachments/assets/f9cf8906-cc06-4a82-b6fc-f167d6778e00" />

<!--
# Instructions

1. Pick a meaningful and result oriented title for your pull request. (Use sentence case, don't include any words indicating the way you achived this result, we just want the result. Keep it short < 70 characters)
  - Prefix the title with an emoji to categorize what is being done. (Copy-paste the emoji from the list below.)
  - Assign the appropriate label(s) to the pull request. (Use one of the labels from the list below.)
  
2. Enter a succinct description that says why the PR is necessary, and what it does.
  - Implement aspect X
  - Leave out feature Y because of A
  - Improve performance by B
  - Improve accessibility by C

3. Provide clear testing instructions that include any pertinent information, i.e. seat, roles, etc.
4. Include screenshots of your changes if they impact the UI (Before & After).
5. Update the preview link with your pull request number.
6. Include any JIRA tickets, design documents, GitHub issues, or other related items to the bottom of the PR.

# Available labels
UI
API
Evaluation Server
OLAP

# Emojis for categorizing pull requests

✨ New feature or functionality
🐛 Bugfix
🔥 P0 fix
✅ Tests
🚀 Performance improvements
🖍 CSS / Styling
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
↩️ Reverting a previous change
🧹 Refactoring / Housekeeping
🔧 Package Upgrades / Maintenance
🗑️ Deleting code

-->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added payment-failure alerts with payment retry, refresh, and status updates.
  * Added payment-failure indicators to the subscription overview.
  * Billing status now refreshes automatically when returning to the page.
* **Bug Fixes**
  * Open invoices now display the amount due and the correct status label.
* **Localization**
  * Added English and Chinese translations for payment-failure and open-invoice states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62629524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with the previously requested repayment-state coverage now implemented and no new actionable defects identified.

<h3>Summary</h3>

- Displays payment failure and synchronization states with retry and refresh actions.
- Refreshes subscription and invoice status after payment.
- Corrects open-invoice amount and status presentation.
- Adds English and Chinese translations.
- Adds end-to-end coverage for repayment states and refresh recovery.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Load billing subscription] --> B{Subscription status}
  B -->|Active| C[Show normal billing overview]
  B -->|Payment failed| D{Retry payment state}
  D -->|Available| E[Show Pay now and Refresh status]
  D -->|Unavailable| F[Show Retry payment link]
  D -->|No open invoice| G[Show synchronization guidance]
  E --> H[Open external payment page]
  E --> I[Refresh subscription]
  F --> I
  G --> I
  I --> J{Refreshed status}
  J -->|Active| K[Confirm payment and remove alert]
  J -->|Payment failed| D
  J -->|Request error| L[Show refresh error and retain guidance]
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["Update billing.spec.ts"](https://github.com/featbit/featbit/commit/965396a143ff5cd5a4d811bb45fc50c15dca7aa2)</sub>

<!-- /greptile_comment -->